### PR TITLE
allow Request class to be provided in options (#1563)

### DIFF
--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -20,6 +20,7 @@ export interface ClientOptions extends Omit<RequestInit, "headers"> {
   baseUrl?: string;
   /** custom fetch (defaults to globalThis.fetch) */
   fetch?: typeof fetch;
+  Request?: typeof Request;
   /** global querySerializer */
   querySerializer?: QuerySerializer<unknown> | QuerySerializerOptions;
   /** global bodySerializer */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -13,6 +13,7 @@ export default function createClient(clientOptions) {
   let {
     baseUrl = "",
     fetch: baseFetch = globalThis.fetch,
+    Request: baseRequest = globalThis.Request,
     querySerializer: globalQuerySerializer,
     bodySerializer: globalBodySerializer,
     headers: baseHeaders,
@@ -32,6 +33,7 @@ export default function createClient(clientOptions) {
   async function coreFetch(url, fetchOptions) {
     let {
       fetch = baseFetch,
+      Request = baseRequest,
       headers,
       params = {},
       parseAs = "json",
@@ -69,7 +71,7 @@ export default function createClient(clientOptions) {
     if (requestInit.body instanceof FormData) {
       requestInit.headers.delete("Content-Type");
     }
-    let request = new Request(
+    let request = new baseRequest(
       createFinalURL(url, { baseUrl, params, querySerializer }),
       requestInit,
     );
@@ -87,7 +89,7 @@ export default function createClient(clientOptions) {
         request.params = params; // (re)attach params
         const result = await m.onRequest(request, mergedOptions);
         if (result) {
-          if (!(result instanceof Request)) {
+          if (!(result instanceof baseRequest)) {
             throw new Error(
               `Middleware must return new Request() when modifying the request`,
             );


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

Allows you to provide the Request class to use.

see: https://github.com/drwpow/openapi-typescript/issues/1563

Caused issues for us using node 20's fetch, unidici's fetch, and node-fetch in different places.

Providing back as a base for someone else to continue, I may not have time soon.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
