### PR TITLE
Guess the used content type when multiple content is defined

### DIFF
--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1051,7 +1051,7 @@ describe("client", () => {
       });
 
       it("use the selected content", async () => {
-        const client = createClient<paths, "application/ld+json">();
+        const client = createClient<paths>();
         mockFetchOnce({
           status: 200,
           headers: { "Content-Type": "application/ld+json" },
@@ -1061,11 +1061,14 @@ describe("client", () => {
             name: null,
           }),
         });
-        const { data } = await client.GET("/multiple-response-content", {
+        const query = client.GET("/multiple-response-content", {
           headers: {
             Accept: "application/ld+json",
           },
         });
+
+        const { data } = await query;
+        //      ^?
 
         data satisfies
           | {


### PR DESCRIPTION
## Changes

This is a follow up of the workaround merged in this PR https://github.com/drwpow/openapi-typescript/pull/1597

Here the point is to infer the content type from the `Accept` header on each request.

For now I'm stuck, in the `ClientMethod` type, I did not succeed to infer the type. The `I extends MaybeOptionalInit<Paths[P], M, AcceptHeader>,` seems to prevent the inference. Did someone have an idea? 

When this works, I still need to add a branch on the `ParseAsResponse` to manage the content type only on `parseAs: json`

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
