### PR TITLE
Support corporate proxy based on standard http_proxy environment vari…

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -203,3 +203,9 @@ This results in more explicit typechecking of array lengths.
 _Note: this has a reasonable limit, so for example `maxItems: 100` would simply flatten back down to `string[];`_
 
 _Thanks, [@kgtkr](https://github.com/kgtkr)!_
+
+## Proxy support
+
+When the use of a corporate proxy is required to access the internet and/or download external definitions, please 
+configure this using the standard environment variable ```http_proxy```. Make sure this environment variable is set when
+running ```openapi-typescript```

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -5,6 +5,16 @@ import fs from "node:fs";
 import path from "node:path";
 import parser from "yargs-parser";
 import openapiTS, { COMMENT_HEADER, astToString, c, error, formatTime, warn } from "../dist/index.js";
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+// Corporate proxy support
+if (process.env.http_proxy) {
+    const proxyUrl = new URL(process.env.http_proxy);
+    const proxyAgent = new ProxyAgent({
+        uri: proxyUrl.protocol + proxyUrl.host,
+    });
+    setGlobalDispatcher(proxyAgent);
+}
 
 const HELP = `Usage
   $ openapi-typescript [input] [options]


### PR DESCRIPTION
…able

## Changes

This change will make the CLI command support an environment variable called ```http_proxy```. This is a standard environment variable in environments where a http proxy is required to access the internet.

## How to Review

Setup a http proxy server. Then start the openapi-typescript CLI command with an environment variable http_proxy. E.g.:

```
http_proxy=http://myproxy.company.lan:1234 ./node_modules/.bin/openapi-typescript 

```
