### PR TITLE
fix: add verification when request body is falsy

### DIFF
--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -80,7 +80,7 @@ export default function createClient(clientOptions) {
       requestInit.body = bodySerializer(requestInit.body);
     }
     // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
-    if (requestInit.body &&requestInit.body instanceof FormData) {
+    if (requestInit.body && requestInit.body instanceof FormData) {
       requestInit.headers.delete("Content-Type");
     }
     let request = new CustomRequest(createFinalURL(url, { baseUrl, params, querySerializer }), requestInit);

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -80,7 +80,7 @@ export default function createClient(clientOptions) {
       requestInit.body = bodySerializer(requestInit.body);
     }
     // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
-    if (requestInit.body instanceof FormData) {
+    if (requestInit.body &&requestInit.body instanceof FormData) {
       requestInit.headers.delete("Content-Type");
     }
     let request = new CustomRequest(createFinalURL(url, { baseUrl, params, querySerializer }), requestInit);

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -78,10 +78,10 @@ export default function createClient(clientOptions) {
     };
     if (requestInit.body) {
       requestInit.body = bodySerializer(requestInit.body);
-    }
-    // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
-    if (requestInit.body && requestInit.body instanceof FormData) {
-      requestInit.headers.delete("Content-Type");
+      // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
+      if (requestInit.body instanceof FormData) {
+        requestInit.headers.delete("Content-Type");
+      }
     }
     let request = new CustomRequest(createFinalURL(url, { baseUrl, params, querySerializer }), requestInit);
     // middleware (request)


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._
https://github.com/openapi-ts/openapi-typescript/issues/1695
#1694

## How to Review

The `instanceof` was throwing an error when the body was falsy.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
