### PR TITLE
Update domain

### DIFF
--- a/docs/.vitepress/shared.ts
+++ b/docs/.vitepress/shared.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitepress";
 import { zhSearch } from "./zh";
 
-const HOSTNAME = "https://openapi-ts.pages.dev";
+const HOSTNAME = "https://openapi-ts.dev";
 
 export const shared = defineConfig({
   title: "OpenAPI TypeScript",
@@ -35,5 +35,12 @@ export const shared = defineConfig({
       },
     },
     socialLinks: [{ icon: "github", link: "https://github.com/drwpow/openapi-typescript" }],
+  },
+  transformPageData({ relativePath, frontmatter }) {
+    frontmatter.head ??= [];
+    frontmatter.head.push([
+      "link",
+      { rel: "canonical", href: `${HOSTNAME}/${relativePath.replace(/(index\.md|\.md)$/, "")}` },
+    ]);
   },
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Docs site powered by [Vitepress](https://vitepress.dev/), an ergonomic docs site template powered by Vite.
 
-Lives at [https://openapi-ts.pages.dev](https://openapi-ts.pages.dev).
+Lives at [https://openapi-ts.dev](https://openapi-ts.dev).
 
 ## Setup
 

--- a/packages/openapi-fetch/CONTRIBUTING.md
+++ b/packages/openapi-fetch/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Pull requests are **welcome** for this repo!
 
 Bugfixes will always be accepted, though in some cases some small changes may be requested.
 
-However, if adding a feature or breaking change, please **open an issue first to discuss.** This ensures no time or work is wasted writing code that won’t be accepted to the project (see [Project Goals](https://openapi-ts.pages.dev/openapi-fetch/about/#project-goals)). Undiscussed feature work may be rejected at the discretion of the maintainers.
+However, if adding a feature or breaking change, please **open an issue first to discuss.** This ensures no time or work is wasted writing code that won’t be accepted to the project (see [Project Goals](https://openapi-ts.dev/openapi-fetch/about/#project-goals)). Undiscussed feature work may be rejected at the discretion of the maintainers.
 
 ### Writing the commit
 

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -38,7 +38,7 @@ await client.PUT("/blogposts", {
 
 `data` and `error` are typechecked and expose their shapes to Intellisense in VS Code (and any other IDE with TypeScript support). Likewise, the request `body` will also typecheck its fields, erring if any required params are missing, or if there’s a type mismatch.
 
-`GET`, `PUT`, `POST`, etc. are only thin wrappers around the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (which you can [swap for any call](https://openapi-ts.pages.dev/openapi-fetch/api/#create-client)).
+`GET`, `PUT`, `POST`, etc. are only thin wrappers around the native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (which you can [swap for any call](https://openapi-ts.dev/openapi-fetch/api/#create-client)).
 
 Notice there are no generics, and no manual typing. Your endpoint’s request and response were inferred automatically. This is a huge improvement in the type safety of your endpoints because **every manual assertion could lead to a bug**! This eliminates all of the following:
 
@@ -116,4 +116,4 @@ const { data, error } = await client.PUT("/blogposts", {
 
 ## 📓 Docs
 
-[View Docs](https://openapi-ts.pages.dev/openapi-fetch/)
+[View Docs](https://openapi-ts.dev/openapi-fetch/)

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -24,7 +24,7 @@
     },
     "./*": "./*"
   },
-  "homepage": "https://openapi-ts.pages.dev",
+  "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/drwpow/openapi-typescript",

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -23,7 +23,7 @@
     },
     "./*": "./*"
   },
-  "homepage": "https://openapi-ts.pages.dev",
+  "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/drwpow/openapi-typescript",

--- a/packages/openapi-typescript/CHANGELOG.md
+++ b/packages/openapi-typescript/CHANGELOG.md
@@ -38,7 +38,7 @@
     - `--immutable-types` has been renamed to `--immutable`
     - `--support-array-length` has been renamed to `--array-length`
 
-- [`fbaf96d`](https://github.com/drwpow/openapi-typescript/commit/fbaf96d33181a2fabd3d4748e54c0f111ed6756e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Remove globbing schemas in favor of `redocly.yaml` config. Specify multiple schemas with outputs in there instead. See [Multiple schemas](https://openapi-ts.pages.dev/docs/cli/#multiple-schemas) for more info.
+- [`fbaf96d`](https://github.com/drwpow/openapi-typescript/commit/fbaf96d33181a2fabd3d4748e54c0f111ed6756e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Remove globbing schemas in favor of `redocly.yaml` config. Specify multiple schemas with outputs in there instead. See [Multiple schemas](https://openapi-ts.dev/docs/cli/#multiple-schemas) for more info.
 
 - [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Most optional objects are now always present in types, just typed as `:never`. This includes keys of the Components Object as well as HTTP methods.
 
@@ -55,7 +55,7 @@
   - By default, it will only throw on actual schema errors (uses Redocly’s default settings)
   - For stricter linting or custom rules, you can create a [redocly.yaml config](https://redocly.com/docs/cli/configuration/)
 
-- [`312b7ba`](https://github.com/drwpow/openapi-typescript/commit/312b7ba03fc0334153d4eeb51d6159f3fc63934e) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature:** allow configuration of schemas via `apis` key in redocly.config.yaml. [See docs](https://openapi-ts.pages.dev/cli/) for more info.
+- [`312b7ba`](https://github.com/drwpow/openapi-typescript/commit/312b7ba03fc0334153d4eeb51d6159f3fc63934e) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature:** allow configuration of schemas via `apis` key in redocly.config.yaml. [See docs](https://openapi-ts.dev/cli/) for more info.
 
   - Any options passed into your [redocly.yaml config](https://redocly.com/docs/cli/configuration/) are respected
 

--- a/packages/openapi-typescript/CONTRIBUTING.md
+++ b/packages/openapi-typescript/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Pull requests are **welcome** for this repo!
 
 Bugfixes will always be accepted, though in some cases some small changes may be requested.
 
-However, if adding a feature or breaking change, please **open an issue first to discuss.** This ensures no time or work is wasted writing code that won’t be accepted to the project (see [Project Goals](https://openapi-ts.pages.dev/about/#project-goals)). Undiscussed feature work may be rejected at the discretion of the maintainers.
+However, if adding a feature or breaking change, please **open an issue first to discuss.** This ensures no time or work is wasted writing code that won’t be accepted to the project (see [Project Goals](https://openapi-ts.dev/about/#project-goals)). Undiscussed feature work may be rejected at the discretion of the maintainers.
 
 ### Setup
 

--- a/packages/openapi-typescript/README.md
+++ b/packages/openapi-typescript/README.md
@@ -87,4 +87,4 @@ _Thanks, [@psmyrdek](https://github.com/psmyrdek)!_
 
 ## 📓 Docs
 
-[View Docs](https://openapi-ts.pages.dev/introduction/)
+[View Docs](https://openapi-ts.dev/)

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -157,7 +157,7 @@ async function main() {
         }
         if (!api[REDOC_CONFIG_KEY]?.output) {
           errorAndExit(
-            `API ${name} is missing an \`${REDOC_CONFIG_KEY}.output\` key. See https://openapi-ts.pages.dev/cli/#multiple-schemas.`,
+            `API ${name} is missing an \`${REDOC_CONFIG_KEY}.output\` key. See https://openapi-ts.dev/cli/#multiple-schemas.`,
           );
         }
         const result = await generateSchema(new URL(api.root, configRoot), { redocly });
@@ -191,7 +191,7 @@ async function main() {
     // throw error on glob
     if (input.includes("*")) {
       errorAndExit(
-        "Globbing has been deprecated in favor of redocly.yaml’s `apis` keys. See https://openapi-ts.pages.dev/cli/#multiple-schemas",
+        "Globbing has been deprecated in favor of redocly.yaml’s `apis` keys. See https://openapi-ts.dev/cli/#multiple-schemas",
       );
     }
     const result = await generateSchema(new URL(input, CWD), {

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -19,7 +19,7 @@
     },
     "./*": "./*"
   },
-  "homepage": "https://openapi-ts.pages.dev",
+  "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/drwpow/openapi-typescript",


### PR DESCRIPTION
## Changes

Updates from `openapi-ts.pages.dev` → `openapi-ts.dev`. The Cloudflare domain is brittle, and there’s no guarantee we can keep that long-term. A domain allows for more flexibility, including moving off Cloudflare if needed.

## How to Review

N/A

## Checklist

N/A