### PR TITLE
Update GitHub org

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "drwpow/openapi-typescript" }],
+  "$schema": "https://unpkg.com/@changesets/config@3.0.1/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "openapi-ts/openapi-typescript" }],
   "ignore": ["openapi-typescript-docs", "@example/*"],
   "commit": false,
   "fixed": [],

--- a/.github/ISSUE_TEMPLATE/bug-report-fetch.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-fetch.md
@@ -20,4 +20,4 @@ _(in case it’s not obvious)_
 
 **Checklist**
 
-- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/bug-report-ts.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-ts.md
@@ -31,4 +31,4 @@ _(in case it’s not obvious)_
 **Checklist**
 
 - [ ] My OpenAPI schema passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
-- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/feature-request-fetch.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-fetch.md
@@ -16,4 +16,4 @@ _Write out the proposed syntax change. Please reference any prior art or similar
 
 **Checklist**
 
-- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/feature-request-ts.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-ts.md
@@ -16,4 +16,4 @@ _Outline the change to the library. If this is for the CLI, propose a flag name 
 
 **Checklist**
 
-- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))
+- [ ] I’m willing to open a PR for this (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Contributions are appreciated and welcome! See the appropriate guide for each pa
 
 ## ♥️ Thanks
 
-- Thanks to [the Project Sponsors](#sponsors) for keeping this project going!
-- Thanks to [dozens of lovely, smart contributors](https://github.com/drwpow/openapi-typescript/graphs/contributors) that made this library possible
+- Thanks to [the Project Sponsors](#-sponsors) for keeping this project going!
+- Thanks to [dozens of lovely, smart contributors](https://github.com/openapi-ts/openapi-typescript/graphs/contributors) that made this library possible
 - Thanks to [Vitepress](https://vitepress.dev/) for the docs site
 - Thanks to [Cloudflare Pages](https://pages.cloudflare.com/) for docs site hosting
 - Thanks to [Algolia](https://www.algolia.com/) for the docs site search

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -78,12 +78,10 @@ export const en = defineConfig({
         indexName: "openapi-ts",
       },
     },
-    socialLinks: [
-      { icon: "github", link: "https://github.com/drwpow/openapi-typescript" },
-    ],
+    socialLinks: [{ icon: "github", link: "https://github.com/openapi-ts/openapi-typescript" }],
     footer: {
       message:
-        'Released under the <a href="https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT License</a>.',
+        'Released under the <a href="https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT License</a>.',
     },
   },
 });

--- a/docs/.vitepress/shared.ts
+++ b/docs/.vitepress/shared.ts
@@ -34,7 +34,7 @@ export const shared = defineConfig({
         locales: { ...zhSearch },
       },
     },
-    socialLinks: [{ icon: "github", link: "https://github.com/drwpow/openapi-typescript" }],
+    socialLinks: [{ icon: "github", link: "https://github.com/openapi-ts/openapi-typescript" }],
   },
   transformPageData({ relativePath, frontmatter }) {
     frontmatter.head ??= [];

--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -54,7 +54,7 @@ export const zh = defineConfig({
 
     footer: {
       message:
-        '基于 <a href="https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT</a> 许可发布',
+        '基于 <a href="https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT</a> 许可发布',
     },
   },
 });

--- a/docs/6.x/introduction.md
+++ b/docs/6.x/introduction.md
@@ -7,7 +7,7 @@ description: Quickstart
 
 openapi-typescript turns [OpenAPI 3.0 & 3.1](https://spec.openapis.org/oas/latest.html) schemas into TypeScript quickly using Node.js. No Java/node-gyp/running OpenAPI servers necessary.
 
-The code is [MIT-licensed](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE) and free for use.
+The code is [MIT-licensed](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE) and free for use.
 
 ## Features
 
@@ -20,7 +20,7 @@ _Note: OpenAPI 2.x is supported with versions `5.x` and previous_
 
 ## Examples
 
-👀 [See examples](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
+👀 [See examples](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
 
 ## Setup
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,15 +6,15 @@ See the [README](./README.md) for basic setup.
 
 ## Corrections / small edits
 
-Corrections are always welcome! Please go straight to [opening a PR](https://github.com/drwpow/openapi-typescript/pulls) for correcting typos or misinformation. Small grammar edits are also welcome such as shortening verbose language or clarifying confusing statements.
+Corrections are always welcome! Please go straight to [opening a PR](https://github.com/openapi-ts/openapi-typescript/pulls) for correcting typos or misinformation. Small grammar edits are also welcome such as shortening verbose language or clarifying confusing statements.
 
 ## Styling fixes
 
-Styling fixes are also welcome (contrast improvements, styling bugs, general frontend improvements). You can also go straight to [opening a PR](https://github.com/drwpow/openapi-typescript/pulls) for those.
+Styling fixes are also welcome (contrast improvements, styling bugs, general frontend improvements). You can also go straight to [opening a PR](https://github.com/openapi-ts/openapi-typescript/pulls) for those.
 
 ## Additions & Larger edits
 
-[Opening a new discussion](https://github.com/drwpow/openapi-typescript/discussions) would be appreciated for all of the following:
+[Opening a new discussion](https://github.com/openapi-ts/openapi-typescript/discussions) would be appreciated for all of the following:
 
 - Adding a new section or page
 - Restructuring the docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hero:
       link: /introduction
     - theme: alt
       text: View on GitHub
-      link: https://github.com/drwpow/openapi-typescript
+      link: https://github.com/openapi-ts/openapi-typescript
 
 features:
   - title: Blazing Fast

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -13,7 +13,7 @@ The 7.x docs are for a beta release that’s not production-ready yet. See the [
 
 openapi-typescript turns [OpenAPI 3.0 & 3.1](https://spec.openapis.org/oas/latest.html) schemas into TypeScript quickly using Node.js. No Java/node-gyp/running OpenAPI servers necessary.
 
-The code is [MIT-licensed](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE") and free for use.
+The code is [MIT-licensed](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE") and free for use.
 
 ::: tip
 
@@ -32,7 +32,7 @@ _Note: OpenAPI 2.x is supported with versions `5.x` and previous_
 
 ## Examples
 
-👀 [See examples](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
+👀 [See examples](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
 
 ## Setup
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -53,4 +53,4 @@ The biggest change is the handling of `string`s—in 6.x a string could refer to
 
 ---
 
-[See the full CHANGELOG](https://github.com/drwpow/openapi-typescript/blob/6.x/packages/openapi-typescript/CHANGELOG.md)
+[See the full CHANGELOG](https://github.com/openapi-ts/openapi-typescript/blob/6.x/packages/openapi-typescript/CHANGELOG.md)

--- a/docs/openapi-fetch/examples.md
+++ b/docs/openapi-fetch/examples.md
@@ -10,13 +10,13 @@ Example code of using openapi-fetch with other frameworks and libraries.
 
 [React Query](https://tanstack.com/query/latest) is a perfect wrapper for openapi-fetch in React. At only 13 kB, it provides clientside caching without too much client weight in return. And its stellar type inference preserves openapi-fetch types perfectly with minimal setup.
 
-[View a code example in GitHub](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/react-query)
+[View a code example in GitHub](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/react-query)
 
 ## Next.js
 
 [Next.js](https://nextjs.org/) is the most popular SSR framework for React. While [React Query](#react--react-query) is recommended for all clientside fetching with openapi-fetch (not SWR), this example shows how to take advantage of Next.js’s [server-side fetching](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-fetch) with built-in caching.
 
-[View a code example in GitHub](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/nextjs)
+[View a code example in GitHub](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/nextjs)
 
 ## Svelte / SvelteKit
 
@@ -24,12 +24,12 @@ Example code of using openapi-fetch with other frameworks and libraries.
 
 _Note: if you’re using Svelte without SvelteKit, the root example in `src/routes/+page.svelte` doesn’t use any SvelteKit features and is generally-applicable to any setup._
 
-[View a code example in GitHub](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/sveltekit)
+[View a code example in GitHub](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/sveltekit)
 
 ## Vue 3
 
 [Vue 3](https://vuejs.org/) is a popular framework with a large ecosystem. Vue 3’s Composition API is a perfect match for openapi-fetch, as it allows for easy separation of concerns and reactivity.
 
-## [View a code example in GitHub](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/vue-3)
+## [View a code example in GitHub](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/vue-3)
 
-Additional examples are always welcome! Please [open a PR](https://github.com/drwpow/openapi-typescript/pulls) with your examples.
+Additional examples are always welcome! Please [open a PR](https://github.com/openapi-ts/openapi-typescript/pulls) with your examples.

--- a/docs/openapi-fetch/index.md
+++ b/docs/openapi-fetch/index.md
@@ -14,7 +14,7 @@ openapi-fetch is a type-safe fetch client that pulls in your OpenAPI schema. Wei
 | superagent                 |    `55 kB` | `50k` ops/s (6× slower)    |
 | openapi-typescript-codegen |   `367 kB` | `100k` ops/s (3× slower)   |
 
-_\* [Benchmarks are approximate](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/test/index.bench.js) to just show rough baseline and will differ among machines and browsers. The relative performance between libraries is more reliable._
+_\* [Benchmarks are approximate](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/test/index.bench.js) to just show rough baseline and will differ among machines and browsers. The relative performance between libraries is more reliable._
 
 The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 5 kb package.
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -11,7 +11,7 @@ hero:
       link: /zh/introduction
     - theme: alt
       text: GitHub
-      link: https://github.com/drwpow/openapi-typescript
+      link: https://github.com/openapi-ts/openapi-typescript
 
 features:
   - title: 快速的

--- a/docs/zh/introduction.md
+++ b/docs/zh/introduction.md
@@ -13,7 +13,7 @@ description: Quickstart
 
 openapi-typescript 使用 Node.js 快速将 [OpenAPI 3.0 & 3.1](https://spec.openapis.org/oas/latest.html) 模式转换为 TypeScript。无需 Java/node-gyp/运行 OpenAPI 服务器。
 
-该代码受到 [MIT 许可](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE") 保护，可免费使用。
+该代码受到 [MIT 许可](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE") 保护，可免费使用。
 
 ## 特性
 
@@ -26,7 +26,7 @@ _注意：OpenAPI 2.x 在版本 `5.x` 及更早版本中受支持_
 
 ## 示例
 
-👀 [查看示例](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
+👀 [查看示例](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/examples/)
 
 ## 安装
 

--- a/docs/zh/openapi-fetch/examples.md
+++ b/docs/zh/openapi-fetch/examples.md
@@ -10,13 +10,13 @@ title: openapi-fetch 示例
 
 [React Query](https://tanstack.com/query/latest) 是在 React 中完美封装 openapi-fetch 的工具。仅有 13 kB 的大小，提供了客户端缓存而没有太多的客户端负担。其出色的类型推断通过最小的设置完美地保留了 openapi-fetch 的类型。
 
-[在 GitHub 中查看代码示例](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/react-query)
+[在 GitHub 中查看代码示例](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/react-query)
 
 ## Next.js
 
 [Next.js](https://nextjs.org/) 是 React 的最流行的 SSR 框架。虽然对于所有客户端获取 openapi-fetch，推荐使用 [React Query](#react--react-query)（而不是 SWR），但该示例展示了如何利用 Next.js 的[服务器端获取](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-fetch)并内建缓存。
 
-[在 GitHub 中查看代码示例](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/nextjs)
+[在 GitHub 中查看代码示例](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/nextjs)
 
 ## Svelte / SvelteKit
 
@@ -24,12 +24,12 @@ title: openapi-fetch 示例
 
 _注意：如果你在没有 SvelteKit 的情况下使用 Svelte，`src/routes/+page.svelte` 中的根示例不使用任何 SvelteKit 特性，通常适用于任何设置。_
 
-[在 GitHub 中查看代码示例](https://github.com/drwpow/openapi-typescript/tree/main/packages/openapi-fetch/examples/sveltekit)
+[在 GitHub 中查看代码示例](https://github.com/openapi-ts/openapi-typescript/tree/main/packages/openapi-fetch/examples/sveltekit)
 
 ## Vue
 
-目前还没有 Vue 的示例应用。你在 Vue 中使用吗？请[提交 PR 添加！](https://github.com/drwpow/openapi-typescript/pulls)
+目前还没有 Vue 的示例应用。你在 Vue 中使用吗？请[提交 PR 添加！](https://github.com/openapi-ts/openapi-typescript/pulls)
 
 ---
 
-欢迎提供更多示例！请[提交 PR](https://github.com/drwpow/openapi-typescript/pulls)添加你的示例。
+欢迎提供更多示例！请[提交 PR](https://github.com/openapi-ts/openapi-typescript/pulls)添加你的示例。

--- a/packages/openapi-fetch/CHANGELOG.md
+++ b/packages/openapi-fetch/CHANGELOG.md
@@ -4,232 +4,232 @@
 
 ### Patch Changes
 
-- [#1672](https://github.com/drwpow/openapi-typescript/pull/1672) [`64cb619`](https://github.com/drwpow/openapi-typescript/commit/64cb6193ddd94523636fd55ba308117f2614a2e2) Thanks [@jaredLunde](https://github.com/jaredLunde)! - Fixes issue where native properties were not excluded from custom properties in the CustomRequest class
+- [#1672](https://github.com/openapi-ts/openapi-typescript/pull/1672) [`64cb619`](https://github.com/openapi-ts/openapi-typescript/commit/64cb6193ddd94523636fd55ba308117f2614a2e2) Thanks [@jaredLunde](https://github.com/jaredLunde)! - Fixes issue where native properties were not excluded from custom properties in the CustomRequest class
 
 ## 0.9.6
 
 ### Patch Changes
 
-- [#1653](https://github.com/drwpow/openapi-typescript/pull/1653) [`4f4253a`](https://github.com/drwpow/openapi-typescript/commit/4f4253a031820a664499b9df7ed5c8b192aa98b3) Thanks [@FreeAoi](https://github.com/FreeAoi)! - Let request object have custom properties
+- [#1653](https://github.com/openapi-ts/openapi-typescript/pull/1653) [`4f4253a`](https://github.com/openapi-ts/openapi-typescript/commit/4f4253a031820a664499b9df7ed5c8b192aa98b3) Thanks [@FreeAoi](https://github.com/FreeAoi)! - Let request object have custom properties
 
 ## 0.9.5
 
 ### Patch Changes
 
-- [#1639](https://github.com/drwpow/openapi-typescript/pull/1639) [`645f436`](https://github.com/drwpow/openapi-typescript/commit/645f4366d2907b05eee1e6ec33d13edab8614fa1) Thanks [@FreeAoi](https://github.com/FreeAoi)! - fix request option types don't showing optional props correctly
+- [#1639](https://github.com/openapi-ts/openapi-typescript/pull/1639) [`645f436`](https://github.com/openapi-ts/openapi-typescript/commit/645f4366d2907b05eee1e6ec33d13edab8614fa1) Thanks [@FreeAoi](https://github.com/FreeAoi)! - fix request option types don't showing optional props correctly
 
 ## 0.9.4
 
 ### Patch Changes
 
-- [#1597](https://github.com/drwpow/openapi-typescript/pull/1597) [`1f7ad9d`](https://github.com/drwpow/openapi-typescript/commit/1f7ad9d41f1f1ca7b1195a381c907393f9ef743b) Thanks [@armandabric](https://github.com/armandabric)! - Allow to select the response content type
+- [#1597](https://github.com/openapi-ts/openapi-typescript/pull/1597) [`1f7ad9d`](https://github.com/openapi-ts/openapi-typescript/commit/1f7ad9d41f1f1ca7b1195a381c907393f9ef743b) Thanks [@armandabric](https://github.com/armandabric)! - Allow to select the response content type
 
-- [#1585](https://github.com/drwpow/openapi-typescript/pull/1585) [`4e06f86`](https://github.com/drwpow/openapi-typescript/commit/4e06f86934e11f3dbc3aabee4b4e61dd62680782) Thanks [@mikestopcontinues](https://github.com/mikestopcontinues)! - Update types for path-methods object
+- [#1585](https://github.com/openapi-ts/openapi-typescript/pull/1585) [`4e06f86`](https://github.com/openapi-ts/openapi-typescript/commit/4e06f86934e11f3dbc3aabee4b4e61dd62680782) Thanks [@mikestopcontinues](https://github.com/mikestopcontinues)! - Update types for path-methods object
 
-- [#1610](https://github.com/drwpow/openapi-typescript/pull/1610) [`cc8073b`](https://github.com/drwpow/openapi-typescript/commit/cc8073b3ee42e7aaa546a9c6a0553c300d8882de) Thanks [@illright](https://github.com/illright)! - Fix data/error discrimination when there are empty-body errors
+- [#1610](https://github.com/openapi-ts/openapi-typescript/pull/1610) [`cc8073b`](https://github.com/openapi-ts/openapi-typescript/commit/cc8073b3ee42e7aaa546a9c6a0553c300d8882de) Thanks [@illright](https://github.com/illright)! - Fix data/error discrimination when there are empty-body errors
 
-- [#1587](https://github.com/drwpow/openapi-typescript/pull/1587) [`2a66a64`](https://github.com/drwpow/openapi-typescript/commit/2a66a6483d755a090e57a457b22eb99696da098a) Thanks [@JE-lee](https://github.com/JE-lee)! - Fix the custom fetch type
+- [#1587](https://github.com/openapi-ts/openapi-typescript/pull/1587) [`2a66a64`](https://github.com/openapi-ts/openapi-typescript/commit/2a66a6483d755a090e57a457b22eb99696da098a) Thanks [@JE-lee](https://github.com/JE-lee)! - Fix the custom fetch type
 
 ## 0.9.3
 
 ### Patch Changes
 
-- [#1580](https://github.com/drwpow/openapi-typescript/pull/1580) [`4c0c7fc`](https://github.com/drwpow/openapi-typescript/commit/4c0c7fc69dc6416dcf1fea785455bce8b9742704) Thanks [@drwpow](https://github.com/drwpow)! - Fix type errors
+- [#1580](https://github.com/openapi-ts/openapi-typescript/pull/1580) [`4c0c7fc`](https://github.com/openapi-ts/openapi-typescript/commit/4c0c7fc69dc6416dcf1fea785455bce8b9742704) Thanks [@drwpow](https://github.com/drwpow)! - Fix type errors
 
 ## 0.9.2
 
 ### Patch Changes
 
-- [#1550](https://github.com/drwpow/openapi-typescript/pull/1550) [`a5a9cc7`](https://github.com/drwpow/openapi-typescript/commit/a5a9cc766f893fd93500a5a1ff909746194bfdc7) Thanks [@shirish87](https://github.com/shirish87)! - Fix 'Content-Type' header being removed from requests with multipart/form-data body
+- [#1550](https://github.com/openapi-ts/openapi-typescript/pull/1550) [`a5a9cc7`](https://github.com/openapi-ts/openapi-typescript/commit/a5a9cc766f893fd93500a5a1ff909746194bfdc7) Thanks [@shirish87](https://github.com/shirish87)! - Fix 'Content-Type' header being removed from requests with multipart/form-data body
 
 ## 0.9.1
 
 ### Patch Changes
 
-- [#1546](https://github.com/drwpow/openapi-typescript/pull/1546) [`cc64453`](https://github.com/drwpow/openapi-typescript/commit/cc64453c7f92c77c19bc45dc0f701a98ab461b16) Thanks [@drwpow](https://github.com/drwpow)! - Fix JSON consuming body
+- [#1546](https://github.com/openapi-ts/openapi-typescript/pull/1546) [`cc64453`](https://github.com/openapi-ts/openapi-typescript/commit/cc64453c7f92c77c19bc45dc0f701a98ab461b16) Thanks [@drwpow](https://github.com/drwpow)! - Fix JSON consuming body
 
 ## 0.9.0
 
 ### Minor Changes
 
-- [#1521](https://github.com/drwpow/openapi-typescript/pull/1521) [`b174dd6`](https://github.com/drwpow/openapi-typescript/commit/b174dd6a7668e2f1f6bf6bd086ba2dabf7fb669e) Thanks [@drwpow](https://github.com/drwpow)! - Add middleware support
+- [#1521](https://github.com/openapi-ts/openapi-typescript/pull/1521) [`b174dd6`](https://github.com/openapi-ts/openapi-typescript/commit/b174dd6a7668e2f1f6bf6bd086ba2dabf7fb669e) Thanks [@drwpow](https://github.com/drwpow)! - Add middleware support
 
-- [#1521](https://github.com/drwpow/openapi-typescript/pull/1521) [`fc3a468`](https://github.com/drwpow/openapi-typescript/commit/fc3a468c4342e17d203712be358b30a3fb82ab1e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change (internal): fetch() is now called with new Request() to support middleware (which may affect test mocking)
+- [#1521](https://github.com/openapi-ts/openapi-typescript/pull/1521) [`fc3a468`](https://github.com/openapi-ts/openapi-typescript/commit/fc3a468c4342e17d203712be358b30a3fb82ab1e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change (internal): fetch() is now called with new Request() to support middleware (which may affect test mocking)
 
-- [#1521](https://github.com/drwpow/openapi-typescript/pull/1521) [`2551e4b`](https://github.com/drwpow/openapi-typescript/commit/2551e4bde41d5437a76c13bb5ba25ede4f14db10) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking change**: Responses are no longer automatically `.clone()`’d in certain instances. Be sure to `.clone()` yourself if you need to access the raw body!
+- [#1521](https://github.com/openapi-ts/openapi-typescript/pull/1521) [`2551e4b`](https://github.com/openapi-ts/openapi-typescript/commit/2551e4bde41d5437a76c13bb5ba25ede4f14db10) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking change**: Responses are no longer automatically `.clone()`’d in certain instances. Be sure to `.clone()` yourself if you need to access the raw body!
 
-- [#1534](https://github.com/drwpow/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/drwpow/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change: no longer supports deeply-nested objects/arrays for query & path serialization.
+- [#1534](https://github.com/openapi-ts/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/openapi-ts/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change: no longer supports deeply-nested objects/arrays for query & path serialization.
 
 ### Patch Changes
 
-- [#1484](https://github.com/drwpow/openapi-typescript/pull/1484) [`49bbd72`](https://github.com/drwpow/openapi-typescript/commit/49bbd72800f7bc6c460a741c50d11eb216746290) Thanks [@drwpow](https://github.com/drwpow)! - Remove prepare script
+- [#1484](https://github.com/openapi-ts/openapi-typescript/pull/1484) [`49bbd72`](https://github.com/openapi-ts/openapi-typescript/commit/49bbd72800f7bc6c460a741c50d11eb216746290) Thanks [@drwpow](https://github.com/drwpow)! - Remove prepare script
 
-- [#1479](https://github.com/drwpow/openapi-typescript/pull/1479) [`c6d945b`](https://github.com/drwpow/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80) Thanks [@darwish](https://github.com/darwish)! - Fixed build of openapi-typescript-helpers for CommonJS environments
+- [#1479](https://github.com/openapi-ts/openapi-typescript/pull/1479) [`c6d945b`](https://github.com/openapi-ts/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80) Thanks [@darwish](https://github.com/darwish)! - Fixed build of openapi-typescript-helpers for CommonJS environments
 
-- [#1534](https://github.com/drwpow/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/drwpow/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - Add support for automatic label & matrix path serialization.
+- [#1534](https://github.com/openapi-ts/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/openapi-ts/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - Add support for automatic label & matrix path serialization.
 
-- [#1521](https://github.com/drwpow/openapi-typescript/pull/1521) [`fd44bd2`](https://github.com/drwpow/openapi-typescript/commit/fd44bd28d881715e30f5a71435f05f6bae13859d) Thanks [@drwpow](https://github.com/drwpow)! - Support arrays in headers
+- [#1521](https://github.com/openapi-ts/openapi-typescript/pull/1521) [`fd44bd2`](https://github.com/openapi-ts/openapi-typescript/commit/fd44bd28d881715e30f5a71435f05f6bae13859d) Thanks [@drwpow](https://github.com/drwpow)! - Support arrays in headers
 
-- [#1534](https://github.com/drwpow/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/drwpow/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - Remove leading question marks from querySerializer
+- [#1534](https://github.com/openapi-ts/openapi-typescript/pull/1534) [`2bbeb92`](https://github.com/openapi-ts/openapi-typescript/commit/2bbeb92244cb82a534abb016ffb5fbd1255d9db5) Thanks [@drwpow](https://github.com/drwpow)! - Remove leading question marks from querySerializer
 
-- [#1530](https://github.com/drwpow/openapi-typescript/pull/1530) [`4765658`](https://github.com/drwpow/openapi-typescript/commit/4765658460e0850d005e3f08cd63c4949326349b) Thanks [@wydengyre](https://github.com/wydengyre)! - Exports the ClientMethod utility type.
+- [#1530](https://github.com/openapi-ts/openapi-typescript/pull/1530) [`4765658`](https://github.com/openapi-ts/openapi-typescript/commit/4765658460e0850d005e3f08cd63c4949326349b) Thanks [@wydengyre](https://github.com/wydengyre)! - Exports the ClientMethod utility type.
 
-- Updated dependencies [[`c6d945b`](https://github.com/drwpow/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80)]:
+- Updated dependencies [[`c6d945b`](https://github.com/openapi-ts/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80)]:
   - openapi-typescript-helpers@0.0.7
 
 ## 0.8.2
 
 ### Patch Changes
 
-- [#1424](https://github.com/drwpow/openapi-typescript/pull/1424) [`8f5adb3`](https://github.com/drwpow/openapi-typescript/commit/8f5adb3700eacff287d8b3f62837cb823503d5a4) Thanks [@drwpow](https://github.com/drwpow)! - Separate TS types to be managed manually
+- [#1424](https://github.com/openapi-ts/openapi-typescript/pull/1424) [`8f5adb3`](https://github.com/openapi-ts/openapi-typescript/commit/8f5adb3700eacff287d8b3f62837cb823503d5a4) Thanks [@drwpow](https://github.com/drwpow)! - Separate TS types to be managed manually
 
-- Updated dependencies [[`5be2082`](https://github.com/drwpow/openapi-typescript/commit/5be20827334c60e53222445561b9cfc526f4f6a9)]:
+- Updated dependencies [[`5be2082`](https://github.com/openapi-ts/openapi-typescript/commit/5be20827334c60e53222445561b9cfc526f4f6a9)]:
   - openapi-typescript-helpers@0.0.5
 
 ## 0.8.1
 
 ### Patch Changes
 
-- [#1404](https://github.com/drwpow/openapi-typescript/pull/1404) [`93204e4`](https://github.com/drwpow/openapi-typescript/commit/93204e4de1b6e0469fdc8b710f5b279671570a9a) Thanks [@drwpow](https://github.com/drwpow)! - Fix behavior for empty arrays and objects in default `querySerializer`
+- [#1404](https://github.com/openapi-ts/openapi-typescript/pull/1404) [`93204e4`](https://github.com/openapi-ts/openapi-typescript/commit/93204e4de1b6e0469fdc8b710f5b279671570a9a) Thanks [@drwpow](https://github.com/drwpow)! - Fix behavior for empty arrays and objects in default `querySerializer`
 
 ## 0.8.0
 
 ### Minor Changes
 
-- [#1399](https://github.com/drwpow/openapi-typescript/pull/1399) [`4fca1e4`](https://github.com/drwpow/openapi-typescript/commit/4fca1e477f524223fa8921559caef6bb364dc194) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: change default querySerializer behavior to produce `style: form`, `explode: true` query params [according to the OpenAPI specification](https://swagger.io/docs/specification/serialization/#query). Also adds support for `deepObject`s (square bracket style).
+- [#1399](https://github.com/openapi-ts/openapi-typescript/pull/1399) [`4fca1e4`](https://github.com/openapi-ts/openapi-typescript/commit/4fca1e477f524223fa8921559caef6bb364dc194) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: change default querySerializer behavior to produce `style: form`, `explode: true` query params [according to the OpenAPI specification](https://swagger.io/docs/specification/serialization/#query). Also adds support for `deepObject`s (square bracket style).
 
 ## 0.7.10
 
 ### Patch Changes
 
-- [#1373](https://github.com/drwpow/openapi-typescript/pull/1373) [`fd3e96f`](https://github.com/drwpow/openapi-typescript/commit/fd3e96fb2e68a0d58b326331264809e76ca89672) Thanks [@HugeLetters](https://github.com/HugeLetters)! - Added the option to provide custom fetch function to individual API calls.
+- [#1373](https://github.com/openapi-ts/openapi-typescript/pull/1373) [`fd3e96f`](https://github.com/openapi-ts/openapi-typescript/commit/fd3e96fb2e68a0d58b326331264809e76ca89672) Thanks [@HugeLetters](https://github.com/HugeLetters)! - Added the option to provide custom fetch function to individual API calls.
 
 ## 0.7.9
 
 ### Patch Changes
 
-- [#1366](https://github.com/drwpow/openapi-typescript/pull/1366) [`04dbd6d`](https://github.com/drwpow/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da) Thanks [@drwpow](https://github.com/drwpow)! - Fix empty object being required param
+- [#1366](https://github.com/openapi-ts/openapi-typescript/pull/1366) [`04dbd6d`](https://github.com/openapi-ts/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da) Thanks [@drwpow](https://github.com/drwpow)! - Fix empty object being required param
 
-- Updated dependencies [[`04dbd6d`](https://github.com/drwpow/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da)]:
+- Updated dependencies [[`04dbd6d`](https://github.com/openapi-ts/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da)]:
   - openapi-typescript-helpers@0.0.4
 
 ## 0.7.8
 
 ### Patch Changes
 
-- [#1360](https://github.com/drwpow/openapi-typescript/pull/1360) [`b59e431`](https://github.com/drwpow/openapi-typescript/commit/b59e431d1876d1cc60dda5e9b59b6185b0136437) Thanks [@marcomuser](https://github.com/marcomuser)! - Fix CJS build for TypeScript
+- [#1360](https://github.com/openapi-ts/openapi-typescript/pull/1360) [`b59e431`](https://github.com/openapi-ts/openapi-typescript/commit/b59e431d1876d1cc60dda5e9b59b6185b0136437) Thanks [@marcomuser](https://github.com/marcomuser)! - Fix CJS build for TypeScript
 
 ## 0.7.7
 
 ### Patch Changes
 
-- Updated dependencies [[`996e51e`](https://github.com/drwpow/openapi-typescript/commit/996e51e9b475f4818af77301ed5c0ab458736cb9)]:
+- Updated dependencies [[`996e51e`](https://github.com/openapi-ts/openapi-typescript/commit/996e51e9b475f4818af77301ed5c0ab458736cb9)]:
   - openapi-typescript-helpers@0.0.3
 
 ## 0.7.6
 
 ### Patch Changes
 
-- [#1332](https://github.com/drwpow/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/drwpow/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
+- [#1332](https://github.com/openapi-ts/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/openapi-ts/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
 
 ## 0.7.5
 
 ### Patch Changes
 
-- Updated dependencies [[`e63a345`](https://github.com/drwpow/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f)]:
+- Updated dependencies [[`e63a345`](https://github.com/openapi-ts/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f)]:
   - openapi-typescript-helpers@0.0.2
 
 ## 0.7.4
 
 ### Patch Changes
 
-- [#1314](https://github.com/drwpow/openapi-typescript/pull/1314) [`181c4de`](https://github.com/drwpow/openapi-typescript/commit/181c4de395e9c337937f61d6dd5e0ba47954d893) Thanks [@drwpow](https://github.com/drwpow)! - Make headers typing friendlier
+- [#1314](https://github.com/openapi-ts/openapi-typescript/pull/1314) [`181c4de`](https://github.com/openapi-ts/openapi-typescript/commit/181c4de395e9c337937f61d6dd5e0ba47954d893) Thanks [@drwpow](https://github.com/drwpow)! - Make headers typing friendlier
 
-- [#1314](https://github.com/drwpow/openapi-typescript/pull/1314) [`181c4de`](https://github.com/drwpow/openapi-typescript/commit/181c4de395e9c337937f61d6dd5e0ba47954d893) Thanks [@drwpow](https://github.com/drwpow)! - Allow unsetting headers
+- [#1314](https://github.com/openapi-ts/openapi-typescript/pull/1314) [`181c4de`](https://github.com/openapi-ts/openapi-typescript/commit/181c4de395e9c337937f61d6dd5e0ba47954d893) Thanks [@drwpow](https://github.com/drwpow)! - Allow unsetting headers
 
 ## 0.7.3
 
 ### Patch Changes
 
-- [#1300](https://github.com/drwpow/openapi-typescript/pull/1300) [`5939e20`](https://github.com/drwpow/openapi-typescript/commit/5939e20b86ca3019cbc0a1c7f6de2b15a806cf72) Thanks [@drwpow](https://github.com/drwpow)! - Use openapi-typescript-helpers package for types
+- [#1300](https://github.com/openapi-ts/openapi-typescript/pull/1300) [`5939e20`](https://github.com/openapi-ts/openapi-typescript/commit/5939e20b86ca3019cbc0a1c7f6de2b15a806cf72) Thanks [@drwpow](https://github.com/drwpow)! - Use openapi-typescript-helpers package for types
 
 ## 0.7.2
 
 ### Patch Changes
 
-- [#1242](https://github.com/drwpow/openapi-typescript/pull/1242) [`8d11701`](https://github.com/drwpow/openapi-typescript/commit/8d11701deb22d47bc8ef04b6210ea6722ecb461b) Thanks [@drwpow](https://github.com/drwpow)! - Fix impossible body typing
+- [#1242](https://github.com/openapi-ts/openapi-typescript/pull/1242) [`8d11701`](https://github.com/openapi-ts/openapi-typescript/commit/8d11701deb22d47bc8ef04b6210ea6722ecb461b) Thanks [@drwpow](https://github.com/drwpow)! - Fix impossible body typing
 
 ## 0.7.1
 
 ### Patch Changes
 
-- [#1251](https://github.com/drwpow/openapi-typescript/pull/1251) [`80717a7`](https://github.com/drwpow/openapi-typescript/commit/80717a75ad20f2224a9a61d2a5b3d2b2bbd7c78b) Thanks [@drwpow](https://github.com/drwpow)! - Fix 2XX, 4XX, 5XX responses
+- [#1251](https://github.com/openapi-ts/openapi-typescript/pull/1251) [`80717a7`](https://github.com/openapi-ts/openapi-typescript/commit/80717a75ad20f2224a9a61d2a5b3d2b2bbd7c78b) Thanks [@drwpow](https://github.com/drwpow)! - Fix 2XX, 4XX, 5XX responses
 
 ## 0.7.0
 
 ### Minor Changes
 
-- [#1243](https://github.com/drwpow/openapi-typescript/pull/1243) [`541abf4`](https://github.com/drwpow/openapi-typescript/commit/541abf4966cf6020de5e4bf4b93cfa9741ec9a00) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking: rename all methods to UPPERCASE (`GET()`, `POST()`, etc.)
+- [#1243](https://github.com/openapi-ts/openapi-typescript/pull/1243) [`541abf4`](https://github.com/openapi-ts/openapi-typescript/commit/541abf4966cf6020de5e4bf4b93cfa9741ec9a00) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking: rename all methods to UPPERCASE (`GET()`, `POST()`, etc.)
 
 ## 0.6.2
 
 ### Patch Changes
 
-- [#1239](https://github.com/drwpow/openapi-typescript/pull/1239) [`4c93067`](https://github.com/drwpow/openapi-typescript/commit/4c9306720daa65b1c1977030737a52121fd46668) Thanks [@drwpow](https://github.com/drwpow)! - Fix params.header inference
+- [#1239](https://github.com/openapi-ts/openapi-typescript/pull/1239) [`4c93067`](https://github.com/openapi-ts/openapi-typescript/commit/4c9306720daa65b1c1977030737a52121fd46668) Thanks [@drwpow](https://github.com/drwpow)! - Fix params.header inference
 
 ## 0.6.1
 
 ### Patch Changes
 
-- [#1192](https://github.com/drwpow/openapi-typescript/pull/1192) [`38ee8b4`](https://github.com/drwpow/openapi-typescript/commit/38ee8b406ecf07e2dece05c4867a0bc5d27c309d) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Fix header handling for FormData
+- [#1192](https://github.com/openapi-ts/openapi-typescript/pull/1192) [`38ee8b4`](https://github.com/openapi-ts/openapi-typescript/commit/38ee8b406ecf07e2dece05c4867a0bc5d27c309d) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Fix header handling for FormData
 
 ## 0.6.0
 
 ### Minor Changes
 
-- [`0380e9a`](https://github.com/drwpow/openapi-typescript/commit/0380e9a572f6edfcc6ca1242b7f11abd8fc24610) Thanks [@drwpow](https://github.com/drwpow)! - Add multipart/form-data request body support
+- [`0380e9a`](https://github.com/openapi-ts/openapi-typescript/commit/0380e9a572f6edfcc6ca1242b7f11abd8fc24610) Thanks [@drwpow](https://github.com/drwpow)! - Add multipart/form-data request body support
 
-- [`0380e9a`](https://github.com/drwpow/openapi-typescript/commit/0380e9a572f6edfcc6ca1242b7f11abd8fc24610) Thanks [@drwpow](https://github.com/drwpow)! - Breaking: openapi-fetch now just takes the first media type it finds rather than preferring JSON. This is because in the case of `multipart/form-data` vs `application/json`, it’s not inherently clear which you’d want. Or if there were multiple JSON-like media types.
+- [`0380e9a`](https://github.com/openapi-ts/openapi-typescript/commit/0380e9a572f6edfcc6ca1242b7f11abd8fc24610) Thanks [@drwpow](https://github.com/drwpow)! - Breaking: openapi-fetch now just takes the first media type it finds rather than preferring JSON. This is because in the case of `multipart/form-data` vs `application/json`, it’s not inherently clear which you’d want. Or if there were multiple JSON-like media types.
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [#1183](https://github.com/drwpow/openapi-typescript/pull/1183) [`431a98f`](https://github.com/drwpow/openapi-typescript/commit/431a98f0b6d518aa8e780f063d680d380a8a12dd) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Add global `querySerializer()` option to `createClient()`
+- [#1183](https://github.com/openapi-ts/openapi-typescript/pull/1183) [`431a98f`](https://github.com/openapi-ts/openapi-typescript/commit/431a98f0b6d518aa8e780f063d680d380a8a12dd) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Add global `querySerializer()` option to `createClient()`
 
 ### Patch Changes
 
-- [#1186](https://github.com/drwpow/openapi-typescript/pull/1186) [`cd0a653`](https://github.com/drwpow/openapi-typescript/commit/cd0a65354b03fce8a6e28453b8760ac017205df1) Thanks [@drwpow](https://github.com/drwpow)! - Fix CJS build
+- [#1186](https://github.com/openapi-ts/openapi-typescript/pull/1186) [`cd0a653`](https://github.com/openapi-ts/openapi-typescript/commit/cd0a65354b03fce8a6e28453b8760ac017205df1) Thanks [@drwpow](https://github.com/drwpow)! - Fix CJS build
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [#1176](https://github.com/drwpow/openapi-typescript/pull/1176) [`21fb484`](https://github.com/drwpow/openapi-typescript/pull/1176/commits/21fb4848f1e70e4423a5f20cae330210b5b813b4) Thanks [@kecrily](https://github.com/kecrily)! - Add CommonJS bundle
+- [#1176](https://github.com/openapi-ts/openapi-typescript/pull/1176) [`21fb484`](https://github.com/openapi-ts/openapi-typescript/pull/1176/commits/21fb4848f1e70e4423a5f20cae330210b5b813b4) Thanks [@kecrily](https://github.com/kecrily)! - Add CommonJS bundle
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Expose createFinalURL() logic for testing
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Expose createFinalURL() logic for testing
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Automatically remove `undefined` and `null` query params without requiring querySerializer
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Automatically remove `undefined` and `null` query params without requiring querySerializer
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Allow overriding of JSON body parsing
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Allow overriding of JSON body parsing
 
 ### Patch Changes
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Clone response internally
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Clone response internally
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Strip trailing slashes from baseUrl
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Strip trailing slashes from baseUrl
 
-- [#1169](https://github.com/drwpow/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/drwpow/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Fix querySerializer typing
+- [#1169](https://github.com/openapi-ts/openapi-typescript/pull/1169) [`74bfc0d`](https://github.com/openapi-ts/openapi-typescript/commit/74bfc0d879747790aed7942e11f4b277b9b0428d) Thanks [@drwpow](https://github.com/drwpow)! - Fix querySerializer typing
 
 ## 0.2.1
 
 ### Patch Changes
 
-- [#1139](https://github.com/drwpow/openapi-typescript/pull/1139) [`30c01fa`](https://github.com/drwpow/openapi-typescript/commit/30c01fa3727a9696166a9bf44dd01693cc354a09) Thanks [@drwpow](https://github.com/drwpow)! - Treat `default` response as error
+- [#1139](https://github.com/openapi-ts/openapi-typescript/pull/1139) [`30c01fa`](https://github.com/openapi-ts/openapi-typescript/commit/30c01fa3727a9696166a9bf44dd01693cc354a09) Thanks [@drwpow](https://github.com/drwpow)! - Treat `default` response as error
 
 ## 0.2.0
 

--- a/packages/openapi-fetch/CONTRIBUTING.md
+++ b/packages/openapi-fetch/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for being willing to contribute! 🙏
 
 ## Open issues
 
-Please check out the [the open issues](https://github.com/drwpow/openapi-typescript/issues). Issues labelled [**Good First Issue**](https://github.com/drwpow/openapi-typescript/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are especially good to start with.
+Please check out the [the open issues](https://github.com/openapi-ts/openapi-typescript/issues). Issues labelled [**Good First Issue**](https://github.com/openapi-ts/openapi-typescript/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are especially good to start with.
 
 Contributing doesn’t have to be in code. Simply answering questions in open issues or providing workarounds is as important as making pull requests.
 

--- a/packages/openapi-fetch/README.md
+++ b/packages/openapi-fetch/README.md
@@ -10,7 +10,7 @@ openapi-fetch is a type-safe fetch client that pulls in your OpenAPI schema. Wei
 | superagent                 |    `55 kB` | `50k` ops/s (6× slower)    |
 | openapi-typescript-codegen |   `367 kB` | `100k` ops/s (3× slower)   |
 
-_\* [Benchmarks are approximate](https://github.com/drwpow/openapi-typescript/blob/main/packages/openapi-fetch/test/index.bench.js) to just show rough baseline and will differ among machines and browsers. The relative performance between libraries is more reliable._
+_\* [Benchmarks are approximate](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/test/index.bench.js) to just show rough baseline and will differ among machines and browsers. The relative performance between libraries is more reliable._
 
 The syntax is inspired by popular libraries like react-query or Apollo client, but without all the bells and whistles and in a 2 kB package.
 

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -27,11 +27,11 @@
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drwpow/openapi-typescript",
+    "url": "https://github.com/openapi-ts/openapi-typescript",
     "directory": "packages/openapi-fetch"
   },
   "bugs": {
-    "url": "https://github.com/drwpow/openapi-typescript/issues"
+    "url": "https://github.com/openapi-ts/openapi-typescript/issues"
   },
   "keywords": [
     "openapi",
@@ -70,7 +70,7 @@
     "esbuild": "^0.20.2",
     "execa": "^8.0.1",
     "msw": "^2.3.0",
-    "openapi-typescript": "^6.7.5",
+    "openapi-typescript": "^6.x",
     "openapi-typescript-codegen": "^0.25.0",
     "openapi-typescript-fetch": "^2.0.0",
     "superagent": "^9.0.2",

--- a/packages/openapi-typescript-helpers/CHANGELOG.md
+++ b/packages/openapi-typescript-helpers/CHANGELOG.md
@@ -4,45 +4,45 @@
 
 ### Patch Changes
 
-- [#1610](https://github.com/drwpow/openapi-typescript/pull/1610) [`cc8073b`](https://github.com/drwpow/openapi-typescript/commit/cc8073b3ee42e7aaa546a9c6a0553c300d8882de) Thanks [@illright](https://github.com/illright)! - Fix data/error discrimination when there are empty-body errors
+- [#1610](https://github.com/openapi-ts/openapi-typescript/pull/1610) [`cc8073b`](https://github.com/openapi-ts/openapi-typescript/commit/cc8073b3ee42e7aaa546a9c6a0553c300d8882de) Thanks [@illright](https://github.com/illright)! - Fix data/error discrimination when there are empty-body errors
 
-- [#1559](https://github.com/drwpow/openapi-typescript/pull/1559) [`6fe2c85`](https://github.com/drwpow/openapi-typescript/commit/6fe2c856331e910b9c8376fc151d63028dcfba11) Thanks [@drwpow](https://github.com/drwpow)! - Simplify build
+- [#1559](https://github.com/openapi-ts/openapi-typescript/pull/1559) [`6fe2c85`](https://github.com/openapi-ts/openapi-typescript/commit/6fe2c856331e910b9c8376fc151d63028dcfba11) Thanks [@drwpow](https://github.com/drwpow)! - Simplify build
 
 ## 0.0.7
 
 ### Patch Changes
 
-- [#1479](https://github.com/drwpow/openapi-typescript/pull/1479) [`c6d945b`](https://github.com/drwpow/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80) Thanks [@darwish](https://github.com/darwish)! - Fixed build of openapi-typescript-helpers for CommonJS environments
+- [#1479](https://github.com/openapi-ts/openapi-typescript/pull/1479) [`c6d945b`](https://github.com/openapi-ts/openapi-typescript/commit/c6d945be717bb3999178fb3a77292e41e1b7ab80) Thanks [@darwish](https://github.com/darwish)! - Fixed build of openapi-typescript-helpers for CommonJS environments
 
 ## 0.0.6
 
 ### Patch Changes
 
-- [#1458](https://github.com/drwpow/openapi-typescript/pull/1458) [`23517a2`](https://github.com/drwpow/openapi-typescript/commit/23517a2c2ab94d49085391130cd7d11f4da33cfb) Thanks [@drwpow](https://github.com/drwpow)! - Add RequestBodyJSON helper
+- [#1458](https://github.com/openapi-ts/openapi-typescript/pull/1458) [`23517a2`](https://github.com/openapi-ts/openapi-typescript/commit/23517a2c2ab94d49085391130cd7d11f4da33cfb) Thanks [@drwpow](https://github.com/drwpow)! - Add RequestBodyJSON helper
 
 ## 0.0.5
 
 ### Patch Changes
 
-- [#1456](https://github.com/drwpow/openapi-typescript/pull/1456) [`5be2082`](https://github.com/drwpow/openapi-typescript/commit/5be20827334c60e53222445561b9cfc526f4f6a9) Thanks [@drwpow](https://github.com/drwpow)! - Add SuccessResponseJSON, ErrorResponseJSON helpers
+- [#1456](https://github.com/openapi-ts/openapi-typescript/pull/1456) [`5be2082`](https://github.com/openapi-ts/openapi-typescript/commit/5be20827334c60e53222445561b9cfc526f4f6a9) Thanks [@drwpow](https://github.com/drwpow)! - Add SuccessResponseJSON, ErrorResponseJSON helpers
 
 ## 0.0.4
 
 ### Patch Changes
 
-- [#1366](https://github.com/drwpow/openapi-typescript/pull/1366) [`04dbd6d`](https://github.com/drwpow/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da) Thanks [@drwpow](https://github.com/drwpow)! - Add HasRequiredKeys<T> helper
+- [#1366](https://github.com/openapi-ts/openapi-typescript/pull/1366) [`04dbd6d`](https://github.com/openapi-ts/openapi-typescript/commit/04dbd6d84fffd1d88300421bae25e946f1c303da) Thanks [@drwpow](https://github.com/drwpow)! - Add HasRequiredKeys<T> helper
 
 ## 0.0.3
 
 ### Patch Changes
 
-- [#1357](https://github.com/drwpow/openapi-typescript/pull/1357) [`996e51e`](https://github.com/drwpow/openapi-typescript/commit/996e51e9b475f4818af77301ed5c0ab458736cb9) Thanks [@muttonchop](https://github.com/muttonchop)! - adds 500-511 error status codes
+- [#1357](https://github.com/openapi-ts/openapi-typescript/pull/1357) [`996e51e`](https://github.com/openapi-ts/openapi-typescript/commit/996e51e9b475f4818af77301ed5c0ab458736cb9) Thanks [@muttonchop](https://github.com/muttonchop)! - adds 500-511 error status codes
 
 ## 0.0.2
 
 ### Patch Changes
 
-- [#1326](https://github.com/drwpow/openapi-typescript/pull/1326) [`e63a345`](https://github.com/drwpow/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f) Thanks [@drwpow](https://github.com/drwpow)! - Fix type bug
+- [#1326](https://github.com/openapi-ts/openapi-typescript/pull/1326) [`e63a345`](https://github.com/openapi-ts/openapi-typescript/commit/e63a34561c8137c4cfdef858a2272be32960ca4f) Thanks [@drwpow](https://github.com/drwpow)! - Fix type bug
 
 ## 0.0.0
 

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -26,11 +26,11 @@
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drwpow/openapi-typescript",
+    "url": "https://github.com/openapi-ts/openapi-typescript",
     "directory": "packages/openapi-fetch"
   },
   "bugs": {
-    "url": "https://github.com/drwpow/openapi-typescript/issues"
+    "url": "https://github.com/openapi-ts/openapi-typescript/issues"
   },
   "scripts": {
     "build": "cp index.d.ts index.d.cts",

--- a/packages/openapi-typescript/CHANGELOG.md
+++ b/packages/openapi-typescript/CHANGELOG.md
@@ -4,282 +4,282 @@
 
 ### Major Changes
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: The Node.js API now returns the TypeScript AST for the main method as well as `transform()` and `postTransform()`. To migrate, you’ll have to use the `typescript` compiler API:
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: The Node.js API now returns the TypeScript AST for the main method as well as `transform()` and `postTransform()`. To migrate, you’ll have to use the `typescript` compiler API:
 
-    ```diff
-    + import ts from "typescript";
+  ```diff
+  + import ts from "typescript";
 
-    + const DATE = ts.factory.createIdentifier("Date");
-    + const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull());
+  + const DATE = ts.factory.createIdentifier("Date");
+  + const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull());
 
-      const ast = await openapiTS(mySchema, {
-        transform(schemaObject, metadata) {
-          if (schemaObject.format === "date-time") {
-    -       return schemaObject.nullable ? "Date | null" : "Date";
-    +       return schemaObject.nullable
-    +         ? ts.factory.createUnionTypeNode([DATE, NULL])
-    +         : DATE;
-          }
-        },
-      };
-    ```
+    const ast = await openapiTS(mySchema, {
+      transform(schemaObject, metadata) {
+        if (schemaObject.format === "date-time") {
+  -       return schemaObject.nullable ? "Date | null" : "Date";
+  +       return schemaObject.nullable
+  +         ? ts.factory.createUnionTypeNode([DATE, NULL])
+  +         : DATE;
+        }
+      },
+    };
+  ```
 
-    Though it’s more verbose, it’s also more powerful, as now you have access to additional properties of the generated code you didn’t before (such as injecting comments).
+  Though it’s more verbose, it’s also more powerful, as now you have access to additional properties of the generated code you didn’t before (such as injecting comments).
 
-    For example syntax, search this codebae to see how the TypeScript AST is used.
+  For example syntax, search this codebae to see how the TypeScript AST is used.
 
-    Also see [AST Explorer](https://astexplorer.net/)’s `typescript` parser to inspect how TypeScript is interpreted as an AST.
+  Also see [AST Explorer](https://astexplorer.net/)’s `typescript` parser to inspect how TypeScript is interpreted as an AST.
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Changing of several CLI flags and Node.js API options
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Changing of several CLI flags and Node.js API options
 
-    - The `--auth`, `--httpHeaders`, `--httpMethod`, and `fetch` (Node.js-only) options were all removed from the CLI and Node.js API
-        - To migrate, you’ll need to create a [redocly.yaml config](https://redocly.com/docs/cli/configuration/) that specifies your auth options [in the http setting](https://redocly.com/docs/cli/configuration/#resolve-non-public-or-non-remote-urls)
-        - You can also set your fetch client in redocly.yaml as well.
-    - `--immutable-types` has been renamed to `--immutable`
-    - `--support-array-length` has been renamed to `--array-length`
+  - The `--auth`, `--httpHeaders`, `--httpMethod`, and `fetch` (Node.js-only) options were all removed from the CLI and Node.js API
+    - To migrate, you’ll need to create a [redocly.yaml config](https://redocly.com/docs/cli/configuration/) that specifies your auth options [in the http setting](https://redocly.com/docs/cli/configuration/#resolve-non-public-or-non-remote-urls)
+    - You can also set your fetch client in redocly.yaml as well.
+  - `--immutable-types` has been renamed to `--immutable`
+  - `--support-array-length` has been renamed to `--array-length`
 
-- [`fbaf96d`](https://github.com/drwpow/openapi-typescript/commit/fbaf96d33181a2fabd3d4748e54c0f111ed6756e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Remove globbing schemas in favor of `redocly.yaml` config. Specify multiple schemas with outputs in there instead. See [Multiple schemas](https://openapi-ts.dev/docs/cli/#multiple-schemas) for more info.
+- [`fbaf96d`](https://github.com/openapi-ts/openapi-typescript/commit/fbaf96d33181a2fabd3d4748e54c0f111ed6756e) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Remove globbing schemas in favor of `redocly.yaml` config. Specify multiple schemas with outputs in there instead. See [Multiple schemas](https://openapi-ts.dev/docs/cli/#multiple-schemas) for more info.
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Most optional objects are now always present in types, just typed as `:never`. This includes keys of the Components Object as well as HTTP methods.
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: Most optional objects are now always present in types, just typed as `:never`. This includes keys of the Components Object as well as HTTP methods.
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: No more `external` export in schemas anymore. Everything gets flattened into the `components` object instead (if referencing a schema object from a remote partial, note it may have had a minor name change to avoid conflict).
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking**: No more `external` export in schemas anymore. Everything gets flattened into the `components` object instead (if referencing a schema object from a remote partial, note it may have had a minor name change to avoid conflict).
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking** `defaultNonNullable` option now defaults to `true`. You’ll now need to manually set `false` to return to old behavior.
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ **Breaking** `defaultNonNullable` option now defaults to `true`. You’ll now need to manually set `false` to return to old behavior.
 
-- [`799194d `](https://github.com/drwpow/openapi-typescript/commit/799194d98c3934570c6500d986496eee17b79309) Thanks [@drwpow](https://github.com/drwpow)~ - ⚠️ **Breaking** TypeScript is now a peerDependency and must be installed alongside `openapi-typescript`
+- [`799194d `](https://github.com/openapi-ts/openapi-typescript/commit/799194d98c3934570c6500d986496eee17b79309) Thanks [@drwpow](https://github.com/drwpow)~ - ⚠️ **Breaking** TypeScript is now a peerDependency and must be installed alongside `openapi-typescript`
 
 ### Minor Changes
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: automatically validate schemas with Redocly CLI ([docs](https://redocly.com/docs/cli/)). No more need for external tools to report errors! 🎉
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: automatically validate schemas with Redocly CLI ([docs](https://redocly.com/docs/cli/)). No more need for external tools to report errors! 🎉
 
   - By default, it will only throw on actual schema errors (uses Redocly’s default settings)
   - For stricter linting or custom rules, you can create a [redocly.yaml config](https://redocly.com/docs/cli/configuration/)
 
-- [`312b7ba`](https://github.com/drwpow/openapi-typescript/commit/312b7ba03fc0334153d4eeb51d6159f3fc63934e) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature:** allow configuration of schemas via `apis` key in redocly.config.yaml. [See docs](https://openapi-ts.dev/cli/) for more info.
+- [`312b7ba`](https://github.com/openapi-ts/openapi-typescript/commit/312b7ba03fc0334153d4eeb51d6159f3fc63934e) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature:** allow configuration of schemas via `apis` key in redocly.config.yaml. [See docs](https://openapi-ts.dev/cli/) for more info.
 
   - Any options passed into your [redocly.yaml config](https://redocly.com/docs/cli/configuration/) are respected
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: add `enum` option to export top-level enums from schemas
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: add `enum` option to export top-level enums from schemas
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: add `formatOptions` to allow formatting TS output
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: add `formatOptions` to allow formatting TS output
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: header responses add `[key: string]: unknown` index type to allow for additional untyped headers
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: header responses add `[key: string]: unknown` index type to allow for additional untyped headers
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: bundle schemas with Redocly CLI
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: bundle schemas with Redocly CLI
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: Added debugger that lets you profile performance and see more in-depth messages
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - ✨ **Feature**: Added debugger that lets you profile performance and see more in-depth messages
 
-- [#1374](https://github.com/drwpow/openapi-typescript/pull/1374) [`7ac5174`](https://github.com/drwpow/openapi-typescript/commit/7ac5174a1f767c1103573543bb17622ac8d25fe4) Thanks [@ElForastero](https://github.com/ElForastero)! - Add support for x-enum-varnames and x-enum-descriptions
+- [#1374](https://github.com/openapi-ts/openapi-typescript/pull/1374) [`7ac5174`](https://github.com/openapi-ts/openapi-typescript/commit/7ac5174a1f767c1103573543bb17622ac8d25fe4) Thanks [@ElForastero](https://github.com/ElForastero)! - Add support for x-enum-varnames and x-enum-descriptions
 
-- [#1545](https://github.com/drwpow/openapi-typescript/pull/1545) [`9158b81`](https://github.com/drwpow/openapi-typescript/commit/9158b81e8fdd45491afde8e291a786d7b2abc154) Thanks [@jaredLunde](https://github.com/drwpow/openapi-typescript/commits?author=jaredLunde)! - Replace # characters in operation IDs with a slash
+- [#1545](https://github.com/openapi-ts/openapi-typescript/pull/1545) [`9158b81`](https://github.com/openapi-ts/openapi-typescript/commit/9158b81e8fdd45491afde8e291a786d7b2abc154) Thanks [@jaredLunde](https://github.com/openapi-ts/openapi-typescript/commits?author=jaredLunde)! - Replace # characters in operation IDs with a slash
 
 ### Patch Changes
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - Refactor internals to use TypeScript AST rather than string mashing
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - Refactor internals to use TypeScript AST rather than string mashing
 
-- [`6d1eb32`](https://github.com/drwpow/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - 🧹 Cleaned up and reorganized all tests
+- [`6d1eb32`](https://github.com/openapi-ts/openapi-typescript/commit/6d1eb32e610cb62effbd1a817ae8fc93337126a6) Thanks [@drwpow](https://github.com/drwpow)! - 🧹 Cleaned up and reorganized all tests
 
-- [#1602](https://github.com/drwpow/openapi-typescript/pull/1602) [`9da96cd`](https://github.com/drwpow/openapi-typescript/commit/9da96cda4eb8f959c4703637d8fc89e1d3532af1) Thanks [@JeanRemiDelteil](https://github.com/JeanRemiDelteil)! - Do not add readonly on Typescript enum when the --immutable option is used.
+- [#1602](https://github.com/openapi-ts/openapi-typescript/pull/1602) [`9da96cd`](https://github.com/openapi-ts/openapi-typescript/commit/9da96cda4eb8f959c4703637d8fc89e1d3532af1) Thanks [@JeanRemiDelteil](https://github.com/JeanRemiDelteil)! - Do not add readonly on Typescript enum when the --immutable option is used.
 
 ## 6.7.0
 
 ### Minor Changes
 
-- [#1355](https://github.com/drwpow/openapi-typescript/pull/1355) [`7568941`](https://github.com/drwpow/openapi-typescript/commit/7568941fb378a9b94c96754553a720093645dd64) Thanks [@drwpow](https://github.com/drwpow)! - Revert optional parameters breaking change (v6.6.0, #1335)
+- [#1355](https://github.com/openapi-ts/openapi-typescript/pull/1355) [`7568941`](https://github.com/openapi-ts/openapi-typescript/commit/7568941fb378a9b94c96754553a720093645dd64) Thanks [@drwpow](https://github.com/drwpow)! - Revert optional parameters breaking change (v6.6.0, #1335)
 
 ## 6.6.2
 
 ### Patch Changes
 
-- [#1348](https://github.com/drwpow/openapi-typescript/pull/1348) [`f6fdd2f`](https://github.com/drwpow/openapi-typescript/commit/f6fdd2f59d035fec22f7fee27136939faae4628b) Thanks [@drwpow](https://github.com/drwpow)! - Improve YAML vs JSON parsing
+- [#1348](https://github.com/openapi-ts/openapi-typescript/pull/1348) [`f6fdd2f`](https://github.com/openapi-ts/openapi-typescript/commit/f6fdd2f59d035fec22f7fee27136939faae4628b) Thanks [@drwpow](https://github.com/drwpow)! - Improve YAML vs JSON parsing
 
-- [#1352](https://github.com/drwpow/openapi-typescript/pull/1352) [`33b2c4f`](https://github.com/drwpow/openapi-typescript/commit/33b2c4f6d9f8d2a1bd42b13b3c8c168ed86609d6) Thanks [@drwpow](https://github.com/drwpow)! - Fix all parameters optional
+- [#1352](https://github.com/openapi-ts/openapi-typescript/pull/1352) [`33b2c4f`](https://github.com/openapi-ts/openapi-typescript/commit/33b2c4f6d9f8d2a1bd42b13b3c8c168ed86609d6) Thanks [@drwpow](https://github.com/drwpow)! - Fix all parameters optional
 
-- [#1345](https://github.com/drwpow/openapi-typescript/pull/1345) [`6f078c1`](https://github.com/drwpow/openapi-typescript/commit/6f078c1eb008a278858e6764e92af6ceb39922b4) Thanks [@SchabaJo](https://github.com/SchabaJo)! - Mirror directory structure of input files if output is a directory to prevent overwriting the same file again and again.
+- [#1345](https://github.com/openapi-ts/openapi-typescript/pull/1345) [`6f078c1`](https://github.com/openapi-ts/openapi-typescript/commit/6f078c1eb008a278858e6764e92af6ceb39922b4) Thanks [@SchabaJo](https://github.com/SchabaJo)! - Mirror directory structure of input files if output is a directory to prevent overwriting the same file again and again.
 
 ## 6.6.1
 
 ### Patch Changes
 
-- [#1342](https://github.com/drwpow/openapi-typescript/pull/1342) [`c17669d`](https://github.com/drwpow/openapi-typescript/commit/c17669dbee47af49136bea3c40e12009e92cd81b) Thanks [@drwpow](https://github.com/drwpow)! - Fix discriminator propertyName inference
+- [#1342](https://github.com/openapi-ts/openapi-typescript/pull/1342) [`c17669d`](https://github.com/openapi-ts/openapi-typescript/commit/c17669dbee47af49136bea3c40e12009e92cd81b) Thanks [@drwpow](https://github.com/drwpow)! - Fix discriminator propertyName inference
 
 ## 6.6.0
 
 ### Minor Changes
 
-- [#1335](https://github.com/drwpow/openapi-typescript/pull/1335) [`7cb02ac`](https://github.com/drwpow/openapi-typescript/commit/7cb02acbcf57946b8202b9598a888454f09f81fa) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Request parameters member is optional when all parameters are optional.
+- [#1335](https://github.com/openapi-ts/openapi-typescript/pull/1335) [`7cb02ac`](https://github.com/openapi-ts/openapi-typescript/commit/7cb02acbcf57946b8202b9598a888454f09f81fa) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Request parameters member is optional when all parameters are optional.
 
 ## 6.5.5
 
 ### Patch Changes
 
-- [#1332](https://github.com/drwpow/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/drwpow/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
+- [#1332](https://github.com/openapi-ts/openapi-typescript/pull/1332) [`8e8ebfd`](https://github.com/openapi-ts/openapi-typescript/commit/8e8ebfdcd84ff6a3d7b6f5d00695fc11366b436e) Thanks [@drwpow](https://github.com/drwpow)! - Restore original .d.ts module-resolution behavior
 
 ## 6.5.4
 
 ### Patch Changes
 
-- [#1324](https://github.com/drwpow/openapi-typescript/pull/1324) [`0357325`](https://github.com/drwpow/openapi-typescript/commit/0357325ae136cbdd9c9891ebb7f5414e3ad8bfec) Thanks [@drwpow](https://github.com/drwpow)! - Fix accidental quote appearing in components/responses with $refs
+- [#1324](https://github.com/openapi-ts/openapi-typescript/pull/1324) [`0357325`](https://github.com/openapi-ts/openapi-typescript/commit/0357325ae136cbdd9c9891ebb7f5414e3ad8bfec) Thanks [@drwpow](https://github.com/drwpow)! - Fix accidental quote appearing in components/responses with $refs
 
 ## 6.5.3
 
 ### Patch Changes
 
-- [#1320](https://github.com/drwpow/openapi-typescript/pull/1320) [`3cf78b9`](https://github.com/drwpow/openapi-typescript/commit/3cf78b920ab23624c0524e0d58338ee66acad799) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Wrap nested readonly types in parentheses, allowing for nested immutable arrays
+- [#1320](https://github.com/openapi-ts/openapi-typescript/pull/1320) [`3cf78b9`](https://github.com/openapi-ts/openapi-typescript/commit/3cf78b920ab23624c0524e0d58338ee66acad799) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Wrap nested readonly types in parentheses, allowing for nested immutable arrays
 
 ## 6.5.2
 
 ### Patch Changes
 
-- [#1317](https://github.com/drwpow/openapi-typescript/pull/1317) [`5e054db`](https://github.com/drwpow/openapi-typescript/commit/5e054dbc0984198c7f89e29b6f38e9d60790cafb) Thanks [@drwpow](https://github.com/drwpow)! - Fix JSONSchema $defs
+- [#1317](https://github.com/openapi-ts/openapi-typescript/pull/1317) [`5e054db`](https://github.com/openapi-ts/openapi-typescript/commit/5e054dbc0984198c7f89e29b6f38e9d60790cafb) Thanks [@drwpow](https://github.com/drwpow)! - Fix JSONSchema $defs
 
-- [#1317](https://github.com/drwpow/openapi-typescript/pull/1317) [`5e054db`](https://github.com/drwpow/openapi-typescript/commit/5e054dbc0984198c7f89e29b6f38e9d60790cafb) Thanks [@drwpow](https://github.com/drwpow)! - Improve remote $ref parsing
+- [#1317](https://github.com/openapi-ts/openapi-typescript/pull/1317) [`5e054db`](https://github.com/openapi-ts/openapi-typescript/commit/5e054dbc0984198c7f89e29b6f38e9d60790cafb) Thanks [@drwpow](https://github.com/drwpow)! - Improve remote $ref parsing
 
 ## 6.5.1
 
 ### Patch Changes
 
-- [#1308](https://github.com/drwpow/openapi-typescript/pull/1308) [`ebb73b6`](https://github.com/drwpow/openapi-typescript/commit/ebb73b68c3a2f9a8c8193888735f9c0b7855722f) Thanks [@drwpow](https://github.com/drwpow)! - Fix bugs with remote $refs, add `cwd` option for JSON schema parsing
+- [#1308](https://github.com/openapi-ts/openapi-typescript/pull/1308) [`ebb73b6`](https://github.com/openapi-ts/openapi-typescript/commit/ebb73b68c3a2f9a8c8193888735f9c0b7855722f) Thanks [@drwpow](https://github.com/drwpow)! - Fix bugs with remote $refs, add `cwd` option for JSON schema parsing
 
 ## 6.5.0
 
 ### Minor Changes
 
-- [#1295](https://github.com/drwpow/openapi-typescript/pull/1295) [`99a1648`](https://github.com/drwpow/openapi-typescript/commit/99a1648affd5731c2d303619f050fee2ed834eef) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Avoid adding a undefined union to additionProperties
+- [#1295](https://github.com/openapi-ts/openapi-typescript/pull/1295) [`99a1648`](https://github.com/openapi-ts/openapi-typescript/commit/99a1648affd5731c2d303619f050fee2ed834eef) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Avoid adding a undefined union to additionProperties
 
 ## 6.4.5
 
 ### Patch Changes
 
-- [#1280](https://github.com/drwpow/openapi-typescript/pull/1280) [`50441d0`](https://github.com/drwpow/openapi-typescript/commit/50441d048b8724d1ec31d20a1583c8748b7ddc99) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix invalid typescript for empty request bodies, fix headers being left out when response body is omitted
+- [#1280](https://github.com/openapi-ts/openapi-typescript/pull/1280) [`50441d0`](https://github.com/openapi-ts/openapi-typescript/commit/50441d048b8724d1ec31d20a1583c8748b7ddc99) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix invalid typescript for empty request bodies, fix headers being left out when response body is omitted
 
-- [#1289](https://github.com/drwpow/openapi-typescript/pull/1289) [`7f452fa`](https://github.com/drwpow/openapi-typescript/commit/7f452fa00044c7191c2721b6691178158f97940f) Thanks [@adamschoenemann](https://github.com/adamschoenemann)! - Fixed a bug where references to types with discriminators with implicit mappings would generate incorrect types
+- [#1289](https://github.com/openapi-ts/openapi-typescript/pull/1289) [`7f452fa`](https://github.com/openapi-ts/openapi-typescript/commit/7f452fa00044c7191c2721b6691178158f97940f) Thanks [@adamschoenemann](https://github.com/adamschoenemann)! - Fixed a bug where references to types with discriminators with implicit mappings would generate incorrect types
 
 ## 6.4.4
 
 ### Patch Changes
 
-- [#1281](https://github.com/drwpow/openapi-typescript/pull/1281) [`ebd31ff`](https://github.com/drwpow/openapi-typescript/commit/ebd31ff3d143dbe8e4d91a4ba18b110ff6656dd0) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Refactor CLI path handling, fixing several bugs
+- [#1281](https://github.com/openapi-ts/openapi-typescript/pull/1281) [`ebd31ff`](https://github.com/openapi-ts/openapi-typescript/commit/ebd31ff3d143dbe8e4d91a4ba18b110ff6656dd0) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Refactor CLI path handling, fixing several bugs
 
 ## 6.4.3
 
 ### Patch Changes
 
-- [#1287](https://github.com/drwpow/openapi-typescript/pull/1287) [`8a9d8ed`](https://github.com/drwpow/openapi-typescript/commit/8a9d8ede95802370c4015846a4856fd0701ada33) Thanks [@drwpow](https://github.com/drwpow)! - Fix oneOf handling with empty object parent type
+- [#1287](https://github.com/openapi-ts/openapi-typescript/pull/1287) [`8a9d8ed`](https://github.com/openapi-ts/openapi-typescript/commit/8a9d8ede95802370c4015846a4856fd0701ada33) Thanks [@drwpow](https://github.com/drwpow)! - Fix oneOf handling with empty object parent type
 
 ## 6.4.2
 
 ### Patch Changes
 
-- [#1278](https://github.com/drwpow/openapi-typescript/pull/1278) [`d7420e3`](https://github.com/drwpow/openapi-typescript/commit/d7420e30f1697ad8cfc0fdefc93127ad2b813f99) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix externalizing external refs
+- [#1278](https://github.com/openapi-ts/openapi-typescript/pull/1278) [`d7420e3`](https://github.com/openapi-ts/openapi-typescript/commit/d7420e30f1697ad8cfc0fdefc93127ad2b813f99) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix externalizing external refs
 
 ## 6.4.1
 
 ### Patch Changes
 
-- [#1269](https://github.com/drwpow/openapi-typescript/pull/1269) [`e735ff2`](https://github.com/drwpow/openapi-typescript/commit/e735ff2b9307eaec1959d0d3bf733a240a880c48) Thanks [@pimveldhuisen](https://github.com/pimveldhuisen)! - Stop trimming whitespace other than linebreaks in string values
+- [#1269](https://github.com/openapi-ts/openapi-typescript/pull/1269) [`e735ff2`](https://github.com/openapi-ts/openapi-typescript/commit/e735ff2b9307eaec1959d0d3bf733a240a880c48) Thanks [@pimveldhuisen](https://github.com/pimveldhuisen)! - Stop trimming whitespace other than linebreaks in string values
 
 ## 6.4.0
 
 ### Minor Changes
 
-- [#1263](https://github.com/drwpow/openapi-typescript/pull/1263) [`1bf2d4d`](https://github.com/drwpow/openapi-typescript/commit/1bf2d4db73b93fd1d36ffb56bdfb90321b0bfaba) Thanks [@drwpow](https://github.com/drwpow)! - Ship CJS bundle
+- [#1263](https://github.com/openapi-ts/openapi-typescript/pull/1263) [`1bf2d4d`](https://github.com/openapi-ts/openapi-typescript/commit/1bf2d4db73b93fd1d36ffb56bdfb90321b0bfaba) Thanks [@drwpow](https://github.com/drwpow)! - Ship CJS bundle
 
 ## 6.3.9
 
 ### Patch Changes
 
-- [#1248](https://github.com/drwpow/openapi-typescript/pull/1248) [`c145f5f`](https://github.com/drwpow/openapi-typescript/commit/c145f5f6164b52a8b437b2e944f60927d546edbf) Thanks [@drwpow](https://github.com/drwpow)! - Fix Record<string, never> appearing in union
+- [#1248](https://github.com/openapi-ts/openapi-typescript/pull/1248) [`c145f5f`](https://github.com/openapi-ts/openapi-typescript/commit/c145f5f6164b52a8b437b2e944f60927d546edbf) Thanks [@drwpow](https://github.com/drwpow)! - Fix Record<string, never> appearing in union
 
-- [#1248](https://github.com/drwpow/openapi-typescript/pull/1248) [`c145f5f`](https://github.com/drwpow/openapi-typescript/commit/c145f5f6164b52a8b437b2e944f60927d546edbf) Thanks [@drwpow](https://github.com/drwpow)! - Improve oneOf generated types
+- [#1248](https://github.com/openapi-ts/openapi-typescript/pull/1248) [`c145f5f`](https://github.com/openapi-ts/openapi-typescript/commit/c145f5f6164b52a8b437b2e944f60927d546edbf) Thanks [@drwpow](https://github.com/drwpow)! - Improve oneOf generated types
 
 ## 6.3.8
 
 ### Patch Changes
 
-- [#1246](https://github.com/drwpow/openapi-typescript/pull/1246) [`17a375e`](https://github.com/drwpow/openapi-typescript/commit/17a375ec5d13b89f526a63f6d9b9f15db85b75e9) Thanks [@drwpow](https://github.com/drwpow)! - Fix remote path item object $refs
+- [#1246](https://github.com/openapi-ts/openapi-typescript/pull/1246) [`17a375e`](https://github.com/openapi-ts/openapi-typescript/commit/17a375ec5d13b89f526a63f6d9b9f15db85b75e9) Thanks [@drwpow](https://github.com/drwpow)! - Fix remote path item object $refs
 
 ## 6.3.7
 
 ### Patch Changes
 
-- [#1236](https://github.com/drwpow/openapi-typescript/pull/1236) [`95a4c8c`](https://github.com/drwpow/openapi-typescript/commit/95a4c8c573c8eea2c911359879419eb07e10bd63) Thanks [@drwpow](https://github.com/drwpow)! - Improve oneOf and enum handling
+- [#1236](https://github.com/openapi-ts/openapi-typescript/pull/1236) [`95a4c8c`](https://github.com/openapi-ts/openapi-typescript/commit/95a4c8c573c8eea2c911359879419eb07e10bd63) Thanks [@drwpow](https://github.com/drwpow)! - Improve oneOf and enum handling
 
 ## 6.3.6
 
 ### Patch Changes
 
-- [#1231](https://github.com/drwpow/openapi-typescript/pull/1231) [`e1ce2d6`](https://github.com/drwpow/openapi-typescript/commit/e1ce2d67a5350ff2871ae01503df2280454b7a80) Thanks [@tkrotoff](https://github.com/tkrotoff)! - Do not append trailing spaces to JSDoc tags
+- [#1231](https://github.com/openapi-ts/openapi-typescript/pull/1231) [`e1ce2d6`](https://github.com/openapi-ts/openapi-typescript/commit/e1ce2d67a5350ff2871ae01503df2280454b7a80) Thanks [@tkrotoff](https://github.com/tkrotoff)! - Do not append trailing spaces to JSDoc tags
 
-- [#1232](https://github.com/drwpow/openapi-typescript/pull/1232) [`31c030d`](https://github.com/drwpow/openapi-typescript/commit/31c030d5f1bf2739dbc146e42372cf9aec922f93) Thanks [@tkrotoff](https://github.com/tkrotoff)! - Remove unnecessary array parenthesis
+- [#1232](https://github.com/openapi-ts/openapi-typescript/pull/1232) [`31c030d`](https://github.com/openapi-ts/openapi-typescript/commit/31c030d5f1bf2739dbc146e42372cf9aec922f93) Thanks [@tkrotoff](https://github.com/tkrotoff)! - Remove unnecessary array parenthesis
 
 ## 6.3.5
 
 ### Patch Changes
 
-- [#1228](https://github.com/drwpow/openapi-typescript/pull/1228) [`3107f1e`](https://github.com/drwpow/openapi-typescript/commit/3107f1edb9119397fca3e34aeda4def3555c0811) Thanks [@m-ronchi](https://github.com/m-ronchi)! - Fix boolean JSON Schemas
+- [#1228](https://github.com/openapi-ts/openapi-typescript/pull/1228) [`3107f1e`](https://github.com/openapi-ts/openapi-typescript/commit/3107f1edb9119397fca3e34aeda4def3555c0811) Thanks [@m-ronchi](https://github.com/m-ronchi)! - Fix boolean JSON Schemas
 
 ## 6.3.4
 
 ### Patch Changes
 
-- [#1221](https://github.com/drwpow/openapi-typescript/pull/1221) [`4e96e9d`](https://github.com/drwpow/openapi-typescript/commit/4e96e9dcb845adc501d7256c3c3c9c30c8c6d99d) Thanks [@drwpow](https://github.com/drwpow)! - Remove OneOf<> helper for simple type comparisons
+- [#1221](https://github.com/openapi-ts/openapi-typescript/pull/1221) [`4e96e9d`](https://github.com/openapi-ts/openapi-typescript/commit/4e96e9dcb845adc501d7256c3c3c9c30c8c6d99d) Thanks [@drwpow](https://github.com/drwpow)! - Remove OneOf<> helper for simple type comparisons
 
-- [#1221](https://github.com/drwpow/openapi-typescript/pull/1221) [`4e96e9d`](https://github.com/drwpow/openapi-typescript/commit/4e96e9dcb845adc501d7256c3c3c9c30c8c6d99d) Thanks [@drwpow](https://github.com/drwpow)! - Fix 3.1 nullable types
+- [#1221](https://github.com/openapi-ts/openapi-typescript/pull/1221) [`4e96e9d`](https://github.com/openapi-ts/openapi-typescript/commit/4e96e9dcb845adc501d7256c3c3c9c30c8c6d99d) Thanks [@drwpow](https://github.com/drwpow)! - Fix 3.1 nullable types
 
 ## 6.3.3
 
 ### Patch Changes
 
-- [#1200](https://github.com/drwpow/openapi-typescript/pull/1200) [`4fc8c20`](https://github.com/drwpow/openapi-typescript/commit/4fc8c20c079e81c600ecffffd90fc9c77c11d49e) Thanks [@toomuchdesign](https://github.com/toomuchdesign)! - Remove unexpected empty string in generated nullable polymophic enum types (["string", "null"])
+- [#1200](https://github.com/openapi-ts/openapi-typescript/pull/1200) [`4fc8c20`](https://github.com/openapi-ts/openapi-typescript/commit/4fc8c20c079e81c600ecffffd90fc9c77c11d49e) Thanks [@toomuchdesign](https://github.com/toomuchdesign)! - Remove unexpected empty string in generated nullable polymophic enum types (["string", "null"])
 
 ## 6.3.2
 
 ### Patch Changes
 
-- [#1212](https://github.com/drwpow/openapi-typescript/pull/1212) [`e173ccf`](https://github.com/drwpow/openapi-typescript/commit/e173ccf0d92fd4b54cb2dec54056f4647cbadc83) Thanks [@drwpow](https://github.com/drwpow)! - Fix bug with remote schema $refs
+- [#1212](https://github.com/openapi-ts/openapi-typescript/pull/1212) [`e173ccf`](https://github.com/openapi-ts/openapi-typescript/commit/e173ccf0d92fd4b54cb2dec54056f4647cbadc83) Thanks [@drwpow](https://github.com/drwpow)! - Fix bug with remote schema $refs
 
 ## 6.3.1
 
 ### Patch Changes
 
-- [#1207](https://github.com/drwpow/openapi-typescript/pull/1207) [`914e049`](https://github.com/drwpow/openapi-typescript/commit/914e049573218b1bf791ce7855cdb1022bedc2b2) Thanks [@drwpow](https://github.com/drwpow)! - Fall back to TypeScript unions for long oneOf lists
+- [#1207](https://github.com/openapi-ts/openapi-typescript/pull/1207) [`914e049`](https://github.com/openapi-ts/openapi-typescript/commit/914e049573218b1bf791ce7855cdb1022bedc2b2) Thanks [@drwpow](https://github.com/drwpow)! - Fall back to TypeScript unions for long oneOf lists
 
 ## 6.3.0
 
 ### Minor Changes
 
-- [#1205](https://github.com/drwpow/openapi-typescript/pull/1205) [`c753f7b`](https://github.com/drwpow/openapi-typescript/commit/c753f7b27a93bb963d8b762b8faa785025aa9135) Thanks [@drwpow](https://github.com/drwpow)! - Add prefixItems support
+- [#1205](https://github.com/openapi-ts/openapi-typescript/pull/1205) [`c753f7b`](https://github.com/openapi-ts/openapi-typescript/commit/c753f7b27a93bb963d8b762b8faa785025aa9135) Thanks [@drwpow](https://github.com/drwpow)! - Add prefixItems support
 
 ### Patch Changes
 
-- [#1203](https://github.com/drwpow/openapi-typescript/pull/1203) [`902fde1`](https://github.com/drwpow/openapi-typescript/commit/902fde156a55f2f0f4889680cea3605cc9d137b4) Thanks [@drwpow](https://github.com/drwpow)! - Fix mutating $refs in Node.js API
+- [#1203](https://github.com/openapi-ts/openapi-typescript/pull/1203) [`902fde1`](https://github.com/openapi-ts/openapi-typescript/commit/902fde156a55f2f0f4889680cea3605cc9d137b4) Thanks [@drwpow](https://github.com/drwpow)! - Fix mutating $refs in Node.js API
 
 ## 6.2.9
 
 ### Patch Changes
 
-- [#1193](https://github.com/drwpow/openapi-typescript/pull/1193) [`64decb7`](https://github.com/drwpow/openapi-typescript/commit/64decb7243e3f4962dd3a97378f37142ee89546a) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Add example for `Blob` type transforms
+- [#1193](https://github.com/openapi-ts/openapi-typescript/pull/1193) [`64decb7`](https://github.com/openapi-ts/openapi-typescript/commit/64decb7243e3f4962dd3a97378f37142ee89546a) Thanks [@psychedelicious](https://github.com/psychedelicious)! - Add example for `Blob` type transforms
 
 ## 6.2.8
 
 ### Patch Changes
 
-- [#1166](https://github.com/drwpow/openapi-typescript/pull/1166) [`db37f3c`](https://github.com/drwpow/openapi-typescript/commit/db37f3ca2993a3d7e7cf580273452c21a68c503d) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix property escaping for discriminators
+- [#1166](https://github.com/openapi-ts/openapi-typescript/pull/1166) [`db37f3c`](https://github.com/openapi-ts/openapi-typescript/commit/db37f3ca2993a3d7e7cf580273452c21a68c503d) Thanks [@pvanagtmaal](https://github.com/pvanagtmaal)! - Fix property escaping for discriminators
 
 ## 6.2.7
 
 ### Patch Changes
 
-- [#1149](https://github.com/drwpow/openapi-typescript/pull/1149) [`b82cffb`](https://github.com/drwpow/openapi-typescript/commit/b82cffbc6c3fc0da9a24d9b90b303dcb2dd71c62) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Stringify const values with no specified type
+- [#1149](https://github.com/openapi-ts/openapi-typescript/pull/1149) [`b82cffb`](https://github.com/openapi-ts/openapi-typescript/commit/b82cffbc6c3fc0da9a24d9b90b303dcb2dd71c62) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Stringify const values with no specified type
 
-- [#1156](https://github.com/drwpow/openapi-typescript/pull/1156) [`ad017a9`](https://github.com/drwpow/openapi-typescript/commit/ad017a9ac2dc5b01726267fca9418b311fe91896) Thanks [@horaklukas](https://github.com/horaklukas)! - Avoid index signature TS error for paths with empty params
+- [#1156](https://github.com/openapi-ts/openapi-typescript/pull/1156) [`ad017a9`](https://github.com/openapi-ts/openapi-typescript/commit/ad017a9ac2dc5b01726267fca9418b311fe91896) Thanks [@horaklukas](https://github.com/horaklukas)! - Avoid index signature TS error for paths with empty params
 
 ## 6.2.6
 
 ### Patch Changes
 
-- [#1146](https://github.com/drwpow/openapi-typescript/pull/1146) [`12aa721`](https://github.com/drwpow/openapi-typescript/commit/12aa7212fbe09efd0fe89dca18713145e8da9c8e) Thanks [@drwpow](https://github.com/drwpow)! - Fix js-yaml $refs
+- [#1146](https://github.com/openapi-ts/openapi-typescript/pull/1146) [`12aa721`](https://github.com/openapi-ts/openapi-typescript/commit/12aa7212fbe09efd0fe89dca18713145e8da9c8e) Thanks [@drwpow](https://github.com/drwpow)! - Fix js-yaml $refs
 
 ## 6.2.5
 
@@ -488,7 +488,7 @@
 
 ### Minor changes
 
-- Now supports a `URL()` as input to make ESM usage easier ([see example](https://github.com/drwpow/openapi-typescript/tree/5.x#-node))
+- Now supports a `URL()` as input to make ESM usage easier ([see example](https://github.com/openapi-ts/openapi-typescript/tree/5.x#-node))
 
 ## 4.5.0
 

--- a/packages/openapi-typescript/CONTRIBUTING.md
+++ b/packages/openapi-typescript/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for being willing to contribute! 🙏
 
 ## Open issues
 
-Please check out the [the open issues](https://github.com/drwpow/openapi-typescript/issues). Issues labelled [**Good First Issue**](https://github.com/drwpow/openapi-typescript/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are especially good to start with.
+Please check out the [the open issues](https://github.com/openapi-ts/openapi-typescript/issues). Issues labelled [**Good First Issue**](https://github.com/openapi-ts/openapi-typescript/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are especially good to start with.
 
 Contributing doesn’t have to be in code. Simply answering questions in open issues or providing workarounds is as important as making pull requests.
 
@@ -68,7 +68,7 @@ To add a schema as a snapshot test, modify the [/scripts/download-schemas.ts](/s
 
 It may be surprising to hear, but generating TypeScript types from OpenAPI is opinionated. Even though TypeScript and OpenAPI are close relatives—both JavaScript/JSON-based—they are nonetheless 2 different languages and thus there is room for interpretation. Further, some parts of the OpenAPI specification can be ambiguous on how they’re used, and what the expected type outcomes may be (though this is generally for more advanced use cases, such as specific implementations of `anyOf` as well as [discriminator](https://spec.openapis.org/oas/latest.html#discriminatorObject) and complex polymorphism).
 
-All that said, this library should strive to generate _the most predictable_ TypeScript output for a given schema. And to achieve that, it always helps to open an [issue](https://github.com/drwpow/openapi-typescript/issues) or [discussion](https://github.com/drwpow/openapi-typescript/discussions) to gather feedback.
+All that said, this library should strive to generate _the most predictable_ TypeScript output for a given schema. And to achieve that, it always helps to open an [issue](https://github.com/openapi-ts/openapi-typescript/issues) or [discussion](https://github.com/openapi-ts/openapi-typescript/discussions) to gather feedback.
 
 ### Opening a PR
 

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drwpow/openapi-typescript",
+    "url": "https://github.com/openapi-ts/openapi-typescript",
     "directory": "packages/openapi-typescript"
   },
   "keywords": [
@@ -37,7 +37,7 @@
     "node"
   ],
   "bugs": {
-    "url": "https://github.com/drwpow/openapi-typescript/issues"
+    "url": "https://github.com/openapi-ts/openapi-typescript/issues"
   },
   "scripts": {
     "build": "pnpm run build:clean && pnpm run build:esm && pnpm run build:cjs",

--- a/packages/openapi-typescript/src/transform/path-item-object.ts
+++ b/packages/openapi-typescript/src/transform/path-item-object.ts
@@ -66,7 +66,7 @@ export default function transformPathItemObject(pathItem: PathItemObject, option
     }
     // if operationId exists, move into an `operations` export and pass the reference in here
     else if (operationObject.operationId) {
-      // workaround for issue caused by redocly ref parsing: https://github.com/drwpow/openapi-typescript/issues/1542
+      // workaround for issue caused by redocly ref parsing: https://github.com/openapi-ts/openapi-typescript/issues/1542
       const operationId = operationObject.operationId.replace(HASH_RE, "/");
       operationType = oapiRef(createRef(["operations", operationId]));
       injectOperationObject(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0(typescript@5.4.5)
       openapi-typescript:
-        specifier: ^6.7.5
-        version: 6.7.5
+        specifier: ^6.x
+        version: 6.7.6
       openapi-typescript-codegen:
         specifier: ^0.25.0
         version: 0.25.0
@@ -2712,8 +2712,8 @@ packages:
     resolution: {integrity: sha512-9YkzVKIx9RVIET0lFjJOuf15VjI9AUsoNByBk5WYM66xVlAKDNy8anj08Ci3zZA+HgTwdDamYz5FCVYt2VoHkA==}
     engines: {node: '>= 12.0.0', npm: '>= 7.0.0'}
 
-  openapi-typescript@6.7.5:
-    resolution: {integrity: sha512-ZD6dgSZi0u1QCP55g8/2yS5hNJfIpgqsSGHLxxdOjvY7eIrXzj271FJEQw33VwsZ6RCtO/NOuhxa7GBWmEudyA==}
+  openapi-typescript@6.7.6:
+    resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
     hasBin: true
 
   os-tmpdir@1.0.2:
@@ -6311,7 +6311,7 @@ snapshots:
 
   openapi-typescript-fetch@2.0.0: {}
 
-  openapi-typescript@6.7.5:
+  openapi-typescript@6.7.6:
     dependencies:
       ansi-colors: 4.1.3
       fast-glob: 3.3.2


### PR DESCRIPTION
## Changes

Chore: Replaces `drwpow/openapi-typescript` → `openapi-ts/openapi-typescript`. GitHub is currently redirecting, but no guarantee how long. And a redirect isn’t great to rely on.

## How to Review

N/A; internal change.

## Checklist

N/A