### PR TITLE
openapi-fetch@0.9.8

### DIFF
--- a/packages/openapi-fetch/CHANGELOG.md
+++ b/packages/openapi-fetch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-fetch
 
+## 0.9.8
+
+### Patch Changes
+
+- [#1697](https://github.com/openapi-ts/openapi-typescript/pull/1697) [`e77ce50`](https://github.com/openapi-ts/openapi-typescript/commit/e77ce501e479f54fb783c19b99fa7a53a894732c) Thanks [@armandabric](https://github.com/armandabric)! - Expose original request on Middleware.onResponse
+
 ## 0.9.7
 
 ### Patch Changes

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-fetch",
   "description": "Fast, type-safe fetch client for your OpenAPI schema. Only 5 kb (min). Works with React, Vue, Svelte, or vanilla JS.",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"


### PR DESCRIPTION
## Changes

Release `openapi-fetch@0.9.8`. Hopefully the last manual release 🤞

## How to Review

- Only releasing already-merged & tested changes; no additional changes.
- CI should pass

## Checklist

N/A
