### PR TITLE
Setup proxy support using environment variable HTTP_PROXY

### DIFF
--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -121,3 +121,9 @@ This results in more explicit typechecking of array lengths.
 _Note: this has a reasonable limit, so for example `maxItems: 100` would simply flatten back down to `string[];`_
 
 _Thanks, [@kgtkr](https://github.com/kgtkr)!_
+
+## Proxy support
+
+When the use of a corporate proxy is required to access the internet and download external definitions, please configure
+this using the standard environment variable ```HTTP_PROXY```. Make sure this environment variable is set when
+running ```openapi-typescript```

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -7,6 +7,13 @@ import glob from "fast-glob";
 import parser from "yargs-parser";
 import openapiTS from "../dist/index.js";
 import { c, error } from "../dist/utils.js";
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+// Corporate proxy support
+if (process.env.HTTP_PROXY) {
+  const proxyAgent = new ProxyAgent(process.env.HTTP_PROXY);
+  setGlobalDispatcher(proxyAgent);
+}
 
 const HELP = `Usage
   $ openapi-typescript [input] [options]


### PR DESCRIPTION
## Changes

This change will make the CLI command support an environment variable called http_proxy. This is a standard environment variable in environments where a http proxy is required to access the internet.

## How to Review

Setup a http proxy server. Then start the openapi-typescript CLI command with an environment variable http_proxy. E.g.:

```
HTTP_PROXY=http://myproxy.company.lan:1234 ./node_modules/.bin/openapi-typescript 

```

## Checklist

- [x] `docs/` updated (if necessary)
