### PR TITLE
Check `result` type before using `in` operator

### DIFF
--- a/.changeset/serious-days-live.md
+++ b/.changeset/serious-days-live.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Make sure result is an object before using the in operator.

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -269,7 +269,7 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
   if ("type" in schemaObject && schemaObject.type) {
     if (typeof options.ctx.transform === "function") {
       const result = options.ctx.transform(schemaObject, options);
-      if (result) {
+      if (result && typeof result === "object") {
         if ("schema" in result) {
           if (result.questionToken) {
             return ts.factory.createUnionTypeNode([result.schema, UNDEFINED]);
@@ -470,7 +470,7 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
 
         if (typeof options.ctx.transform === "function") {
           const result = options.ctx.transform(v as SchemaObject, options);
-          if (result) {
+          if (result && typeof result === "object") {
             if ("schema" in result) {
               type = result.schema;
               optional = result.questionToken ? QUESTION_TOKEN : optional;


### PR DESCRIPTION
## Changes

Make sure `result` is an object before using the `in` operator. Fixes the following errors when generating a schema:

```bash
node_modules/openapi-typescript/dist/transform/schema-object.js:149
                if ("schema" in result) {
                             ^

TypeError: Cannot use 'in' operator to search for 'schema' in UUID
    at transformSchemaObjectCore (node_modules/openapi-typescript/dist/transform/schema-object.js:149:30)
    at transformSchemaObjectWithComposition (node_modules/openapi-typescript/dist/transform/schema-object.js:108:28)
    at transformSchemaObject (node_modules/openapi-typescript/dist/transform/schema-object.js:6:18)
    at transformParameterObject (node_modules/openapi-typescript/dist/transform/parameter-object.js:4:37)
    at transformParametersArray (node_modules/openapi-typescript/dist/transform/parameters-array.js:30:19)
    at transformOperationObject (node_modules/openapi-typescript/dist/transform/operation-object.js:9:18)
    at injectOperationObject (node_modules/openapi-typescript/dist/transform/operation-object.js:38:18)
    at transformPathItemObject (node_modules/openapi-typescript/dist/transform/path-item-object.js:37:13)
    at Object.transformPathsObject [as paths] (node_modules/openapi-typescript/dist/transform/paths-object.js:18:34)
    at transformSchema (node_modules/openapi-typescript/dist/transform/index.js:20:47)
```


```bash
node_modules/openapi-typescript/dist/transform/schema-object.js:298
                        if ("schema" in result) {
                                     ^

TypeError: Cannot use 'in' operator to search for 'schema' in UUID
    at transformSchemaObjectCore (node_modules/openapi-typescript/dist/transform/schema-object.js:298:38)
    at transformSchemaObjectWithComposition (node_modules/openapi-typescript/dist/transform/schema-object.js:108:28)
    at Object.transformSchemaObject [as schemas] (node_modules/openapi-typescript/dist/transform/schema-object.js:6:18)
    at Object.transformComponentsObject [as components] (node_modules/openapi-typescript/dist/transform/components-object.js:25:48)
    at transformSchema (node_modules/openapi-typescript/dist/transform/index.js:20:47)
    at openapiTS (node_modules/openapi-typescript/dist/index.js:65:20)
```
