### PR TITLE
fix(fetch/react-query-example) : use the correct response object in t…

### DIFF
--- a/packages/openapi-fetch/examples/react-query/src/lib/api/index.ts
+++ b/packages/openapi-fetch/examples/react-query/src/lib/api/index.ts
@@ -2,11 +2,11 @@ import createClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./v1";
 
 const throwOnError: Middleware = {
-  async onResponse(res) {
-    if (res.status >= 400) {
-      const body = res.headers.get("content-type")?.includes("json")
-        ? await res.clone().json()
-        : await res.clone().text();
+  async onResponse({ response }) {
+    if (response.status >= 400) {
+      const body = response.headers.get("content-type")?.includes("json")
+        ? await response.clone().json()
+        : await response.clone().text();
       throw new Error(body);
     }
     return undefined;


### PR DESCRIPTION
## Changes
fixes  #1730
Destructures the response object in the middleweare to only extract the response

