### PR TITLE
Remove sourceRoot configuration to enable proper source file mapping

### DIFF
--- a/packages/openapi-typescript/tsconfig.json
+++ b/packages/openapi-typescript/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "skipLibCheck": true,
-    "sourceRoot": ".",
     "outDir": "dist",
     "types": ["vitest/globals"]
   },


### PR DESCRIPTION
Hi, @drwpow! I've encountered an issue where VSCode's debugger cannot correctly navigate to the source files.
![image](https://github.com/openapi-ts/openapi-typescript/assets/59734322/64f68868-565b-419a-b9fc-fe97fe985482)


## Changes

- Removed `sourceRoot` configuration from `tsconfig.json` .
- This fix resolves the issue where source maps were not correctly mapping to the original TypeScript files.

