### PR TITLE
fix: Generate valid types for referenced nested properties

### DIFF
--- a/.changeset/plenty-islands-tie.md
+++ b/.changeset/plenty-islands-tie.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Generate valid types for referenced nested properties

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -122,6 +122,11 @@ export function oapiRef(path: string): ts.TypeNode {
   );
   if (pointer.length > 1) {
     for (let i = 1; i < pointer.length; i++) {
+      // Skip `properties` items when in the middle of the pointer
+      // See: https://github.com/openapi-ts/openapi-typescript/issues/1742
+      if (i > 2 && i < pointer.length - 1 && pointer[i] === "properties") {
+        continue;
+      }
       t = ts.factory.createIndexedAccessTypeNode(
         t,
         ts.factory.createLiteralTypeNode(

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -64,6 +64,16 @@ describe("oapiRef", () => {
   test("multiple parts", () => {
     expect(astToString(oapiRef("#/components/schemas/User")).trim()).toBe(`components["schemas"]["User"]`);
   });
+
+  test("removes inner `properties`", () => {
+    expect(astToString(oapiRef("#/components/schemas/User/properties/username")).trim()).toBe(
+      `components["schemas"]["User"]["username"]`,
+    );
+  });
+
+  test("leaves final `properties` intact", () => {
+    expect(astToString(oapiRef("#/components/schemas/properties")).trim()).toBe(`components["schemas"]["properties"]`);
+  });
 });
 
 describe("tsEnum", () => {

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -503,6 +503,60 @@ describe("transformComponentsObject", () => {
         },
       },
     ],
+    [
+      "$ref nested properties",
+      {
+        given: {
+          parameters: {
+            direct: {
+              name: "direct",
+              in: "query",
+              required: true,
+              schema: {
+                $ref: "#/components/aaa",
+              },
+            },
+            nested: {
+              name: "nested",
+              in: "query",
+              required: true,
+              schema: {
+                $ref: "#/components/schemas/bbb/properties/ccc",
+              },
+            },
+          },
+          schemas: {
+            aaa: {
+              type: "string",
+            },
+            bbb: {
+              type: "object",
+              properties: {
+                ccc: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+        want: `{
+    schemas: {
+        aaa: string;
+        bbb: {
+            ccc?: string;
+        };
+    };
+    responses: never;
+    parameters: {
+        direct: components["aaa"];
+        nested: components["schemas"]["bbb"]["ccc"];
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}`,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {


### PR DESCRIPTION
## Changes

Closes #1742

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
