### PR TITLE
Add enum notes

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -68,6 +68,8 @@ enum ErrorCode {
 
 :::
 
+To generate in this fashion, `--enum` needs to be specified on the [command line](cli.md#flags).
+
 Alternatively you can use `x-enumNames` and `x-enumDescriptions` ([NSwag/NJsonSchema](https://github.com/RicoSuter/NJsonSchema/wiki/Enums#enum-names-and-descriptions)).
 
 ## Styleguide


### PR DESCRIPTION

## Changes

The example in the enum extensions sections of the docs needs to have `--enum` specified on the command line to generate as expected, so I added a note for that so future developers aren't as confused as I was.

## How to Review

This is a docs-only change, not much to review.

## Checklist

- [ ] Unit tests updated (n/a)
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript) (n/a)
