### PR TITLE
fix(docs): createTypeReferenceNode in transform examples

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -116,7 +116,7 @@ By default, openapiTS will generate `updated_at?: string;` because it’s not su
 import openapiTS from "openapi-typescript";
 import ts from "typescript";
 
-const DATE = ts.factory.createIdentifier("Date"); // `Date`
+const DATE = ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Date")); // `Date`
 const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull()); // `null`
 
 const ast = await openapiTS(mySchema, {
@@ -168,7 +168,7 @@ Use the same pattern to transform the types:
 import openapiTS from "openapi-typescript";
 import ts from "typescript";
 
-const BLOB = ts.factory.createIdentifier("Blob"); // `Blob`
+const BLOB = ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Blob")); // `Blob`
 const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull()); // `null`
 
 const ast = await openapiTS(mySchema, {
@@ -221,7 +221,7 @@ Here we return an object with a schema property, which is the same as the above 
 import openapiTS from "openapi-typescript";
 import ts from "typescript";
 
-const BLOB = ts.factory.createIdentifier("Blob"); // `Blob`
+const BLOB = ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Blob")); // `Blob`
 const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull()); // `null`
 
 const ast = await openapiTS(mySchema, {


### PR DESCRIPTION
## Changes

Fixes #1688

## How to Review

Verify example from docs:

```ts
# test1.ts
import path from "node:path";
import { fileURLToPath } from "node:url";
import openapiTS, { astToString } from "openapi-typescript";
import ts from "typescript";

const BLOB = ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Blob")); // `Blob`
const NULL = ts.factory.createLiteralTypeNode(ts.factory.createNull()); // `null`

const baseDir = path.dirname(fileURLToPath(import.meta.url));
const mySchema = new URL(path.resolve(baseDir, "../test1.yaml"), import.meta.url);

const ast = await openapiTS(mySchema, {
  transform(schemaObject, metadata) {
    if (schemaObject.format === "binary") {
      return {
        schema: schemaObject.nullable ? ts.factory.createUnionTypeNode([BLOB, NULL]) : BLOB,
        questionToken: true,
      };
    }
  },
});

console.log(astToString(ast));
```

using a minimal example:

```yaml
# test1.yaml
openapi: "3.0"
paths:
  /test:
    post:
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                source:
                  type: string
                file:
                  type: string
                  format: binary
```

## Checklist

- [x] `docs/` updated (if necessary)
