### PR TITLE
docs: correct redocly config example

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -61,7 +61,7 @@ import { createConfig, loadConfig } from "@redocly/openapi-core";
 import openapiTS from "openapi-typescript";
 
 // option 1: create in-memory config
-const redoc = await createConfig(
+const redocly = await createConfig(
   {
     apis: {
       "core@v2": { … },
@@ -72,9 +72,9 @@ const redoc = await createConfig(
 );
 
 // option 2: load from redocly.yaml file
-const redoc = await loadConfig({ configPath: "redocly.yaml" });
+const redocly = await loadConfig({ configPath: "redocly.yaml" });
 
-const ast = await openapiTS(mySchema, { redoc });
+const ast = await openapiTS(mySchema, { redocly });
 ```
 
 :::


### PR DESCRIPTION
## Changes

The Redocly config field on OpenAPITSOptions is named `redocly`, not `redoc`. This corrects the code example.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
