### PR TITLE
fix: Enum option cannot generate enums if values are not valid property names

### DIFF
--- a/.changeset/brave-lizards-juggle.md
+++ b/.changeset/brave-lizards-juggle.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix: Enum option cannot generate enums if values are not valid property names

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -285,7 +285,15 @@ export function tsEnumMember(value: string | number, metadata: { name?: string; 
     } else if (name[0] === "-") {
       name = `ValueMinus${name.slice(1)}`;
     }
-    name = name.replace(JS_PROPERTY_INDEX_INVALID_CHARS_RE, "_");
+
+    const invalidCharMatch = name.match(JS_PROPERTY_INDEX_INVALID_CHARS_RE);
+    if (invalidCharMatch) {
+      if (invalidCharMatch[0] === name) {
+        name = `"${name}"`;
+      } else {
+        name = name.replace(JS_PROPERTY_INDEX_INVALID_CHARS_RE, "_");
+      }
+    }
   }
 
   let member: ts.EnumMember;

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -620,7 +620,7 @@ export type operations = Record<string, never>;`,
               InvalidPropertyNameChars: {
                 type: "string",
                 enum: ["=", "!=", ">", "~", "^", "TE=ST"],
-              }
+              },
             },
           },
         },

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -617,6 +617,10 @@ export type operations = Record<string, never>;`,
                 "x-enumNames": ["Uno", "Dos", "Tres"],
                 "x-enumDescriptions": ["El número uno", "El número dos", "El número tres"],
               },
+              InvalidPropertyNameChars: {
+                type: "string",
+                enum: ["=", "!=", ">", "~", "^", "TE=ST"],
+              }
             },
           },
         },
@@ -660,6 +664,8 @@ export interface components {
         XEnumVarnames: XEnumVarnames;
         /** @enum {number} */
         XEnumNames: XEnumNames;
+        /** @enum {string} */
+        InvalidPropertyNameChars: InvalidPropertyNameChars;
     };
     responses: never;
     parameters: never;
@@ -699,6 +705,14 @@ export enum XEnumNames {
     Dos = 2,
     // El número tres
     Tres = 3
+}
+export enum InvalidPropertyNameChars {
+    "=" = "=",
+    "!=" = "!=",
+    ">" = ">",
+    "~" = "~",
+    "^" = "^",
+    TE_ST = "TE=ST"
 }
 export type operations = Record<string, never>;`,
         options: { enum: true },


### PR DESCRIPTION
## Changes
#1722

Made the following changes:
- Quote the name if it consists entirely of invalid characters.
- Replace only the invalid characters with "_" if they are part of the name.

The existing logic that replaces invalid characters within a key name with "_" has been kept. Additionally, by quoting the name when it consists entirely of invalid characters, it helps prevent errors.

## How to Review
Ensure that the test passes.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
