### PR TITLE
feat: allow form data through default body serializer

### DIFF
--- a/.changeset/warm-plums-wait.md
+++ b/.changeset/warm-plums-wait.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Allow FormData through defaultBodySerializer

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -435,7 +435,7 @@ export function defaultPathSerializer(pathname, pathParams) {
  */
 export function defaultBodySerializer(body) {
   if (body instanceof FormData) {
-    return body
+    return body;
   }
   return JSON.stringify(body);
 }

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -434,6 +434,9 @@ export function defaultPathSerializer(pathname, pathParams) {
  * @type {import("./index.js").defaultBodySerializer}
  */
 export function defaultBodySerializer(body) {
+  if (body instanceof FormData) {
+    return body
+  }
   return JSON.stringify(body);
 }
 

--- a/packages/openapi-fetch/test/fixtures/api.d.ts
+++ b/packages/openapi-fetch/test/fixtures/api.d.ts
@@ -814,6 +814,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/multipart-form-data-file-upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "multipart/form-data": string;
+                };
+            };
+            responses: {
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            text: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/packages/openapi-fetch/test/fixtures/api.yaml
+++ b/packages/openapi-fetch/test/fixtures/api.yaml
@@ -470,6 +470,26 @@ paths:
       responses:
         200:
           $ref: "#/components/responses/MultipleResponse"
+  /multipart-form-data-file-upload:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                required:
+                  - text
 components:
   schemas:
     Post:

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1352,6 +1352,33 @@ describe("client", () => {
         customProperty: "value",
       });
     });
+
+    it('multipart/form-data with a file', async () => {
+      const TEST_STRING = 'Hello this is text file string';
+      
+      const file = new Blob([TEST_STRING], { type: 'text/plain' });
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const client = createClient<paths>({ baseUrl });
+       useMockRequestHandler({
+        baseUrl,
+        method: "post",
+        path: "/multipart-form-data-file-upload",
+        handler: async (data) =>{
+          // Get text from file and send it back
+          const formData = await data.request.formData();
+          const text = await (formData.get('file') as File).text()
+          return new HttpResponse(JSON.stringify({text}))
+        },
+      });
+      const {data} = await client.POST("/multipart-form-data-file-upload", {
+        // @ts-ignore // TODO: how to get this to accept FormData? 
+        body: formData,
+      })
+
+      expect(data?.text).toBe(TEST_STRING)
+    })
   });
 
   describe("responses", () => {

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1355,7 +1355,7 @@ describe("client", () => {
 
     it('multipart/form-data with a file', async () => {
       const TEST_STRING = 'Hello this is text file string';
-      
+
       const file = new Blob([TEST_STRING], { type: 'text/plain' });
       const formData = new FormData();
       formData.append('file', file);
@@ -1373,8 +1373,8 @@ describe("client", () => {
         },
       });
       const {data} = await client.POST("/multipart-form-data-file-upload", {
-        // @ts-ignore // TODO: how to get this to accept FormData? 
-        body: formData,
+        // TODO: how to get this to accept FormData? 
+        body: formData as unknown as string,
       })
 
       expect(data?.text).toBe(TEST_STRING)

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1353,32 +1353,32 @@ describe("client", () => {
       });
     });
 
-    it('multipart/form-data with a file', async () => {
-      const TEST_STRING = 'Hello this is text file string';
+    it("multipart/form-data with a file", async () => {
+      const TEST_STRING = "Hello this is text file string";
 
-      const file = new Blob([TEST_STRING], { type: 'text/plain' });
+      const file = new Blob([TEST_STRING], { type: "text/plain" });
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append("file", file);
 
       const client = createClient<paths>({ baseUrl });
-       useMockRequestHandler({
+      useMockRequestHandler({
         baseUrl,
         method: "post",
         path: "/multipart-form-data-file-upload",
-        handler: async (data) =>{
+        handler: async (data) => {
           // Get text from file and send it back
           const formData = await data.request.formData();
-          const text = await (formData.get('file') as File).text()
-          return new HttpResponse(JSON.stringify({text}))
+          const text = await (formData.get("file") as File).text();
+          return new HttpResponse(JSON.stringify({ text }));
         },
       });
-      const {data} = await client.POST("/multipart-form-data-file-upload", {
-        // TODO: how to get this to accept FormData? 
+      const { data } = await client.POST("/multipart-form-data-file-upload", {
+        // TODO: how to get this to accept FormData?
         body: formData as unknown as string,
-      })
+      });
 
-      expect(data?.text).toBe(TEST_STRING)
-    })
+      expect(data?.text).toBe(TEST_STRING);
+    });
   });
 
   describe("responses", () => {


### PR DESCRIPTION
I was trying to use openapi-fetch for file uploading, but by default that wasn't possible (using `multipart/form-data`). Looking at the source code I noticed that part of the solution for fixing it seemed to be missing as `defaultBodySerializer` never allows `FormData` to be passed through it:
```js
if (requestInit.body) {
  // Here, bodySerializer always returns a JSON string by default
  requestInit.body = bodySerializer(requestInit.body);
  // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
  if (requestInit.body instanceof FormData) {
    requestInit.headers.delete("Content-Type");
  }
}
```

I'm trying to fix that in this PR by allowing `FormData` to be passed through the `defaultBodySerializer` enabling file uploads with `multipart/form-data` by default.


## Changes

Allow `FormData` to be passed through `defaultBodySerializer` as `body` to enable file uploading by default.

## How to Review

Upload a file as part of `multipart/form-data`

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
