### PR TITLE
fix: schema.content might be omitted

### DIFF
--- a/.changeset/rich-olives-scream.md
+++ b/.changeset/rich-olives-scream.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix: schema.content might be omitted

--- a/packages/openapi-typescript/src/transform/header-object.ts
+++ b/packages/openapi-typescript/src/transform/header-object.ts
@@ -17,7 +17,7 @@ export default function transformHeaderObject(headerObject: HeaderObject, option
 
   if (headerObject.content) {
     const type: ts.TypeElement[] = [];
-    for (const [contentType, mediaTypeObject] of getEntries(headerObject.content, options.ctx)) {
+    for (const [contentType, mediaTypeObject] of getEntries(headerObject.content ?? {}, options.ctx)) {
       const nextPath = `${options.path ?? "#"}/${escapePointer(contentType)}`;
       const mediaType =
         "$ref" in mediaTypeObject

--- a/packages/openapi-typescript/src/transform/request-body-object.ts
+++ b/packages/openapi-typescript/src/transform/request-body-object.ts
@@ -14,7 +14,7 @@ export default function transformRequestBodyObject(
   options: TransformNodeOptions,
 ): ts.TypeNode {
   const type: ts.TypeElement[] = [];
-  for (const [contentType, mediaTypeObject] of getEntries(requestBodyObject.content, options.ctx)) {
+  for (const [contentType, mediaTypeObject] of getEntries(requestBodyObject.content ?? {}, options.ctx)) {
     const nextPath = createRef([options.path, contentType]);
     const mediaType =
       "$ref" in mediaTypeObject

--- a/packages/openapi-typescript/src/transform/response-object.ts
+++ b/packages/openapi-typescript/src/transform/response-object.ts
@@ -74,7 +74,7 @@ export default function transformResponseObject(
   // content
   const contentObject: ts.TypeElement[] = [];
   if (responseObject.content) {
-    for (const [contentType, mediaTypeObject] of getEntries(responseObject.content, options.ctx)) {
+    for (const [contentType, mediaTypeObject] of getEntries(responseObject.content ?? {}, options.ctx)) {
       const property = ts.factory.createPropertySignature(
         /* modifiers     */ tsModifiers({ readonly: options.ctx.immutable }),
         /* name          */ tsPropertyIndex(contentType),

--- a/packages/openapi-typescript/test/transform/request-body-object.test.ts
+++ b/packages/openapi-typescript/test/transform/request-body-object.test.ts
@@ -51,6 +51,17 @@ describe("transformRequestBodyObject", () => {
       },
     ],
     [
+      "no-content",
+      {
+        given: {},
+        want: `{
+    content: {
+        "*/*"?: never;
+    };
+}`,
+      },
+    ],
+    [
       "POST data with default values",
       {
         given: {

--- a/packages/openapi-typescript/test/transform/response-object.test.ts
+++ b/packages/openapi-typescript/test/transform/response-object.test.ts
@@ -70,6 +70,18 @@ describe("transformResponseObject", () => {
         // options: DEFAULT_OPTIONS,
       },
     ],
+    [
+      "no-content",
+      {
+        given: {},
+        want: `{
+    headers: {
+        [name: string]: unknown;
+    };
+    content?: never;
+}`,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {


### PR DESCRIPTION
references #369

## Changes

There is a case when there is no content in request or response, at the moment openapi-typescript panic in such cases

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
