### PR TITLE
fix: --properties-required-by-default flag

### DIFF
--- a/.changeset/eight-pants-attack.md
+++ b/.changeset/eight-pants-attack.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix --properties-required-by-default flag not working

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -101,7 +101,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       alphabetize: flags.alphabetize,
       arrayLength: flags.arrayLength,
       contentNever: flags.contentNever,
-      propertiesRequired: flags.propertiesRequired,
+      propertiesRequiredByDefault: flags.propertiesRequiredByDefault,
       defaultNonNullable: flags.defaultNonNullable,
       emptyObjectsUnknown: flags.emptyObjectsUnknown,
       enum: flags.enum,

--- a/packages/openapi-typescript/test/cli.test.ts
+++ b/packages/openapi-typescript/test/cli.test.ts
@@ -105,6 +105,11 @@ describe("CLI", () => {
       const { stdout } = await execa(cmd, ["--version"], { cwd });
       expect(stdout).toEqual(expect.stringMatching(/^v[\d.]+(-.*)?$/));
     });
+
+    test("--properties-required-by-default", async () => {
+      const { stdout } = await execa(cmd, ["--properties-required-by-default=true", "./examples/github-api.yaml"], { cwd });
+      expect(stdout).toMatchFileSnapshot(fileURLToPath(new URL("./examples/github-api-required.ts", root)));
+    }, TIMEOUT)
   });
 
   describe("Redocly config", () => {

--- a/packages/openapi-typescript/test/cli.test.ts
+++ b/packages/openapi-typescript/test/cli.test.ts
@@ -106,10 +106,16 @@ describe("CLI", () => {
       expect(stdout).toEqual(expect.stringMatching(/^v[\d.]+(-.*)?$/));
     });
 
-    test("--properties-required-by-default", async () => {
-      const { stdout } = await execa(cmd, ["--properties-required-by-default=true", "./examples/github-api.yaml"], { cwd });
-      expect(stdout).toMatchFileSnapshot(fileURLToPath(new URL("./examples/github-api-required.ts", root)));
-    }, TIMEOUT)
+    test(
+      "--properties-required-by-default",
+      async () => {
+        const { stdout } = await execa(cmd, ["--properties-required-by-default=true", "./examples/github-api.yaml"], {
+          cwd,
+        });
+        expect(stdout).toMatchFileSnapshot(fileURLToPath(new URL("./examples/github-api-required.ts", root)));
+      },
+      TIMEOUT,
+    );
   });
 
   describe("Redocly config", () => {


### PR DESCRIPTION
## Changes

Fix --properties-required-by-default flag not working. #1651 

## How to Review

It was just simple typo.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
