### PR TITLE
fix: add explicit import of performance to fix bazel compatibility issues

### DIFF
--- a/.changeset/chilled-radios-remain.md
+++ b/.changeset/chilled-radios-remain.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix: add explicit import of performance to fix bazel compatibility issues

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -3,6 +3,7 @@
 import { createConfig, findConfig, loadConfig } from "@redocly/openapi-core";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import parser from "yargs-parser";
 import openapiTS, { COMMENT_HEADER, astToString, c, error, formatTime, warn } from "../dist/index.js";
 

--- a/packages/openapi-typescript/scripts/download-schemas.ts
+++ b/packages/openapi-typescript/scripts/download-schemas.ts
@@ -1,6 +1,7 @@
 import degit from "degit";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { error } from "../src/lib/utils.js";
 import { multiFile, singleFile } from "./schemas.js";

--- a/packages/openapi-typescript/scripts/update-examples.ts
+++ b/packages/openapi-typescript/scripts/update-examples.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { multiFile, singleFile } from "./schemas.js";
 
 async function generateSchemas() {

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -1,5 +1,6 @@
 import { createConfig } from "@redocly/openapi-core";
 import type { Readable } from "node:stream";
+import { performance } from "node:perf_hooks";
 import type ts from "typescript";
 import { validateAndBundle } from "./lib/redoc.js";
 import { debug, resolveRef, scanDiscriminators } from "./lib/utils.js";

--- a/packages/openapi-typescript/src/lib/redoc.ts
+++ b/packages/openapi-typescript/src/lib/redoc.ts
@@ -7,6 +7,7 @@ import {
   type Document,
   lintDocument,
 } from "@redocly/openapi-core";
+import { performance } from "node:perf_hooks";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import parseJson from "parse-json";

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { performance } from "node:perf_hooks";
 import { NEVER, QUESTION_TOKEN, addJSDocComment, tsModifiers, tsPropertyIndex } from "../lib/ts.js";
 import { createRef, debug, getEntries } from "../lib/utils.js";
 import type { ComponentsObject, GlobalContext, SchemaObject, TransformNodeOptions } from "../types.js";

--- a/packages/openapi-typescript/src/transform/index.ts
+++ b/packages/openapi-typescript/src/transform/index.ts
@@ -1,4 +1,5 @@
 import ts, { type InterfaceDeclaration, type TypeLiteralNode } from "typescript";
+import { performance } from "node:perf_hooks";
 import { NEVER, STRING, stringToAST, tsModifiers, tsRecord } from "../lib/ts.js";
 import { createRef, debug } from "../lib/utils.js";
 import type { GlobalContext, OpenAPI3 } from "../types.js";

--- a/packages/openapi-typescript/src/transform/paths-object.ts
+++ b/packages/openapi-typescript/src/transform/paths-object.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { performance } from "node:perf_hooks";
 import { addJSDocComment, oapiRef, stringToAST, tsModifiers, tsPropertyIndex } from "../lib/ts.js";
 import { createRef, debug, getEntries } from "../lib/utils.js";
 import type {


### PR DESCRIPTION
## Changes

- Running openapi-typescript through Bazel results in a `ReferenceError: performance is not defined` error
- This PR adds an explicit `import { performance } from "node:perf_hooks"` whenever `performance` is used in the code.
- I've tested that this fixes my Bazel compability issues.

## How to Review

- Make sure I didn't miss any usages of `performance`.
- Let me know if there's a reason why the import was omitted.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
