### PR TITLE
Unblock changesets release

### DIFF
--- a/.changeset/little-pets-perform.md
+++ b/.changeset/little-pets-perform.md
@@ -1,5 +1,4 @@
 ---
-"openapi-typescript-docs": minor
 "openapi-typescript": minor
 ---
 

--- a/.changeset/stupid-pans-hug.md
+++ b/.changeset/stupid-pans-hug.md
@@ -1,5 +1,4 @@
 ---
-"openapi-typescript-docs": minor
 "openapi-typescript": minor
 ---
 


### PR DESCRIPTION
## Changes

`openapi-typescript-docs` isn’t an actual package, so it’s blocking releases until it’s removed 

## How to Review

- CI should pass

## Checklist

N/A