### PR TITLE
Fixed the opencollective link in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Ultra-fast fetching for TypeScript generated automatically from your OpenAPI sch
 
 Become a sponsor by supporting this project on [OpenCollective](https://opencollective.com/openapi-ts)!
 
-<a href="https://opencollective.com/webpack/donate" target="_blank">
-  <img src="https://opencollective.com/webpack/donate/button@2x.png?color=blue" width="300" />
+<a href="https://opencollective.com/openapi-ts/donate" target="_blank">
+  <img src="https://opencollective.com/openapi-ts/donate/button@2x.png?color=blue" width="300" />
 </a>
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Changes

Fixed the opencollective link in the README file.

## How to Review

Review the updated link in the README file to ensure it points to the correct location.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
