### PR TITLE
Improve querySerializer

### DIFF
--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -382,7 +382,7 @@ export function createQuerySerializer(options) {
         search.push(serializePrimitiveParam(name, value, options));
       }
     }
-    return search.join("&");
+    return search.filter(Boolean).join("&");
   };
 }
 


### PR DESCRIPTION
## Changes

Added filtering after forming query parameters in querySerialize.

## How to Review

Currently, if there is any key in queryParams with an empty object, the result of the generation will include a double ampersand.

For example:
```javascript
{
      a: 1,
      b: {},
      c: 3,
}
```
will return => example.com?a=1&&c=3
Because Serialize creates an array with an empty string.

After the improvement, it will be example.com?a=1&c=3

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
