### PR TITLE
fix(openapi-typescript-helpers): keep index.d.cts in npm distribution

### DIFF
--- a/.changeset/soft-roses-teach.md
+++ b/.changeset/soft-roses-teach.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+keep index.d.cts in npm distribution

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -23,6 +23,12 @@
     },
     "./*": "./*"
   },
+  "files": [
+    "index.js",
+    "index.cjs",
+    "index.d.ts",
+    "index.d.cts"
+  ],
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -23,12 +23,7 @@
     },
     "./*": "./*"
   },
-  "files": [
-    "index.js",
-    "index.cjs",
-    "index.d.ts",
-    "index.d.cts"
-  ],
+  "files": ["index.js", "index.cjs", "index.d.ts", "index.d.cts"],
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

Fix https://github.com/openapi-ts/openapi-typescript/issues/1749

By default, `npm publish` respects `.gitignore` so that [the npm distribution](https://www.npmjs.com/package/openapi-typescript-helpers/v/0.0.9?activeTab=code) doesn't include `index.d.cts`.

[`package.ison` points to it](https://github.com/yukukotani/openapi-typescript/blob/510cff34ce11a007365463bb3fa498cabc5eb57c/packages/openapi-typescript-helpers/package.json#L20) even though it's missing, and this results in fallback to `index.cjs`.  This causes that types from `openapi-typescript-helpers` to be treated as `any`.

This PR adds `files` field in `package.json` to explicitly declare `index.d.cts` to be included in the distribution.

## How to Review

The output of `npm pack` includes `package.d.cts`.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
