### PR TITLE
style: fix formatting after CI commit

### DIFF
--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -23,12 +23,7 @@
     },
     "./*": "./*"
   },
-  "files": [
-    "index.js",
-    "index.cjs",
-    "index.d.ts",
-    "index.d.cts"
-  ],
+  "files": ["index.js", "index.cjs", "index.d.ts", "index.d.cts"],
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Seems like 8e5fa3a24cf217b730d35a7f825ba0509856a1bb broke the formatting.