### PR TITLE
Automatically stale and close issues

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -1,0 +1,23 @@
+name: Close inactive issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity. If there is no activity in the next 7 days, the issue will be closed."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem."
+          ascending: false
+          operations-per-run: 300
+          days-before-issue-stale: 90
+          days-before-issue-close: 5
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: "stale"
+          exempt-issue-labels: "Issue accepted"
+          enable-statistics: true


### PR DESCRIPTION
## Introduction

This is a pull request as well as an enhancement proposal for the repository.

There are issues created in 2021 that are still opened, some of them might be relevant but not enough to receive any updates. To avoid accumulating issues, I think it would be interesting to automatically stale and close issues that does not receive any update.

## Changes

This pull requests adds a new automated workflow to automatically mark issues as stale and close them using the [Stale Github Action](https://github.com/actions/stale).

It works as the following:

1. After 90 days without activity, the issue is marked as stale with the following message

`"This issue is stale because it has been open for 90 days with no activity. If there is no activity in the next 7 days, the issue will be closed."`

2. After 97 days without activity, the issue is closed with the following message

`"This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem."`

> It is possible to label issues with `Issue accepted` to ensure that they will never be closed automatically.