### PR TITLE
chore: Add LICENSE in root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Drew Powers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,7 @@
     "enabled": false
   },
   "files": {
-    "ignore": ["**/dist/**"]
+    "ignore": ["**/dist/**", "**/package.json"]
   },
   "formatter": {
     "indentStyle": "space",

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -23,7 +23,12 @@
     },
     "./*": "./*"
   },
-  "files": ["index.js", "index.cjs", "index.d.ts", "index.d.cts"],
+  "files": [
+    "index.js",
+    "index.cjs",
+    "index.d.ts",
+    "index.d.cts"
+  ],
   "homepage": "https://openapi-ts.dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

Adds MIT License in root. Doesn’t change licensing of anything; just flags to GitHub the whole thing is MIT-licensed.

## How to Review

N/A

## Checklist

N/A