### PR TITLE
perf: remove unnecessary `async` keywords

### DIFF
--- a/.changeset/chilled-rules-judge.md
+++ b/.changeset/chilled-rules-judge.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+perf: remove unnecessary `async` keywords (for reduced code size)

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -178,35 +178,35 @@ export default function createClient(clientOptions) {
 
   return {
     /** Call a GET endpoint */
-    async GET(url, init) {
+    GET(url, init) {
       return coreFetch(url, { ...init, method: "GET" });
     },
     /** Call a PUT endpoint */
-    async PUT(url, init) {
+    PUT(url, init) {
       return coreFetch(url, { ...init, method: "PUT" });
     },
     /** Call a POST endpoint */
-    async POST(url, init) {
+    POST(url, init) {
       return coreFetch(url, { ...init, method: "POST" });
     },
     /** Call a DELETE endpoint */
-    async DELETE(url, init) {
+    DELETE(url, init) {
       return coreFetch(url, { ...init, method: "DELETE" });
     },
     /** Call a OPTIONS endpoint */
-    async OPTIONS(url, init) {
+    OPTIONS(url, init) {
       return coreFetch(url, { ...init, method: "OPTIONS" });
     },
     /** Call a HEAD endpoint */
-    async HEAD(url, init) {
+    HEAD(url, init) {
       return coreFetch(url, { ...init, method: "HEAD" });
     },
     /** Call a PATCH endpoint */
-    async PATCH(url, init) {
+    PATCH(url, init) {
       return coreFetch(url, { ...init, method: "PATCH" });
     },
     /** Call a TRACE endpoint */
-    async TRACE(url, init) {
+    TRACE(url, init) {
       return coreFetch(url, { ...init, method: "TRACE" });
     },
     /** Register middleware */


### PR DESCRIPTION
## Changes

Remove unnecessary `async` keywords in object returned from `createClient`.
They simply increase code size (perf in this sense).

I stumbled upon this when working on #1791 / #1526.

I have checked that `dist/index.min.js` still contains the `async` keyword, so at least when minified with esbuild, this really contributes to bundle size.

## How to Review

- Check that `async` does not hint to the JIT.

## Checklist

All points N/A.

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
