### PR TITLE
test: remove unused nanoid import in index.bench.js

### DIFF
--- a/packages/openapi-fetch/test/index.bench.js
+++ b/packages/openapi-fetch/test/index.bench.js
@@ -2,7 +2,6 @@ import axios from "axios";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { Fetcher } from "openapi-typescript-fetch";
-import { nanoid } from "nanoid";
 import superagent from "superagent";
 import { afterAll, bench, describe } from "vitest";
 import createClient from "../dist/index.js";


### PR DESCRIPTION
It is not declared in package.json, so running `npx vite bench` fails.