### PR TITLE
Allow falsy values (except undefined) as a valid body

### DIFF
--- a/.changeset/rich-crews-repeat.md
+++ b/.changeset/rich-crews-repeat.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Allow falsy values (except undefined) as a valid body

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -84,7 +84,7 @@ export default function createClient(clientOptions) {
       ...init,
       headers: mergeHeaders(baseHeaders, headers, params.header),
     };
-    if (requestInit.body) {
+    if (requestInit.body !== undefined) {
       requestInit.body = bodySerializer(requestInit.body);
       // remove `Content-Type` if serialized body is FormData; browser will correctly set Content-Type & boundary expression
       if (requestInit.body instanceof FormData) {


### PR DESCRIPTION
## Changes

Resolves https://github.com/openapi-ts/openapi-typescript/issues/1695

This PR ensures that all falsy values except `undefined` i.e. `null`, `false`, `0` and `""` are treated as a valid body. This means:
- going through `bodySerializer`, when specified
- sending the body to the server

## How to Review

- Check the added unit tests which describe the desired behavior.
- The change in implementation itself is ridiculously simple.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
  - I didn't find any section describing the behavior. 
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
