### PR TITLE
Do not set content-type on body-less requests

### DIFF
--- a/.changeset/chilled-forks-rush.md
+++ b/.changeset/chilled-forks-rush.md
@@ -1,5 +1,5 @@
 ---
-"openapi-typescript": minor
+"openapi-fetch": minor
 ---
 
 Do not set content-type on body-less requests

--- a/.changeset/chilled-forks-rush.md
+++ b/.changeset/chilled-forks-rush.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Do not set content-type on body-less requests

--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -181,6 +181,18 @@ const { data, error } = await client.PUT("/submit", {
 });
 ```
 
+::: tip
+
+For convenience, `openapi-fetch` sets `Content-Type` to `application/json` automatically
+for any request that provides value for the `body` parameter. When the `bodySerializer` returns an instance of `FormData`,
+`Content-Type` is omitted, allowing the browser to set it automatically with the correct message part boundary.
+
+You can also set `Content-Type` manually through `headers` object either in the fetch options,
+or when instantiating the client. Setting `Content-Type` to `null` will omit the header, however the native fetch API
+will likely set it to `text/plain` in this case.
+
+:::
+
 ## Path serialization
 
 openapi-fetch supports path serialization as [outlined in the 3.1 spec](https://swagger.io/docs/specification/serialization/#path). This happens automatically, based on the specific format in your OpenAPI schema:

--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -188,8 +188,7 @@ for any request that provides value for the `body` parameter. When the `bodySeri
 `Content-Type` is omitted, allowing the browser to set it automatically with the correct message part boundary.
 
 You can also set `Content-Type` manually through `headers` object either in the fetch options,
-or when instantiating the client. Setting `Content-Type` to `null` will omit the header, however the native fetch API
-will likely set it to `text/plain` in this case.
+or when instantiating the client.
 
 :::
 

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -981,9 +981,10 @@ describe("client", () => {
             },
           });
           // the fetch implementation won't allow sending a body without content-type,
-          // so it invents one up and sends it, hopefully this will be consistent across
-          // local environments and won't make the tests flaky
-          expect(contentType).toBe("text/plain;charset=UTF-8");
+          // and it defaults to `text/plain;charset=UTF-8`, however the actual default value
+          // is irrelevant and might be flaky across different fetch implementations
+          // for us, it's important that it's not `application/json`
+          expect(contentType).not.toBe("application/json");
         },
       );
 

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -933,7 +933,6 @@ describe("client", () => {
       });
 
       const BODIES = [{ prop: "a" }, {}, "", "str", null, false, 0, 1, new Date("2024-08-07T09:52:00.836Z")] as const;
-      // const BODIES = ["str"] as const;
       const METHOD_BODY_COMBINATIONS = BODY_ACCEPTING_METHODS.flatMap(([method]) =>
         BODIES.map((body) => [method, body] as const),
       );

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -4,7 +4,6 @@ import createClient, {
   type BodySerializer,
   type FetchOptions,
   type MethodResponse,
-  type FetchOptions,
   type HeadersOptions,
   type Middleware,
   type MiddlewareCallbackParams,


### PR DESCRIPTION
## Changes

Resolves #1694

**Important:** This PR touches the same code as #1825 and in-fact includes the same fix by itself. I recommend merging #1825 first.

This PR prevents Content-Type header from being set on requests with no body. This is required to ensure compatibility with strict server impls. such as [fastify](https://fastify.dev/).

## How to Review

- Consider checking the included tests and docs to understand the desired behavior.
- The change in the implementation is rather simple.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
