### PR TITLE
fix(openapi-fetch): don't rely on DOM types

### DIFF
--- a/.changeset/smooth-actors-tickle.md
+++ b/.changeset/smooth-actors-tickle.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix typing for environments without DOM lib

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -24,7 +24,7 @@ export interface ClientOptions extends Omit<RequestInit, "headers"> {
 }
 
 export type HeadersOptions =
-  | HeadersInit
+  | Required<RequestInit>["headers"]
   | Record<string, string | number | boolean | (string | number | boolean)[] | null | undefined>;
 
 export type QuerySerializer<T> = (


### PR DESCRIPTION
## Changes

This PR changes typing to avoid the global `HeadersInit`, which is declared in the DOM lib and therefore typically not included in Node projects.

Resolves #1823 
Resolves #1824

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
