### PR TITLE
set stale issue close time to 7 days

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -15,7 +15,7 @@ jobs:
           ascending: false
           operations-per-run: 300
           days-before-issue-stale: 90
-          days-before-issue-close: 5
+          days-before-issue-close: 7
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-label: "stale"


### PR DESCRIPTION
## Changes

Follow-up to #1795

In the GitHub stale issue workflow, change the stale issue close time to 7 days to match the comments added to the issue by the automation:

> If there is no activity in the next 7 days, the issue will be closed.

> This issue was closed because it has been inactive for 7 days since being marked as stale.

## How to Review

[Relevant docs](https://github.com/actions/stale?tab=readme-ov-file#all-options) for `actions/stale`.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
