### PR TITLE
Add MethodResponse utility type

### DIFF
--- a/.changeset/hip-years-invite.md
+++ b/.changeset/hip-years-invite.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Add MethodResponse utility type to easily get the return type of an endpoint on a client

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -190,6 +190,20 @@ export interface Client<Paths extends {}, Media extends MediaType = MediaType> {
   eject(...middleware: Middleware[]): void;
 }
 
+export type ClientPathsWithMethod<
+  CreatedClient extends Client<any, any>,
+  Method extends HttpMethod,
+> = CreatedClient extends Client<infer Paths, infer _Media> ? PathsWithMethod<Paths, Method> : never;
+
+export type MethodResponse<
+  CreatedClient extends Client<any, any>,
+  Method extends HttpMethod,
+  Path extends ClientPathsWithMethod<CreatedClient, Method>,
+  Options = {},
+> = CreatedClient extends Client<infer Paths extends { [key: string]: any }, infer Media extends MediaType>
+  ? NonNullable<FetchResponse<Paths[Path][Method], Options, Media>["data"]>
+  : never;
+
 export default function createClient<Paths extends {}, Media extends MediaType = MediaType>(
   clientOptions?: ClientOptions,
 ): Client<Paths, Media>;

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -133,7 +133,7 @@ describe("client", () => {
           created_at: number;
           updated_at: number;
         }>();
-        expectTypeOf(result.data).toEqualTypeOf<MethodResponse<typeof client, 'get', '/mismatched-errors'>>();
+        expectTypeOf(result.data).toEqualTypeOf<MethodResponse<typeof client, "get", "/mismatched-errors">>();
       } else {
         expectTypeOf(result.data).toBeUndefined();
         expectTypeOf(result.error).extract<{ code: number }>().toEqualTypeOf<{ code: number; message: string }>();

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, type StrictResponse } from "msw";
 import { afterAll, beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 import createClient, {
+  type MethodResponse,
   type Middleware,
   type MiddlewareCallbackParams,
   type QuerySerializerOptions,
@@ -132,6 +133,7 @@ describe("client", () => {
           created_at: number;
           updated_at: number;
         }>();
+        expectTypeOf(result.data).toEqualTypeOf<MethodResponse<typeof client, 'get', '/mismatched-errors'>>();
       } else {
         expectTypeOf(result.data).toBeUndefined();
         expectTypeOf(result.error).extract<{ code: number }>().toEqualTypeOf<{ code: number; message: string }>();


### PR DESCRIPTION
## Changes

Adds a new `MethodResponse` utility type to `openapi-fetch` to easily reference the return type of a fetch call in your code

## How to Review

### Understanding the rationale

There are many times in a codebase where you do something like this:

```ts
async function getData(...data): Promise<Data> {
   // 1) Process the data in some way
   // 2) Do some other async calls like DB queries or querying other services
  
   const { data, error } = await client.GET('/data', {});
   if (error != null) { /* handle case */ }
   return data;
}
```

The return type of this function is based solely on the `data` endpoint result, so it would be nice to make this relation explicitly clear

#### Before this PR

The easiest way to do this is the following code, is the following code

```ts
async function getData(): Promise<Awaited<ReturnType<typeof client.GET<'/data', {}>>>>
```

This has a problem though: if `client` isn't statically known as a global variable. In that case, you cannot get around this by just doing `Client<paths>['GET']<'/data', {}>` as this is not valid typescript

#### After this PR

This is the new code which is both shorter, and also works well even if `typeof client` is not possible and a type variable is used in its place

```ts
async function getData(): Promise<MethodResponse<typeof client, 'get', '/data'>>
// this also works
async function getData(): Promise<MethodResponse<MyClient, 'get', '/data'>>
```

#### Why not just use schemas?

Another option is to use `components['schemas']['GetDataResponse']`, which is also valid and just a matter of preference. I think being able to explicitly specify the connection between a method and the response is more flexible than this

For example, you could create a wrapper on the type I added to this library (which I don't think you can easily do before this PR), by doing something like 

```ts
type GetType<Path extends PathsWithMethod<typeof client, 'get'>> = MethodResponse<
  typeof client,
  'get',
  Path
>;

// you can now use it like this
async function getData(): Promise<GetType<'/data'>>
```

Additionally, this `components['schemas']` option isn't always guaranteed to work. For example, there are cases where the schema is partially inlined into the `operations` object:

```ts
export interface operations {
    GetData: {
        // ...
        responses: {
             200: {
                 content: {
                     "application/json": {
                        dataSummary: components["schemas"]["GetDataResponse"][];
                     }
                 }
             }
        }
    }
}
```

As you can see in this example, you cannot just use `GetDataResponse` directly because it's missing the fact it's actually contained inside a `dataSummary` object

### Code

This is just a utility type, so there is no functionality change

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
