### PR TITLE
fix type checking when `strictNullChecks` is disabled

### DIFF
--- a/.changeset/lazy-dancers-push.md
+++ b/.changeset/lazy-dancers-push.md
@@ -1,0 +1,7 @@
+---
+"openapi-typescript-helpers": patch
+"openapi-react-query": patch
+"openapi-fetch": patch
+---
+
+Fix identification of required properties when `strictNullChecks` is disabled

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -59,6 +59,7 @@
     "test": "pnpm run \"/^test:/\"",
     "test:js": "vitest run",
     "test:ts": "tsc --noEmit",
+    "test:ts-no-strict": "tsc --noEmit -p test/no-strict-null-checks/tsconfig.json",
     "test-e2e": "playwright test",
     "e2e-vite-build": "vite build test/fixtures/e2e",
     "e2e-vite-start": "vite preview test/fixtures/e2e",

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -1,12 +1,13 @@
 import type {
   ErrorResponse,
   FilterKeys,
-  HasRequiredKeys,
   HttpMethod,
+  IsOperationRequestBodyOptional,
   MediaType,
   OperationRequestBodyContent,
   PathsWithMethod,
   ResponseObjectMap,
+  RequiredKeysOf,
   SuccessResponse,
 } from "openapi-typescript-helpers";
 
@@ -82,14 +83,14 @@ export interface DefaultParamsOption {
 export type ParamsOption<T> = T extends {
   parameters: any;
 }
-  ? HasRequiredKeys<T["parameters"]> extends never
+  ? RequiredKeysOf<T["parameters"]> extends never
     ? { params?: T["parameters"] }
     : { params: T["parameters"] }
   : DefaultParamsOption;
 
 export type RequestBodyOption<T> = OperationRequestBodyContent<T> extends never
   ? { body?: never }
-  : undefined extends OperationRequestBodyContent<T>
+  : IsOperationRequestBodyOptional<T> extends true
     ? { body?: OperationRequestBodyContent<T> }
     : { body: OperationRequestBodyContent<T> };
 
@@ -150,7 +151,7 @@ export interface Middleware {
 }
 
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
-export type MaybeOptionalInit<Params extends Record<HttpMethod, {}>, Location extends keyof Params> = HasRequiredKeys<
+export type MaybeOptionalInit<Params extends Record<HttpMethod, {}>, Location extends keyof Params> = RequiredKeysOf<
   FetchOptions<FilterKeys<Params, Location>>
 > extends never
   ? FetchOptions<FilterKeys<Params, Location>> | undefined
@@ -160,7 +161,7 @@ export type MaybeOptionalInit<Params extends Record<HttpMethod, {}>, Location ex
 // - Determines if the param is optional or not.
 // - Performs arbitrary [key: string] addition.
 // Note: the addition It MUST happen after all the inference happens (otherwise TS can’t infer if init is required or not).
-type InitParam<Init> = HasRequiredKeys<Init> extends never
+type InitParam<Init> = RequiredKeysOf<Init> extends never
   ? [(Init & { [key: string]: unknown })?]
   : [Init & { [key: string]: unknown }];
 

--- a/packages/openapi-fetch/test/no-strict-null-checks/noStrictNullChecks.test.ts
+++ b/packages/openapi-fetch/test/no-strict-null-checks/noStrictNullChecks.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, it } from "vitest";
+import createClient from "../../src/index.js";
+import { server, baseUrl, useMockRequestHandler } from "../fixtures/mock-server.js";
+import type { paths } from "../fixtures/api.js";
+
+beforeAll(() => {
+  server.listen({
+    onUnhandledRequest: (request) => {
+      throw new Error(`No request handler found for ${request.method} ${request.url}`);
+    },
+  });
+});
+
+afterEach(() => server.resetHandlers());
+
+afterAll(() => server.close());
+
+describe("client", () => {
+  describe("TypeScript checks", () => {
+    describe("params", () => {
+      it("is optional if no parameters are defined", async () => {
+        const client = createClient<paths>({
+          baseUrl,
+        });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: { message: "OK" },
+        });
+
+        // assert no type error
+        await client.GET("/self");
+
+        // assert no type error with empty params
+        await client.GET("/self", { params: {} });
+      });
+
+      it("checks types of optional params", async () => {
+        const client = createClient<paths>({
+          baseUrl,
+        });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "get",
+          path: "/self",
+          status: 200,
+          body: { message: "OK" },
+        });
+
+        // assert no type error with no params
+        await client.GET("/blogposts");
+
+        // assert no type error with empty params
+        await client.GET("/blogposts", { params: {} });
+
+        // expect error on incorrect param type
+        // @ts-expect-error
+        await client.GET("/blogposts", { params: { query: { published: "yes" } } });
+
+        // expect error on extra params
+        // @ts-expect-error
+        await client.GET("/blogposts", { params: { query: { fake: true } } });
+      });
+    });
+
+    describe("body", () => {
+      it("requires necessary requestBodies", async () => {
+        const client = createClient<paths>({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts",
+        });
+
+        // expect error on missing `body`
+        // @ts-expect-error
+        await client.PUT("/blogposts");
+
+        // expect error on missing fields
+        // @ts-expect-error
+        await client.PUT("/blogposts", { body: { title: "Foo" } });
+
+        // (no error)
+        await client.PUT("/blogposts", {
+          body: {
+            title: "Foo",
+            body: "Bar",
+            publish_date: new Date("2023-04-01T12:00:00Z").getTime(),
+          },
+        });
+      });
+
+      it("requestBody with required: false", async () => {
+        const client = createClient<paths>({ baseUrl });
+
+        useMockRequestHandler({
+          baseUrl,
+          method: "put",
+          path: "/blogposts-optional",
+          status: 201,
+        });
+
+        // assert missing `body` doesn’t raise a TS error
+        await client.PUT("/blogposts-optional");
+
+        // assert error on type mismatch
+        // @ts-expect-error
+        await client.PUT("/blogposts-optional", { body: { error: true } });
+
+        // (no error)
+        await client.PUT("/blogposts-optional", {
+          body: {
+            title: "",
+            publish_date: 3,
+            body: "",
+          },
+        });
+      });
+    });
+  });
+});

--- a/packages/openapi-fetch/test/no-strict-null-checks/tsconfig.json
+++ b/packages/openapi-fetch/test/no-strict-null-checks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": false
+  },
+  "include": ["."],
+  "exclude": []
+}

--- a/packages/openapi-fetch/tsconfig.json
+++ b/packages/openapi-fetch/tsconfig.json
@@ -15,5 +15,5 @@
     "types": ["vitest/globals"]
   },
   "include": ["src", "test"],
-  "exclude": ["examples", "node_modules"]
+  "exclude": ["examples", "node_modules", "test/no-strict-null-checks"]
 }

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -11,7 +11,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient } from "openapi-fetch";
-import type { HasRequiredKeys, HttpMethod, MediaType, PathsWithMethod } from "openapi-typescript-helpers";
+import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 
 export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
@@ -22,7 +22,7 @@ export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>,
 >(
   method: Method,
   url: Path,
-  ...[init, options, queryClient]: HasRequiredKeys<Init> extends never
+  ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
     ? [(Init & { [key: string]: unknown })?, Options?, QueryClient?]
     : [Init & { [key: string]: unknown }, Options?, QueryClient?]
 ) => UseQueryResult<Response["data"], Response["error"]>;
@@ -36,7 +36,7 @@ export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMetho
 >(
   method: Method,
   url: Path,
-  ...[init, options, queryClient]: HasRequiredKeys<Init> extends never
+  ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
     ? [(Init & { [key: string]: unknown })?, Options?, QueryClient?]
     : [Init & { [key: string]: unknown }, Options?, QueryClient?]
 ) => UseSuspenseQueryResult<Response["data"], Response["error"]>;


### PR DESCRIPTION
## Changes

This PR refactors some types to remove usage of `undefined extends T` conditional types. It also adds a new test suite that is type checked with `strictNullChecks` disabled to allow for increased support of that configuration.

Resolves #1778 

## How to Review

See context in [this comment on the issue](https://github.com/openapi-ts/openapi-typescript/issues/1778#issuecomment-2276217668). Using `undefined extends T` only behaves as expected when `strictNullChecks` is enabled. While this configuration is highly recommended for consuming projects, it is not the default, and we should design types that also work without it when possible.

#1778 describes a case where `params` is required on calls to routes with no parameters defined or no required parameters in the spec. At least two other cases are caused by the same underlying issue:
1. If all parameter types (query, header, path, and cookie) are defined on a route, `params` is not required, regardless of whether any of the parameters are required in the spec.
2. The `body` property is not required on calls to routes with a required request body defined in the spec.

This PR fixes the behavior of those cases.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
