### PR TITLE
fix: allow use of `PathBasedClient` with generated `paths`

### DIFF
--- a/.changeset/little-knives-design.md
+++ b/.changeset/little-knives-design.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+fix: allow use of `PathBasedClient` with generated `paths`

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -151,7 +151,7 @@ export interface Middleware {
 }
 
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
-export type MaybeOptionalInit<Params extends Record<HttpMethod, {}>, Location extends keyof Params> = RequiredKeysOf<
+export type MaybeOptionalInit<Params, Location extends keyof Params> = RequiredKeysOf<
   FetchOptions<FilterKeys<Params, Location>>
 > extends never
   ? FetchOptions<FilterKeys<Params, Location>> | undefined
@@ -174,7 +174,7 @@ export type ClientMethod<
   ...init: InitParam<Init>
 ) => Promise<FetchResponse<Paths[Path][Method], Init, Media>>;
 
-export type ClientForPath<PathInfo extends Record<HttpMethod, {}>, Media extends MediaType> = {
+export type ClientForPath<PathInfo, Media extends MediaType> = {
   [Method in keyof PathInfo as Uppercase<string & Method>]: <Init extends MaybeOptionalInit<PathInfo, Method>>(
     ...init: InitParam<Init>
   ) => Promise<FetchResponse<PathInfo[Method], Init, Media>>;
@@ -221,10 +221,7 @@ export default function createClient<Paths extends {}, Media extends MediaType =
   clientOptions?: ClientOptions,
 ): Client<Paths, Media>;
 
-export type PathBasedClient<
-  Paths extends Record<string, Record<HttpMethod, {}>>,
-  Media extends MediaType = MediaType,
-> = {
+export type PathBasedClient<Paths, Media extends MediaType = MediaType> = {
   [Path in keyof Paths]: ClientForPath<Paths[Path], Media>;
 };
 

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -5,6 +5,8 @@ import createClient, {
   type Middleware,
   type MiddlewareCallbackParams,
   type QuerySerializerOptions,
+  type Client,
+  type PathBasedClient,
   createPathBasedClient,
 } from "../src/index.js";
 import { server, baseUrl, useMockRequestHandler, toAbsoluteURL } from "./fixtures/mock-server.js";
@@ -140,6 +142,11 @@ describe("client", () => {
         expectTypeOf(result.error).extract<{ code: number }>().toEqualTypeOf<{ code: number; message: string }>();
         expectTypeOf(result.error).exclude<{ code: number }>().toEqualTypeOf<never>();
       }
+    });
+
+    it("provides a Client type", () => {
+      const client = createClient<paths>({ baseUrl });
+      expectTypeOf(client).toEqualTypeOf<Client<paths>>();
     });
 
     describe("params", () => {
@@ -1875,6 +1882,11 @@ describe("client", () => {
   });
 
   describe("path based client", () => {
+    it("provides a PathBasedClient type", () => {
+      const client = createPathBasedClient<paths>({ baseUrl });
+      expectTypeOf(client).toEqualTypeOf<PathBasedClient<paths>>();
+    });
+
     it("performs a call without params", async () => {
       const client = createPathBasedClient<paths>({ baseUrl });
 


### PR DESCRIPTION
To achieve this, we remove unnecessary type bounds.

This fixes #1840.

## Changes

- Remove unnecessary type bounds.
- Add tests for client types.

## How to Review

- Double check the removal of type bounds does not break anything.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
