### PR TITLE
feat: Proposal of an approach to support readOnly / writeOnly properties

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -54,7 +54,7 @@
     "build:cjs": "esbuild --bundle src/index.js --format=cjs --outfile=dist/cjs/index.cjs && cp dist/index.d.ts dist/cjs/index.d.cts",
     "format": "biome format . --write",
     "lint": "biome check .",
-    "generate-types": "openapi-typescript -c test/redocly.yaml",
+    "generate-types": "openapi-typescript -c test/redocly.yaml --experimental-visibility",
     "pretest": "pnpm run generate-types",
     "test": "pnpm run \"/^test:/\"",
     "test:js": "vitest run",

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -9,6 +9,7 @@ import type {
   ResponseObjectMap,
   RequiredKeysOf,
   SuccessResponse,
+  Writable,
 } from "openapi-typescript-helpers";
 
 /** Options for each client instance */
@@ -29,7 +30,7 @@ export type HeadersOptions =
   | Record<string, string | number | boolean | (string | number | boolean)[] | null | undefined>;
 
 export type QuerySerializer<T> = (
-  query: T extends { parameters: any } ? NonNullable<T["parameters"]["query"]> : Record<string, unknown>,
+  query: T extends { parameters: any } ? Writable<NonNullable<T["parameters"]["query"]>> : Record<string, unknown>,
 ) => string;
 
 /** @see https://swagger.io/docs/specification/serialization/#query */
@@ -84,8 +85,8 @@ export type ParamsOption<T> = T extends {
   parameters: any;
 }
   ? RequiredKeysOf<T["parameters"]> extends never
-    ? { params?: T["parameters"] }
-    : { params: T["parameters"] }
+    ? { params?: Writable<T["parameters"]> }
+    : { params: Writable<T["parameters"]> }
   : DefaultParamsOption;
 
 export type RequestBodyOption<T> = OperationRequestBodyContent<T> extends never

--- a/packages/openapi-fetch/test/fixtures/api.d.ts
+++ b/packages/openapi-fetch/test/fixtures/api.d.ts
@@ -859,9 +859,15 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         Post: {
+            id: {
+                $read: string;
+            };
             title: string;
             body: string;
             publish_date?: number;
+            password: {
+                $write: string;
+            };
         };
         StringArray: string[];
         User: {

--- a/packages/openapi-fetch/test/fixtures/api.yaml
+++ b/packages/openapi-fetch/test/fixtures/api.yaml
@@ -495,15 +495,23 @@ components:
     Post:
       type: object
       properties:
+        id:
+          type: string
+          readOnly: true
         title:
           type: string
         body:
           type: string
         publish_date:
           type: number
+        password:
+          type: string
+          writeOnly: true
       required:
+        - id
         - title
         - body
+        - password
     StringArray:
       type: array
       items:

--- a/packages/openapi-fetch/test/index.test.ts
+++ b/packages/openapi-fetch/test/index.test.ts
@@ -114,6 +114,7 @@ describe("client", () => {
               updated_at: number;
             }
           | {
+              id: string;
               title: string;
               body: string;
               publish_date?: number;
@@ -721,6 +722,7 @@ describe("client", () => {
             title: "",
             publish_date: 3,
             body: "",
+            password: "",
           },
         });
       });

--- a/packages/openapi-react-query/package.json
+++ b/packages/openapi-react-query/package.json
@@ -54,7 +54,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "format": "biome format . --write",
     "lint": "biome check .",
-    "generate-types": "openapi-typescript test/fixtures/api.yaml -o test/fixtures/api.d.ts",
+    "generate-types": "openapi-typescript test/fixtures/api.yaml -o test/fixtures/api.d.ts --experimental-visibility",
     "pretest": "pnpm run generate-types",
     "test": "pnpm run \"/^test:/\"",
     "test:js": "vitest run",

--- a/packages/openapi-react-query/test/fixtures/api.d.ts
+++ b/packages/openapi-react-query/test/fixtures/api.d.ts
@@ -819,9 +819,15 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         Post: {
+            id: {
+                $read: string;
+            };
             title: string;
             body: string;
             publish_date?: number;
+            password: {
+                $write: string;
+            };
         };
         StringArray: string[];
         User: {

--- a/packages/openapi-react-query/test/fixtures/api.yaml
+++ b/packages/openapi-react-query/test/fixtures/api.yaml
@@ -475,15 +475,23 @@ components:
     Post:
       type: object
       properties:
+        id:
+          type: string
+          readOnly: true
         title:
           type: string
         body:
           type: string
         publish_date:
           type: number
+        password:
+          type: string
+          writeOnly: true
       required:
+        - id
         - title
         - body
+        - password
     StringArray:
       type: array
       items:

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -26,6 +26,7 @@ Options
   --default-non-nullable     Set to \`false\` to ignore default values when generating non-nullable types
   --properties-required-by-default
                              Treat schema objects as if \`required\` is set to all properties by default
+  --experimental-visibility  Enable experimental visibility support (readOnly, writeOnly) 
   --array-length             Generate tuples using array minItems / maxItems
   --path-params-as-types     Convert paths to template literal types
   --alphabetize              Sort object keys alphabetically
@@ -133,6 +134,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       exportType: flags.exportType,
       immutable: flags.immutable,
       pathParamsAsTypes: flags.pathParamsAsTypes,
+      experimentalVisibility: flags.experimentalVisibility,
       redocly,
       silent,
     }),

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -83,6 +83,7 @@ export default async function openapiTS(
     pathParamsAsTypes: options.pathParamsAsTypes ?? false,
     postTransform: typeof options.postTransform === "function" ? options.postTransform : undefined,
     propertiesRequiredByDefault: options.propertiesRequiredByDefault ?? false,
+    experimentalVisibility: options.experimentalVisibility ?? false,
     redoc,
     silent: options.silent ?? false,
     inject: options.inject ?? undefined,

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -389,3 +389,11 @@ export function warn(msg: string, silent = false) {
     console.warn(c.yellow(` ⚠  ${msg}`));
   }
 }
+
+export function createReadOnly(type: ts.TypeNode): ts.TypeNode {
+  return ts.factory.createTypeLiteralNode([ts.factory.createPropertySignature(undefined, "$read", undefined, type)]);
+}
+
+export function createWriteOnly(type: ts.TypeNode): ts.TypeNode {
+  return ts.factory.createTypeLiteralNode([ts.factory.createPropertySignature(undefined, "$write", undefined, type)]);
+}

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -657,6 +657,8 @@ export interface OpenAPITSOptions {
   pathParamsAsTypes?: boolean;
   /** Treat all objects as if they have \`required\` set to all properties by default (default: false) */
   propertiesRequiredByDefault?: boolean;
+  /** Enable experimental visibility support (readOnly, writeOnly) */
+  experimentalVisibility?: boolean;
   /**
    * Configure Redocly for validation, schema fetching, and bundling
    * @see https://redocly.com/docs/cli/configuration/
@@ -688,6 +690,7 @@ export interface GlobalContext {
   pathParamsAsTypes: boolean;
   postTransform: OpenAPITSOptions["postTransform"];
   propertiesRequiredByDefault: boolean;
+  experimentalVisibility: boolean;
   redoc: RedoclyConfig;
   silent: boolean;
   transform: OpenAPITSOptions["transform"];

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CTX: GlobalContext = {
   pathParamsAsTypes: false,
   postTransform: undefined,
   propertiesRequiredByDefault: false,
+  experimentalVisibility: false,
   redoc: await createConfig({}, { extends: ["minimal"] }),
   resolve($ref) {
     return resolveRef({}, $ref, { silent: false });

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -411,6 +411,45 @@ describe("transformSchemaObject > object", () => {
         },
       },
     ],
+    [
+      "options > experimentalVisibility",
+      {
+        given: {
+          type: "object",
+          required: ["id", "name", "password"],
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+              readOnly: true,
+            },
+            name: {
+              type: "string",
+            },
+            password: {
+              type: "string",
+              format: "password",
+              writeOnly: true,
+            },
+          },
+        },
+        want: `{
+    /** Format: uuid */
+    id: {
+        $read: string;
+    };
+    name: string;
+    /** Format: password */
+    password: {
+        $write: string;
+    };
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, experimentalVisibility: true },
+        },
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {


### PR DESCRIPTION
## Changes

refs #604

To support readOnly / writeOnly properties, I tried to generate a magic object type `{$read: T} | {$write: T}` and resolve the type with `Readable<T>` and `Writable<T>` helpers. This approach is inspired from [ColumnType API](https://kysely-org.github.io/kysely-apidoc/types/ColumnType.html) in Kysely, a TypeScript-first query builder library.

Since this pull request changes the generated type, it will be a breaking change for some users, I marked this as an experimental feature and require users to opt-in the feature if needed.

This pull request is working, but still just a PoC and some improvements may be needed. I would like request you all for any ideas or concerns about this approach.

## How to Review

- The generated types doesn't change anyway if `experimentalVisibility` is turned off
- `readOnly` or `writeOnly` properties can be transformed into a magic `{$read: T}` `{$write: T}` type correctly
- Path parameters, query parameters, request body, and response body are resolved correctly with visibility

TS Playground for reviewing type utilities: https://www.typescriptlang.org/play/?#code/C4TwDgpgBAShCGATA8gOwDYgDwBUB8UAvFAN5QAkATgogFxQ5QC+A3AFBuiRQDqlAlsAhpMuAsTLkA7gKH1GrDl2hwkIkAGkI2fEVJQA2hqj9UUANbaA9gDMGAXXlH7UCAA8hqRAGdYNdVgArqjmqFZSqAQA-FDG9KgQAG4QlMwGliC2Duyc4NB8gsIYmtpiemRGJmYZWTiODM6uHhBevgVCAcGh4ZFQMXFQCcmpTOnWdnU5yn5I8ABG6BBlxMgAtoJYbFD6laYW4w5OGi7unj4zKMVYpjYpsNGwUEcnza1+AMZWlIhY3sACqAA5gAaKBdMIRB6qRDzRa4ZwEZ7MYFbXiyIqYLQ6PBsPBTPJowSwpa6FbrYCbbYkVHbXbVA51JGnFrndoY7A3O48B48J4NY5NM6+OCfb6-f6mEFgkIQ3oxdrE+HHRH8+zsbZMFHbaHqLFiXH47jkbzvAAWEFW8HKNJMdFIVBo9D+AMBim221Q8FWECdEqB6vdiAgJoEYGA-CsqCivpdAe2YHg3m8Ui+dpI0nRMclikUbAAFNT3YMvT6oAByGxWKxlrXuhNJlPfehl+CtmtsJhQbzwcPeGz8YOE4CK41mi3wPAAShyBZt-DtLbm73bRc93ublerKM73d7-cH0JHJvNlqn7CAA

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
