### PR TITLE
fix(openapi-typescript): type errors generated under `enumValues`

### DIFF
--- a/.changeset/proud-students-repeat.md
+++ b/.changeset/proud-students-repeat.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix(openapi-typescript): type errors generated under `enumValues`

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -136,6 +136,7 @@ export function transformSchemaObjectWithComposition(
         {
           export: true,
           readonly: true,
+          injectFooter: options.ctx.injectFooter,
         },
       );
 

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -797,6 +797,11 @@ export interface components {
     pathItems: never;
 }
 export type $defs = Record<string, never>;
+type ReadonlyArray<T> = [
+    Exclude<T, undefined>
+] extends [
+    any[]
+] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;
 export const pathsUrlGetParametersQueryStatusValues: ReadonlyArray<paths["/url"]["get"]["parameters"]["query"]["status"]> = ["active", "inactive"];
 export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["active", "inactive"];
 export const errorCodeValues: ReadonlyArray<components["schemas"]["ErrorCode"]> = [100, 101, 102, 103, 104, 105];


### PR DESCRIPTION
## Changes

reference: #1856 

In injectFooter, by redefining ReadonlyArray, type inference for ReadonlyArray is correctly applied to the array type.

## How to Review

All test cases should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
