### PR TITLE
fix(openapi-typescript-helpers): fix SuccessResponseJSON and ErrorResponseJSON helpers

### DIFF
--- a/.changeset/silly-apes-know.md
+++ b/.changeset/silly-apes-know.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+fix SuccessResponseJSON and ErrorResponseJSON helpers

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -131,13 +131,13 @@ export type ErrorResponse<T, Media extends MediaType = MediaType> = FilterKeys<
 >;
 
 /** Return first JSON-like 2XX response from a path + HTTP method */
-export type SuccessResponseJSON<PathMethod> = JSONLike<SuccessResponse<ResponseObjectMap<PathMethod>>>;
+export type SuccessResponseJSON<PathMethod> = SuccessResponse<ResponseObjectMap<PathMethod>>;
 
 /** Return first JSON-like 5XX or 4XX response from a path + HTTP method */
-export type ErrorResponseJSON<PathMethod> = JSONLike<ErrorResponse<ResponseObjectMap<PathMethod>>>;
+export type ErrorResponseJSON<PathMethod> = ErrorResponse<ResponseObjectMap<PathMethod>>;
 
 /** Return JSON-like request body from a path + HTTP method */
-export type RequestBodyJSON<PathMethod> = JSONLike<FilterKeys<OperationRequestBody<PathMethod>, "content">>;
+export type RequestBodyJSON<PathMethod> = FilterKeys<OperationRequestBody<PathMethod>, "content">;
 
 // Generic TS utils
 


### PR DESCRIPTION

## Changes

fix SuccessResponseJSON and ErrorResponseJSON helpers

## How to Review


Should fix issue  #1785 

I tested it with the following code:

```typescript
import type { ErrorResponseJSON, SuccessResponseJSON } from "./index.d.ts";
import type { components, paths } from "./v1.d.ts";

type Expect<T extends true> = T;
type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;

type A = ErrorResponseJSON<paths["/fact"]["get"]>;

type B = number;

type Tests = [
  Expect<Equal<ErrorResponseJSON<paths["/fact"]["get"]>, components["schemas"]["Error"]>>,
  Expect<Equal<SuccessResponseJSON<paths["/breeds"]["get"]>, components["schemas"]["Breed"][]>>,
];
```


## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)

I could add a test.d.ts to test the types but i thought it could (on breaking changes) break the global test script (used in ci...)
