### PR TITLE
fix(openapi-typescript): correct generated type when using `prefixItems`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -258,8 +258,7 @@ minItems: 2
 
 ```yaml
 type: array
-items:
-  type: number
+items: false
 prefixItems:
   - number
   - number

--- a/docs/ja/advanced.md
+++ b/docs/ja/advanced.md
@@ -258,8 +258,7 @@ minItems: 2
 
 ```yaml
 type: array
-items:
-  type: number
+items: false
 prefixItems:
   - number
   - number

--- a/docs/zh/advanced.md
+++ b/docs/zh/advanced.md
@@ -250,8 +250,7 @@ minItems: 2
 
 ```yaml
 type: array
-items:
-  type: number
+items: false
 prefixItems:
   - number
   - number

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -302,10 +302,49 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
     if (schemaObject.type === "array") {
       // default to `unknown[]`
       let itemType: ts.TypeNode = UNKNOWN;
-      // tuple type
-      if (schemaObject.prefixItems || Array.isArray(schemaObject.items)) {
-        const prefixItems = schemaObject.prefixItems ?? (schemaObject.items as (SchemaObject | ReferenceObject)[]);
+      // tuple type using deprecated syntax
+      if (Array.isArray(schemaObject.items)) {
+        const prefixItems = schemaObject.items;
         itemType = ts.factory.createTupleTypeNode(prefixItems.map((item) => transformSchemaObject(item, options)));
+      }
+      // standard tuple type
+      else if (schemaObject.prefixItems) {
+        const prefixItems = schemaObject.prefixItems;
+        itemType = ts.factory.createTupleTypeNode(prefixItems.map((item) => transformSchemaObject(item, options)));
+        if (schemaObject.items !== undefined) {
+          if (schemaObject.items !== false) {
+            let additionalItemType: ts.TypeNode = UNKNOWN;
+            if ("type" in schemaObject.items) {
+              additionalItemType = ts.factory.createArrayTypeNode(transformSchemaObject(schemaObject.items, options));
+            } else {
+              additionalItemType = transformSchemaObject(schemaObject.items, options);
+            }
+            itemType = ts.factory.createTupleTypeNode([
+              ...(itemType as ts.TupleTypeNode).elements,
+              ts.factory.createRestTypeNode(additionalItemType),
+            ]);
+          }
+        } else if (schemaObject.unevaluatedItems !== undefined) {
+          if (schemaObject.unevaluatedItems !== false) {
+            let additionalItemType: ts.TypeNode = UNKNOWN;
+            if ("type" in schemaObject.unevaluatedItems) {
+              additionalItemType = ts.factory.createArrayTypeNode(
+                transformSchemaObject(schemaObject.unevaluatedItems, options),
+              );
+            } else {
+              additionalItemType = transformSchemaObject(schemaObject.unevaluatedItems, options);
+            }
+            itemType = ts.factory.createTupleTypeNode([
+              ...(itemType as ts.TupleTypeNode).elements,
+              ts.factory.createRestTypeNode(additionalItemType),
+            ]);
+          }
+        } else {
+          itemType = ts.factory.createTupleTypeNode([
+            ...(itemType as ts.TupleTypeNode).elements,
+            ts.factory.createRestTypeNode(ts.factory.createArrayTypeNode(UNKNOWN)),
+          ]);
+        }
       }
       // standard array type
       else if (schemaObject.items) {

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -483,7 +483,8 @@ export interface IntegerSubtype {
 export interface ArraySubtype {
   type: "array" | ["array", "null"];
   prefixItems?: (SchemaObject | ReferenceObject)[];
-  items?: SchemaObject | ReferenceObject | (SchemaObject | ReferenceObject)[];
+  items?: false | SchemaObject | ReferenceObject | (SchemaObject | ReferenceObject)[];
+  unevaluatedItems?: false | SchemaObject | ReferenceObject;
   minItems?: number;
   maxItems?: number;
   enum?: (SchemaObject | ReferenceObject)[];

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -35,11 +35,77 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
-      "tuple > prefixItems",
+      "tuple > prefixItems (open tuple using items)",
       {
         given: {
           type: "array",
           items: { type: "number" },
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `[
+    number,
+    number,
+    number,
+    ...number[]
+]`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "tuple > prefixItems (closed tuple using unevaluatedItems)",
+      {
+        given: {
+          type: "array",
+          unevaluatedItems: { type: "number" },
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `[
+    number,
+    number,
+    number,
+    ...number[]
+]`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "tuple > prefixItems (open tuple not specified)",
+      {
+        given: {
+          type: "array",
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `[
+    number,
+    number,
+    number,
+    ...unknown[]
+]`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "tuple > prefixItems (closed tuple using items)",
+      {
+        given: {
+          type: "array",
+          items: false,
+          prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
+        },
+        want: `[
+    number,
+    number,
+    number
+]`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "tuple > prefixItems (closed tuple using unevaluatedItems)",
+      {
+        given: {
+          type: "array",
+          unevaluatedItems: false,
           prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
         },
         want: `[
@@ -179,7 +245,7 @@ describe("transformSchemaObject > array", () => {
       {
         given: {
           type: "array",
-          items: { type: "number" },
+          items: false,
           prefixItems: [{ type: "number" }, { type: "number" }, { type: "number" }],
         },
         want: `readonly [


### PR DESCRIPTION
## Changes

Closes #1892

## How to Review

Note that this PR also adds support for `unevaluatedItems`, which was supported in OAS 3.1.0.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
