### PR TITLE
chore(openapi-fetch): Improve benchmarks

### DIFF
--- a/packages/openapi-fetch/biome.json
+++ b/packages/openapi-fetch/biome.json
@@ -3,7 +3,7 @@
   "extends": ["../../biome.json"],
   "files": {
     "include": ["./src/", "./test/"],
-    "ignore": ["**/test/**/schemas/**"]
+    "ignore": ["./test/**/schemas/**", "./test/bench/*.min.js"]
   },
   "linter": {
     "rules": {

--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -67,8 +67,7 @@
     "version": "pnpm run prepare && pnpm run build"
   },
   "dependencies": {
-    "openapi-typescript-helpers": "workspace:^",
-    "vitest-fetch-mock": "^0.3.0"
+    "openapi-typescript-helpers": "workspace:^"
   },
   "devDependencies": {
     "axios": "^1.7.7",

--- a/packages/openapi-fetch/test/bench/index.bench.js
+++ b/packages/openapi-fetch/test/bench/index.bench.js
@@ -2,25 +2,27 @@ import axios from "axios";
 import { Fetcher } from "openapi-typescript-fetch";
 import { createApiFetchClient } from "feature-fetch";
 import superagent from "superagent";
-import { afterAll, beforeAll, bench, describe, vi } from "vitest";
-import createFetchMock from "vitest-fetch-mock";
-import createClient, { createPathBasedClient } from "../dist/index.js";
-import * as openapiTSCodegen from "./fixtures/openapi-typescript-codegen.min.js";
+import { afterAll, bench, describe, vi } from "vitest";
+import createClient, { createPathBasedClient } from "../../dist/index.js";
+import * as openapiTSCodegen from "./openapi-typescript-codegen.min.js";
 
 const BASE_URL = "https://api.test.local";
 
-const fetchMocker = createFetchMock(vi);
+const fetchMock = vi.fn(
+  () =>
+    new Promise((resolve) => {
+      process.nextTick(() => {
+        resolve(Response.json({}, { status: 200 }));
+      });
+    }),
+);
+vi.stubGlobal("fetch", fetchMock);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("setup", () => {
-  beforeAll(() => {
-    // mock global fetch in this benchmark, without any delaly, shared state or resources
-    fetchMocker.enableMocks();
-  });
-
-  afterAll(() => {
-    fetchMocker.disableMocks();
-  });
-
   bench("openapi-fetch", async () => {
     createClient({ baseUrl: BASE_URL });
   });

--- a/packages/openapi-fetch/test/bench/openapi-typescript-codegen.min.js
+++ b/packages/openapi-fetch/test/bench/openapi-typescript-codegen.min.js
@@ -1,0 +1,1614 @@
+"use strict";var v=(e,n)=>()=>(n||e((n={exports:{}}).exports,n),n.exports);var So=v((_v,Dt)=>{"use strict";var Du=/[\p{Lu}]/u,Nu=/[\p{Ll}]/u,Po=/^[\p{Lu}](?![\p{Lu}])/gu,wo=/([\p{Alpha}\p{N}_]|$)/u,ko=/[_.\- ]+/,Hu=new RegExp("^"+ko.source),bo=new RegExp(ko.source+wo.source,"gu"),Oo=new RegExp("\\d+"+wo.source,"gu"),Fu=(e,n,o)=>{let i=!1,r=!1,t=!1;for(let a=0;a<e.length;a++){let l=e[a];i&&Du.test(l)?(e=e.slice(0,a)+"-"+e.slice(a),i=!1,t=r,r=!0,a++):r&&t&&Nu.test(l)?(e=e.slice(0,a-1)+"-"+e.slice(a-1),t=r,r=!1,i=!0):(i=n(l)===l&&o(l)!==l,t=r,r=o(l)===l&&n(l)!==l)}return e},$u=(e,n)=>(Po.lastIndex=0,e.replace(Po,o=>n(o))),Lu=(e,n)=>(bo.lastIndex=0,Oo.lastIndex=0,e.replace(bo,(o,i)=>n(i)).replace(Oo,o=>n(o))),Co=(e,n)=>{if(!(typeof e=="string"||Array.isArray(e)))throw new TypeError("Expected the input to be `string | string[]`");if(n={pascalCase:!1,preserveConsecutiveUppercase:!1,...n},Array.isArray(e)?e=e.map(t=>t.trim()).filter(t=>t.length).join("-"):e=e.trim(),e.length===0)return"";let o=n.locale===!1?t=>t.toLowerCase():t=>t.toLocaleLowerCase(n.locale),i=n.locale===!1?t=>t.toUpperCase():t=>t.toLocaleUpperCase(n.locale);return e.length===1?n.pascalCase?i(e):o(e):(e!==o(e)&&(e=Fu(e,o,i)),e=e.replace(Hu,""),n.preserveConsecutiveUppercase?e=$u(e,o):e=o(e),n.pascalCase&&(e=i(e.charAt(0))+e.slice(1)),Lu(e,i))};Dt.exports=Co;Dt.exports.default=Co});var et=v(on=>{"use strict";Object.defineProperty(on,"__esModule",{value:!0});on.getDeepKeys=on.toJSON=void 0;var Mu=["function","symbol","undefined"],Bu=["constructor","prototype","__proto__"],Uu=Object.getPrototypeOf({});function Wu(){let e={},n=this;for(let o of Eo(n))if(typeof o=="string"){let i=n[o],r=typeof i;Mu.includes(r)||(e[o]=i)}return e}on.toJSON=Wu;function Eo(e,n=[]){let o=[];for(;e&&e!==Uu;)o=o.concat(Object.getOwnPropertyNames(e),Object.getOwnPropertySymbols(e)),e=Object.getPrototypeOf(e);let i=new Set(o);for(let r of n.concat(Bu))i.delete(r);return i}on.getDeepKeys=Eo});var Nt=v(an=>{"use strict";Object.defineProperty(an,"__esModule",{value:!0});an.addInspectMethod=an.format=void 0;var Ro=require("util"),Vu=et(),qo=Ro.inspect.custom||Symbol.for("nodejs.util.inspect.custom");an.format=Ro.format;function Yu(e){e[qo]=Ju}an.addInspectMethod=Yu;function Ju(){let e={},n=this;for(let o of Vu.getDeepKeys(n)){let i=n[o];e[o]=i}return delete e[qo],e}});var Io=v(ye=>{"use strict";Object.defineProperty(ye,"__esModule",{value:!0});ye.lazyJoinStacks=ye.joinStacks=ye.isWritableStack=ye.isLazyStack=void 0;var Gu=/\r?\n/,Ku=/\bono[ @]/;function zu(e){return!!(e&&e.configurable&&typeof e.get=="function")}ye.isLazyStack=zu;function Qu(e){return!!(!e||e.writable||typeof e.set=="function")}ye.isWritableStack=Qu;function Ao(e,n){let o=To(e.stack),i=n?n.stack:void 0;return o&&i?o+`
+
+`+i:o||i}ye.joinStacks=Ao;function Xu(e,n,o){o?Object.defineProperty(n,"stack",{get:()=>{let i=e.get.apply(n);return Ao({stack:i},o)},enumerable:!1,configurable:!0}):Zu(n,e)}ye.lazyJoinStacks=Xu;function To(e){if(e){let n=e.split(Gu),o;for(let i=0;i<n.length;i++){let r=n[i];if(Ku.test(r))o===void 0&&(o=i);else if(o!==void 0){n.splice(o,i-o);break}}if(n.length>0)return n.join(`
+`)}return e}function Zu(e,n){Object.defineProperty(e,"stack",{get:()=>To(n.get.apply(e)),enumerable:!1,configurable:!0})}});var Do=v(tt=>{"use strict";Object.defineProperty(tt,"__esModule",{value:!0});tt.extendError=void 0;var _o=Nt(),nt=Io(),jo=et(),ec=["name","message","stack"];function nc(e,n,o){let i=e;return tc(i,n),n&&typeof n=="object"&&rc(i,n),i.toJSON=jo.toJSON,_o.addInspectMethod&&_o.addInspectMethod(i),o&&typeof o=="object"&&Object.assign(i,o),i}tt.extendError=nc;function tc(e,n){let o=Object.getOwnPropertyDescriptor(e,"stack");nt.isLazyStack(o)?nt.lazyJoinStacks(o,e,n):nt.isWritableStack(o)&&(e.stack=nt.joinStacks(e,n))}function rc(e,n){let o=jo.getDeepKeys(n,ec),i=e,r=n;for(let t of o)if(i[t]===void 0)try{i[t]=r[t]}catch{}}});var No=v(ln=>{"use strict";Object.defineProperty(ln,"__esModule",{value:!0});ln.normalizeArgs=ln.normalizeOptions=void 0;var oc=Nt();function ac(e){return e=e||{},{concatMessages:e.concatMessages===void 0?!0:!!e.concatMessages,format:e.format===void 0?oc.format:typeof e.format=="function"?e.format:!1}}ln.normalizeOptions=ac;function ic(e,n){let o,i,r,t="";return typeof e[0]=="string"?r=e:typeof e[1]=="string"?(e[0]instanceof Error?o=e[0]:i=e[0],r=e.slice(1)):(o=e[0],i=e[1],r=e.slice(2)),r.length>0&&(n.format?t=n.format.apply(void 0,r):t=r.join(" ")),n.concatMessages&&o&&o.message&&(t+=(t?` 
+`:"")+o.message),{originalError:o,props:i,message:t}}ln.normalizeArgs=ic});var Ft=v(ot=>{"use strict";Object.defineProperty(ot,"__esModule",{value:!0});ot.Ono=void 0;var rt=Do(),Ho=No(),lc=et(),sc=Ht;ot.Ono=sc;function Ht(e,n){n=Ho.normalizeOptions(n);function o(...i){let{originalError:r,props:t,message:a}=Ho.normalizeArgs(i,n),l=new e(a);return rt.extendError(l,r,t)}return o[Symbol.species]=e,o}Ht.toJSON=function(n){return lc.toJSON.call(n)};Ht.extend=function(n,o,i){return i||o instanceof Error?rt.extendError(n,o,i):o?rt.extendError(n,void 0,o):rt.extendError(n)}});var Fo=v(at=>{"use strict";Object.defineProperty(at,"__esModule",{value:!0});at.ono=void 0;var We=Ft(),uc=ve;at.ono=uc;ve.error=new We.Ono(Error);ve.eval=new We.Ono(EvalError);ve.range=new We.Ono(RangeError);ve.reference=new We.Ono(ReferenceError);ve.syntax=new We.Ono(SyntaxError);ve.type=new We.Ono(TypeError);ve.uri=new We.Ono(URIError);var cc=ve;function ve(...e){let n=e[0];if(typeof n=="object"&&typeof n.name=="string"){for(let o of Object.values(cc))if(typeof o=="function"&&o.name==="ono"){let i=o[Symbol.species];if(i&&i!==Error&&(n instanceof i||n.name===i.name))return o.apply(void 0,e)}}return ve.error.apply(void 0,e)}});var Lo=v($o=>{"use strict";Object.defineProperty($o,"__esModule",{value:!0});var Mv=require("util")});var Te=v((ue,sn)=>{"use strict";var pc=ue&&ue.__createBinding||(Object.create?function(e,n,o,i){i===void 0&&(i=o),Object.defineProperty(e,i,{enumerable:!0,get:function(){return n[o]}})}:function(e,n,o,i){i===void 0&&(i=o),e[i]=n[o]}),fc=ue&&ue.__exportStar||function(e,n){for(var o in e)o!=="default"&&!n.hasOwnProperty(o)&&pc(n,e,o)};Object.defineProperty(ue,"__esModule",{value:!0});ue.ono=void 0;var Mo=Fo();Object.defineProperty(ue,"ono",{enumerable:!0,get:function(){return Mo.ono}});var mc=Ft();Object.defineProperty(ue,"Ono",{enumerable:!0,get:function(){return mc.Ono}});fc(Lo(),ue);ue.default=Mo.ono;typeof sn=="object"&&typeof sn.exports=="object"&&(sn.exports=Object.assign(sn.exports.default,sn.exports))});var ie=v((ee,Bo)=>{"use strict";var it=/^win/.test(process.platform),dc=/\//g,hc=/^(\w{2,}):\/\//i,Mt=Bo.exports,yc=/~1/g,vc=/~0/g,$t=[/\?/g,"%3F",/\#/g,"%23"],Lt=[/\%23/g,"#",/\%24/g,"$",/\%26/g,"&",/\%2C/g,",",/\%40/g,"@"];ee.parse=require("url").parse;ee.resolve=require("url").resolve;ee.cwd=function(){if(process.browser)return location.href;let n=process.cwd(),o=n.slice(-1);return o==="/"||o==="\\"?n:n+"/"};ee.getProtocol=function(n){let o=hc.exec(n);if(o)return o[1].toLowerCase()};ee.getExtension=function(n){let o=n.lastIndexOf(".");return o>=0?Mt.stripQuery(n.substr(o).toLowerCase()):""};ee.stripQuery=function(n){let o=n.indexOf("?");return o>=0&&(n=n.substr(0,o)),n};ee.getHash=function(n){let o=n.indexOf("#");return o>=0?n.substr(o):"#"};ee.stripHash=function(n){let o=n.indexOf("#");return o>=0&&(n=n.substr(0,o)),n};ee.isHttp=function(n){let o=Mt.getProtocol(n);return o==="http"||o==="https"?!0:o===void 0?process.browser:!1};ee.isFileSystemPath=function(n){if(process.browser)return!1;let o=Mt.getProtocol(n);return o===void 0||o==="file"};ee.fromFileSystemPath=function(n){it&&(n=n.replace(/\\/g,"/")),n=encodeURI(n);for(let o=0;o<$t.length;o+=2)n=n.replace($t[o],$t[o+1]);return n};ee.toFileSystemPath=function(n,o){n=decodeURI(n);for(let r=0;r<Lt.length;r+=2)n=n.replace(Lt[r],Lt[r+1]);let i=n.substr(0,7).toLowerCase()==="file://";return i&&(n=n[7]==="/"?n.substr(8):n.substr(7),it&&n[1]==="/"&&(n=n[0]+":"+n.substr(1)),o?n="file:///"+n:(i=!1,n=it?n:"/"+n)),it&&!i&&(n=n.replace(dc,"\\"),n.substr(1,2)===":\\"&&(n=n[0].toUpperCase()+n.substr(1))),n};ee.safePointerToPath=function(n){return n.length<=1||n[0]!=="#"||n[1]!=="/"?[]:n.slice(2).split("/").map(o=>decodeURIComponent(o).replace(yc,"/").replace(vc,"~"))}});var pe=v(ce=>{"use strict";var{Ono:Uo}=Te(),{stripHash:Wo,toFileSystemPath:gc}=ie(),Ie=ce.JSONParserError=class extends Error{constructor(n,o){super(),this.code="EUNKNOWN",this.message=n,this.source=o,this.path=null,Uo.extend(this)}get footprint(){return`${this.path}+${this.source}+${this.code}+${this.message}`}};_e(Ie);var Vo=ce.JSONParserErrorGroup=class Yo extends Error{constructor(n){super(),this.files=n,this.message=`${this.errors.length} error${this.errors.length>1?"s":""} occurred while reading '${gc(n.$refs._root$Ref.path)}'`,Uo.extend(this)}static getParserErrors(n){let o=[];for(let i of Object.values(n.$refs._$refs))i.errors&&o.push(...i.errors);return o}get errors(){return Yo.getParserErrors(this.files)}};_e(Vo);var xc=ce.ParserError=class extends Ie{constructor(n,o){super(`Error parsing ${o}: ${n}`,o),this.code="EPARSER"}};_e(xc);var Pc=ce.UnmatchedParserError=class extends Ie{constructor(n){super(`Could not find parser for "${n}"`,n),this.code="EUNMATCHEDPARSER"}};_e(Pc);var bc=ce.ResolverError=class extends Ie{constructor(n,o){super(n.message||`Error reading file "${o}"`,o),this.code="ERESOLVER","code"in n&&(this.ioErrorCode=String(n.code))}};_e(bc);var Oc=ce.UnmatchedResolverError=class extends Ie{constructor(n){super(`Could not find resolver for "${n}"`,n),this.code="EUNMATCHEDRESOLVER"}};_e(Oc);var wc=ce.MissingPointerError=class extends Ie{constructor(n,o){super(`Token "${n}" does not exist.`,Wo(o)),this.code="EMISSINGPOINTER"}};_e(wc);var kc=ce.InvalidPointerError=class extends Ie{constructor(n,o){super(`Invalid $ref pointer "${n}". Pointers must begin with "#/"`,Wo(o)),this.code="EINVALIDPOINTER"}};_e(kc);function _e(e){Object.defineProperty(e.prototype,"name",{value:e.name,enumerable:!0})}ce.isHandledError=function(e){return e instanceof Ie||e instanceof Vo};ce.normalizeError=function(e){return e.path===null&&(e.path=[]),e}});var En=v((Qv,Ko)=>{"use strict";Ko.exports=je;var Bt=un(),Ut=ie(),{JSONParserError:Cc,InvalidPointerError:Sc,MissingPointerError:Ec,isHandledError:Rc}=pe(),qc=/\//g,Ac=/~/g,Tc=/~1/g,Ic=/~0/g;function je(e,n,o){this.$ref=e,this.path=n,this.originalPath=o||n,this.value=void 0,this.circular=!1,this.indirections=0}je.prototype.resolve=function(e,n,o){let i=je.parse(this.path,this.originalPath);this.value=Go(e);for(let r=0;r<i.length;r++){if(lt(this,n)&&(this.path=je.join(this.path,i.slice(r))),typeof this.value=="object"&&this.value!==null&&"$ref"in this.value)return this;let t=i[r];if(this.value[t]===void 0||this.value[t]===null)throw this.value=null,new Ec(t,this.originalPath);this.value=this.value[t]}return(!this.value||this.value.$ref&&Ut.resolve(this.path,this.value.$ref)!==o)&&lt(this,n),this};je.prototype.set=function(e,n,o){let i=je.parse(this.path),r;if(i.length===0)return this.value=n,n;this.value=Go(e);for(let t=0;t<i.length-1;t++)lt(this,o),r=i[t],this.value&&this.value[r]!==void 0?this.value=this.value[r]:this.value=Jo(this,r,{});return lt(this,o),r=i[i.length-1],Jo(this,r,n),e};je.parse=function(e,n){let o=Ut.getHash(e).substr(1);if(!o)return[];o=o.split("/");for(let i=0;i<o.length;i++)o[i]=decodeURIComponent(o[i].replace(Tc,"/").replace(Ic,"~"));if(o[0]!=="")throw new Sc(o,n===void 0?e:n);return o.slice(1)};je.join=function(e,n){e.indexOf("#")===-1&&(e+="#"),n=Array.isArray(n)?n:[n];for(let o=0;o<n.length;o++){let i=n[o];e+="/"+encodeURIComponent(i.replace(Ac,"~0").replace(qc,"~1"))}return e};function lt(e,n){if(Bt.isAllowed$Ref(e.value,n)){let o=Ut.resolve(e.path,e.value.$ref);if(o===e.path)e.circular=!0;else{let i=e.$ref.$refs._resolve(o,e.path,n);return i===null?!1:(e.indirections+=i.indirections+1,Bt.isExtended$Ref(e.value)?(e.value=Bt.dereference(e.value,i.value),!1):(e.$ref=i.$ref,e.path=i.path,e.value=i.value,!0))}}}function Jo(e,n,o){if(e.value&&typeof e.value=="object")n==="-"&&Array.isArray(e.value)?e.value.push(o):e.value[n]=o;else throw new Cc(`Error assigning $ref pointer "${e.path}". 
+Cannot set "${n}" of a non-object.`);return o}function Go(e){if(Rc(e))throw e;return e}});var un=v((Xv,Xo)=>{"use strict";Xo.exports=G;var Qo=En(),{InvalidPointerError:_c,isHandledError:jc,normalizeError:zo}=pe(),{safePointerToPath:Dc,stripHash:Nc,getHash:Hc}=ie();function G(){this.path=void 0,this.value=void 0,this.$refs=void 0,this.pathType=void 0,this.errors=void 0}G.prototype.addError=function(e){this.errors===void 0&&(this.errors=[]);let n=this.errors.map(({footprint:o})=>o);Array.isArray(e.errors)?this.errors.push(...e.errors.map(zo).filter(({footprint:o})=>!n.includes(o))):n.includes(e.footprint)||this.errors.push(zo(e))};G.prototype.exists=function(e,n){try{return this.resolve(e,n),!0}catch{return!1}};G.prototype.get=function(e,n){return this.resolve(e,n).value};G.prototype.resolve=function(e,n,o,i){let r=new Qo(this,e,o);try{return r.resolve(this.value,n,i)}catch(t){if(!n||!n.continueOnError||!jc(t))throw t;return t.path===null&&(t.path=Dc(Hc(i))),t instanceof _c&&(t.source=Nc(i)),this.addError(t),null}};G.prototype.set=function(e,n){let o=new Qo(this,e);this.value=o.set(this.value,n)};G.is$Ref=function(e){return e&&typeof e=="object"&&typeof e.$ref=="string"&&e.$ref.length>0};G.isExternal$Ref=function(e){return G.is$Ref(e)&&e.$ref[0]!=="#"};G.isAllowed$Ref=function(e,n){if(G.is$Ref(e)){if(e.$ref.substr(0,2)==="#/"||e.$ref==="#")return!0;if(e.$ref[0]!=="#"&&(!n||n.resolve.external))return!0}};G.isExtended$Ref=function(e){return G.is$Ref(e)&&Object.keys(e).length>1};G.dereference=function(e,n){if(n&&typeof n=="object"&&G.isExtended$Ref(e)){let o={};for(let i of Object.keys(e))i!=="$ref"&&(o[i]=e[i]);for(let i of Object.keys(n))i in o||(o[i]=n[i]);return o}else return n}});var ta=v((Zv,na)=>{"use strict";var{ono:Zo}=Te(),Fc=un(),De=ie();na.exports=fe;function fe(){this.circular=!1,this._$refs={},this._root$Ref=null}fe.prototype.paths=function(e){return ea(this._$refs,arguments).map(o=>o.decoded)};fe.prototype.values=function(e){let n=this._$refs;return ea(n,arguments).reduce((i,r)=>(i[r.decoded]=n[r.encoded].value,i),{})};fe.prototype.toJSON=fe.prototype.values;fe.prototype.exists=function(e,n){try{return this._resolve(e,"",n),!0}catch{return!1}};fe.prototype.get=function(e,n){return this._resolve(e,"",n).value};fe.prototype.set=function(e,n){let o=De.resolve(this._root$Ref.path,e),i=De.stripHash(o),r=this._$refs[i];if(!r)throw Zo(`Error resolving $ref pointer "${e}". 
+"${i}" not found.`);r.set(o,n)};fe.prototype._add=function(e){let n=De.stripHash(e),o=new Fc;return o.path=n,o.$refs=this,this._$refs[n]=o,this._root$Ref=this._root$Ref||o,o};fe.prototype._resolve=function(e,n,o){let i=De.resolve(this._root$Ref.path,e),r=De.stripHash(i),t=this._$refs[r];if(!t)throw Zo(`Error resolving $ref pointer "${e}". 
+"${r}" not found.`);return t.resolve(i,o,e,n)};fe.prototype._get$Ref=function(e){e=De.resolve(this._root$Ref.path,e);let n=De.stripHash(e);return this._$refs[n]};function ea(e,n){let o=Object.keys(e);return n=Array.isArray(n[0])?n[0]:Array.prototype.slice.call(n),n.length>0&&n[0]&&(o=o.filter(i=>n.indexOf(e[i].pathType)!==-1)),o.map(i=>({encoded:i,decoded:e[i].pathType==="file"?De.toFileSystemPath(i,!0):i}))}});var oa=v(Rn=>{"use strict";Rn.all=function(e){return Object.keys(e).filter(n=>typeof e[n]=="object").map(n=>(e[n].name=n,e[n]))};Rn.filter=function(e,n,o){return e.filter(i=>!!ra(i,n,o))};Rn.sort=function(e){for(let n of e)n.order=n.order||Number.MAX_SAFE_INTEGER;return e.sort((n,o)=>n.order-o.order)};Rn.run=function(e,n,o,i){let r,t,a=0;return new Promise((l,s)=>{u();function u(){if(r=e[a++],!r)return s(t);try{let m=ra(r,n,o,p,i);if(m&&typeof m.then=="function")m.then(c,f);else if(m!==void 0)c(m);else if(a===e.length)throw new Error("No promise has been returned or callback has been called.")}catch(m){f(m)}}function p(m,d){m?f(m):c(d)}function c(m){l({plugin:r,result:m})}function f(m){t={plugin:r,error:m},u()}})};function ra(e,n,o,i,r){let t=e[n];if(typeof t=="function")return t.apply(e,[o,i,r]);if(!i){if(t instanceof RegExp)return t.test(o.url);if(typeof t=="string")return t===o.extension;if(Array.isArray(t))return t.indexOf(o.extension)!==-1}return t}});var Vt=v((ng,sa)=>{"use strict";var{ono:Wt}=Te(),aa=ie(),Ne=oa(),{ResolverError:ia,ParserError:la,UnmatchedParserError:$c,UnmatchedResolverError:Lc,isHandledError:Mc}=pe();sa.exports=Bc;async function Bc(e,n,o){e=aa.stripHash(e);let i=n._add(e),r={url:e,extension:aa.getExtension(e)};try{let t=await Uc(r,o,n);i.pathType=t.plugin.name,r.data=t.result;let a=await Wc(r,o,n);return i.value=a.result,a.result}catch(t){throw Mc(t)&&(i.value=t),t}}function Uc(e,n,o){return new Promise((i,r)=>{let t=Ne.all(n.resolve);t=Ne.filter(t,"canRead",e),Ne.sort(t),Ne.run(t,"read",e,o).then(i,a);function a(l){!l&&n.continueOnError?r(new Lc(e.url)):!l||!("error"in l)?r(Wt.syntax(`Unable to resolve $ref pointer "${e.url}"`)):l.error instanceof ia?r(l.error):r(new ia(l,e.url))}})}function Wc(e,n,o){return new Promise((i,r)=>{let t=Ne.all(n.parse),a=Ne.filter(t,"canParse",e),l=a.length>0?a:t;Ne.sort(l),Ne.run(l,"parse",e,o).then(s,u);function s(p){!p.plugin.allowEmpty&&Vc(p.result)?r(Wt.syntax(`Error parsing "${e.url}" as ${p.plugin.name}. 
+Parsed value is empty`)):i(p)}function u(p){!p&&n.continueOnError?r(new $c(e.url)):!p||!("error"in p)?r(Wt.syntax(`Unable to parse ${e.url}`)):p.error instanceof la?r(p.error):r(new la(p.error.message,e.url))}})}function Vc(e){return e===void 0||typeof e=="object"&&Object.keys(e).length===0||typeof e=="string"&&e.trim().length===0||Buffer.isBuffer(e)&&e.length===0}});var ca=v((tg,ua)=>{"use strict";var{ParserError:Yc}=pe();ua.exports={order:100,allowEmpty:!0,canParse:".json",async parse(e){let n=e.data;if(Buffer.isBuffer(n)&&(n=n.toString()),typeof n=="string"){if(n.trim().length===0)return;try{return JSON.parse(n)}catch(o){throw new Yc(o.message,e.url)}}else return n}}});var cn=v((rg,Ve)=>{"use strict";function pa(e){return typeof e>"u"||e===null}function Jc(e){return typeof e=="object"&&e!==null}function Gc(e){return Array.isArray(e)?e:pa(e)?[]:[e]}function Kc(e,n){var o,i,r,t;if(n)for(t=Object.keys(n),o=0,i=t.length;o<i;o+=1)r=t[o],e[r]=n[r];return e}function zc(e,n){var o="",i;for(i=0;i<n;i+=1)o+=e;return o}function Qc(e){return e===0&&Number.NEGATIVE_INFINITY===1/e}Ve.exports.isNothing=pa;Ve.exports.isObject=Jc;Ve.exports.toArray=Gc;Ve.exports.repeat=zc;Ve.exports.isNegativeZero=Qc;Ve.exports.extend=Kc});var pn=v((og,ma)=>{"use strict";function fa(e,n){var o="",i=e.reason||"(unknown reason)";return e.mark?(e.mark.name&&(o+='in "'+e.mark.name+'" '),o+="("+(e.mark.line+1)+":"+(e.mark.column+1)+")",!n&&e.mark.snippet&&(o+=`
+
+`+e.mark.snippet),i+" "+o):i}function qn(e,n){Error.call(this),this.name="YAMLException",this.reason=e,this.mark=n,this.message=fa(this,!1),Error.captureStackTrace?Error.captureStackTrace(this,this.constructor):this.stack=new Error().stack||""}qn.prototype=Object.create(Error.prototype);qn.prototype.constructor=qn;qn.prototype.toString=function(n){return this.name+": "+fa(this,n)};ma.exports=qn});var ha=v((ag,da)=>{"use strict";var An=cn();function Yt(e,n,o,i,r){var t="",a="",l=Math.floor(r/2)-1;return i-n>l&&(t=" ... ",n=i-l+t.length),o-i>l&&(a=" ...",o=i+l-a.length),{str:t+e.slice(n,o).replace(/\t/g,"\u2192")+a,pos:i-n+t.length}}function Jt(e,n){return An.repeat(" ",n-e.length)+e}function Xc(e,n){if(n=Object.create(n||null),!e.buffer)return null;n.maxLength||(n.maxLength=79),typeof n.indent!="number"&&(n.indent=1),typeof n.linesBefore!="number"&&(n.linesBefore=3),typeof n.linesAfter!="number"&&(n.linesAfter=2);for(var o=/\r?\n|\r|\0/g,i=[0],r=[],t,a=-1;t=o.exec(e.buffer);)r.push(t.index),i.push(t.index+t[0].length),e.position<=t.index&&a<0&&(a=i.length-2);a<0&&(a=i.length-1);var l="",s,u,p=Math.min(e.line+n.linesAfter,r.length).toString().length,c=n.maxLength-(n.indent+p+3);for(s=1;s<=n.linesBefore&&!(a-s<0);s++)u=Yt(e.buffer,i[a-s],r[a-s],e.position-(i[a]-i[a-s]),c),l=An.repeat(" ",n.indent)+Jt((e.line-s+1).toString(),p)+" | "+u.str+`
+`+l;for(u=Yt(e.buffer,i[a],r[a],e.position,c),l+=An.repeat(" ",n.indent)+Jt((e.line+1).toString(),p)+" | "+u.str+`
+`,l+=An.repeat("-",n.indent+p+3+u.pos)+`^
+`,s=1;s<=n.linesAfter&&!(a+s>=r.length);s++)u=Yt(e.buffer,i[a+s],r[a+s],e.position-(i[a]-i[a+s]),c),l+=An.repeat(" ",n.indent)+Jt((e.line+s+1).toString(),p)+" | "+u.str+`
+`;return l.replace(/\n$/,"")}da.exports=Xc});var V=v((ig,va)=>{"use strict";var ya=pn(),Zc=["kind","multi","resolve","construct","instanceOf","predicate","represent","representName","defaultStyle","styleAliases"],ep=["scalar","sequence","mapping"];function np(e){var n={};return e!==null&&Object.keys(e).forEach(function(o){e[o].forEach(function(i){n[String(i)]=o})}),n}function tp(e,n){if(n=n||{},Object.keys(n).forEach(function(o){if(Zc.indexOf(o)===-1)throw new ya('Unknown option "'+o+'" is met in definition of "'+e+'" YAML type.')}),this.options=n,this.tag=e,this.kind=n.kind||null,this.resolve=n.resolve||function(){return!0},this.construct=n.construct||function(o){return o},this.instanceOf=n.instanceOf||null,this.predicate=n.predicate||null,this.represent=n.represent||null,this.representName=n.representName||null,this.defaultStyle=n.defaultStyle||null,this.multi=n.multi||!1,this.styleAliases=np(n.styleAliases||null),ep.indexOf(this.kind)===-1)throw new ya('Unknown kind "'+this.kind+'" is specified for "'+e+'" YAML type.')}va.exports=tp});var zt=v((lg,xa)=>{"use strict";var Tn=pn(),Gt=V();function ga(e,n){var o=[];return e[n].forEach(function(i){var r=o.length;o.forEach(function(t,a){t.tag===i.tag&&t.kind===i.kind&&t.multi===i.multi&&(r=a)}),o[r]=i}),o}function rp(){var e={scalar:{},sequence:{},mapping:{},fallback:{},multi:{scalar:[],sequence:[],mapping:[],fallback:[]}},n,o;function i(r){r.multi?(e.multi[r.kind].push(r),e.multi.fallback.push(r)):e[r.kind][r.tag]=e.fallback[r.tag]=r}for(n=0,o=arguments.length;n<o;n+=1)arguments[n].forEach(i);return e}function Kt(e){return this.extend(e)}Kt.prototype.extend=function(n){var o=[],i=[];if(n instanceof Gt)i.push(n);else if(Array.isArray(n))i=i.concat(n);else if(n&&(Array.isArray(n.implicit)||Array.isArray(n.explicit)))n.implicit&&(o=o.concat(n.implicit)),n.explicit&&(i=i.concat(n.explicit));else throw new Tn("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");o.forEach(function(t){if(!(t instanceof Gt))throw new Tn("Specified list of YAML types (or a single Type object) contains a non-Type object.");if(t.loadKind&&t.loadKind!=="scalar")throw new Tn("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");if(t.multi)throw new Tn("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.")}),i.forEach(function(t){if(!(t instanceof Gt))throw new Tn("Specified list of YAML types (or a single Type object) contains a non-Type object.")});var r=Object.create(Kt.prototype);return r.implicit=(this.implicit||[]).concat(o),r.explicit=(this.explicit||[]).concat(i),r.compiledImplicit=ga(r,"implicit"),r.compiledExplicit=ga(r,"explicit"),r.compiledTypeMap=rp(r.compiledImplicit,r.compiledExplicit),r};xa.exports=Kt});var Qt=v((sg,Pa)=>{"use strict";var op=V();Pa.exports=new op("tag:yaml.org,2002:str",{kind:"scalar",construct:function(e){return e!==null?e:""}})});var Xt=v((ug,ba)=>{"use strict";var ap=V();ba.exports=new ap("tag:yaml.org,2002:seq",{kind:"sequence",construct:function(e){return e!==null?e:[]}})});var Zt=v((cg,Oa)=>{"use strict";var ip=V();Oa.exports=new ip("tag:yaml.org,2002:map",{kind:"mapping",construct:function(e){return e!==null?e:{}}})});var er=v((pg,wa)=>{"use strict";var lp=zt();wa.exports=new lp({explicit:[Qt(),Xt(),Zt()]})});var nr=v((fg,ka)=>{"use strict";var sp=V();function up(e){if(e===null)return!0;var n=e.length;return n===1&&e==="~"||n===4&&(e==="null"||e==="Null"||e==="NULL")}function cp(){return null}function pp(e){return e===null}ka.exports=new sp("tag:yaml.org,2002:null",{kind:"scalar",resolve:up,construct:cp,predicate:pp,represent:{canonical:function(){return"~"},lowercase:function(){return"null"},uppercase:function(){return"NULL"},camelcase:function(){return"Null"},empty:function(){return""}},defaultStyle:"lowercase"})});var tr=v((mg,Ca)=>{"use strict";var fp=V();function mp(e){if(e===null)return!1;var n=e.length;return n===4&&(e==="true"||e==="True"||e==="TRUE")||n===5&&(e==="false"||e==="False"||e==="FALSE")}function dp(e){return e==="true"||e==="True"||e==="TRUE"}function hp(e){return Object.prototype.toString.call(e)==="[object Boolean]"}Ca.exports=new fp("tag:yaml.org,2002:bool",{kind:"scalar",resolve:mp,construct:dp,predicate:hp,represent:{lowercase:function(e){return e?"true":"false"},uppercase:function(e){return e?"TRUE":"FALSE"},camelcase:function(e){return e?"True":"False"}},defaultStyle:"lowercase"})});var rr=v((dg,Sa)=>{"use strict";var yp=cn(),vp=V();function gp(e){return 48<=e&&e<=57||65<=e&&e<=70||97<=e&&e<=102}function xp(e){return 48<=e&&e<=55}function Pp(e){return 48<=e&&e<=57}function bp(e){if(e===null)return!1;var n=e.length,o=0,i=!1,r;if(!n)return!1;if(r=e[o],(r==="-"||r==="+")&&(r=e[++o]),r==="0"){if(o+1===n)return!0;if(r=e[++o],r==="b"){for(o++;o<n;o++)if(r=e[o],r!=="_"){if(r!=="0"&&r!=="1")return!1;i=!0}return i&&r!=="_"}if(r==="x"){for(o++;o<n;o++)if(r=e[o],r!=="_"){if(!gp(e.charCodeAt(o)))return!1;i=!0}return i&&r!=="_"}if(r==="o"){for(o++;o<n;o++)if(r=e[o],r!=="_"){if(!xp(e.charCodeAt(o)))return!1;i=!0}return i&&r!=="_"}}if(r==="_")return!1;for(;o<n;o++)if(r=e[o],r!=="_"){if(!Pp(e.charCodeAt(o)))return!1;i=!0}return!(!i||r==="_")}function Op(e){var n=e,o=1,i;if(n.indexOf("_")!==-1&&(n=n.replace(/_/g,"")),i=n[0],(i==="-"||i==="+")&&(i==="-"&&(o=-1),n=n.slice(1),i=n[0]),n==="0")return 0;if(i==="0"){if(n[1]==="b")return o*parseInt(n.slice(2),2);if(n[1]==="x")return o*parseInt(n.slice(2),16);if(n[1]==="o")return o*parseInt(n.slice(2),8)}return o*parseInt(n,10)}function wp(e){return Object.prototype.toString.call(e)==="[object Number]"&&e%1===0&&!yp.isNegativeZero(e)}Sa.exports=new vp("tag:yaml.org,2002:int",{kind:"scalar",resolve:bp,construct:Op,predicate:wp,represent:{binary:function(e){return e>=0?"0b"+e.toString(2):"-0b"+e.toString(2).slice(1)},octal:function(e){return e>=0?"0o"+e.toString(8):"-0o"+e.toString(8).slice(1)},decimal:function(e){return e.toString(10)},hexadecimal:function(e){return e>=0?"0x"+e.toString(16).toUpperCase():"-0x"+e.toString(16).toUpperCase().slice(1)}},defaultStyle:"decimal",styleAliases:{binary:[2,"bin"],octal:[8,"oct"],decimal:[10,"dec"],hexadecimal:[16,"hex"]}})});var or=v((hg,Ra)=>{"use strict";var Ea=cn(),kp=V(),Cp=new RegExp("^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");function Sp(e){return!(e===null||!Cp.test(e)||e[e.length-1]==="_")}function Ep(e){var n,o;return n=e.replace(/_/g,"").toLowerCase(),o=n[0]==="-"?-1:1,"+-".indexOf(n[0])>=0&&(n=n.slice(1)),n===".inf"?o===1?Number.POSITIVE_INFINITY:Number.NEGATIVE_INFINITY:n===".nan"?NaN:o*parseFloat(n,10)}var Rp=/^[-+]?[0-9]+e/;function qp(e,n){var o;if(isNaN(e))switch(n){case"lowercase":return".nan";case"uppercase":return".NAN";case"camelcase":return".NaN"}else if(Number.POSITIVE_INFINITY===e)switch(n){case"lowercase":return".inf";case"uppercase":return".INF";case"camelcase":return".Inf"}else if(Number.NEGATIVE_INFINITY===e)switch(n){case"lowercase":return"-.inf";case"uppercase":return"-.INF";case"camelcase":return"-.Inf"}else if(Ea.isNegativeZero(e))return"-0.0";return o=e.toString(10),Rp.test(o)?o.replace("e",".e"):o}function Ap(e){return Object.prototype.toString.call(e)==="[object Number]"&&(e%1!==0||Ea.isNegativeZero(e))}Ra.exports=new kp("tag:yaml.org,2002:float",{kind:"scalar",resolve:Sp,construct:Ep,predicate:Ap,represent:qp,defaultStyle:"lowercase"})});var ar=v((yg,qa)=>{"use strict";qa.exports=er().extend({implicit:[nr(),tr(),rr(),or()]})});var ir=v((vg,Aa)=>{"use strict";Aa.exports=ar()});var lr=v((gg,_a)=>{"use strict";var Tp=V(),Ta=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"),Ia=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");function Ip(e){return e===null?!1:Ta.exec(e)!==null||Ia.exec(e)!==null}function _p(e){var n,o,i,r,t,a,l,s=0,u=null,p,c,f;if(n=Ta.exec(e),n===null&&(n=Ia.exec(e)),n===null)throw new Error("Date resolve error");if(o=+n[1],i=+n[2]-1,r=+n[3],!n[4])return new Date(Date.UTC(o,i,r));if(t=+n[4],a=+n[5],l=+n[6],n[7]){for(s=n[7].slice(0,3);s.length<3;)s+="0";s=+s}return n[9]&&(p=+n[10],c=+(n[11]||0),u=(p*60+c)*6e4,n[9]==="-"&&(u=-u)),f=new Date(Date.UTC(o,i,r,t,a,l,s)),u&&f.setTime(f.getTime()-u),f}function jp(e){return e.toISOString()}_a.exports=new Tp("tag:yaml.org,2002:timestamp",{kind:"scalar",resolve:Ip,construct:_p,instanceOf:Date,represent:jp})});var sr=v((xg,ja)=>{"use strict";var Dp=V();function Np(e){return e==="<<"||e===null}ja.exports=new Dp("tag:yaml.org,2002:merge",{kind:"scalar",resolve:Np})});var cr=v((Pg,Da)=>{"use strict";var Hp=V(),ur=`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=
+\r`;function Fp(e){if(e===null)return!1;var n,o,i=0,r=e.length,t=ur;for(o=0;o<r;o++)if(n=t.indexOf(e.charAt(o)),!(n>64)){if(n<0)return!1;i+=6}return i%8===0}function $p(e){var n,o,i=e.replace(/[\r\n=]/g,""),r=i.length,t=ur,a=0,l=[];for(n=0;n<r;n++)n%4===0&&n&&(l.push(a>>16&255),l.push(a>>8&255),l.push(a&255)),a=a<<6|t.indexOf(i.charAt(n));return o=r%4*6,o===0?(l.push(a>>16&255),l.push(a>>8&255),l.push(a&255)):o===18?(l.push(a>>10&255),l.push(a>>2&255)):o===12&&l.push(a>>4&255),new Uint8Array(l)}function Lp(e){var n="",o=0,i,r,t=e.length,a=ur;for(i=0;i<t;i++)i%3===0&&i&&(n+=a[o>>18&63],n+=a[o>>12&63],n+=a[o>>6&63],n+=a[o&63]),o=(o<<8)+e[i];return r=t%3,r===0?(n+=a[o>>18&63],n+=a[o>>12&63],n+=a[o>>6&63],n+=a[o&63]):r===2?(n+=a[o>>10&63],n+=a[o>>4&63],n+=a[o<<2&63],n+=a[64]):r===1&&(n+=a[o>>2&63],n+=a[o<<4&63],n+=a[64],n+=a[64]),n}function Mp(e){return Object.prototype.toString.call(e)==="[object Uint8Array]"}Da.exports=new Hp("tag:yaml.org,2002:binary",{kind:"scalar",resolve:Fp,construct:$p,predicate:Mp,represent:Lp})});var pr=v((bg,Na)=>{"use strict";var Bp=V(),Up=Object.prototype.hasOwnProperty,Wp=Object.prototype.toString;function Vp(e){if(e===null)return!0;var n=[],o,i,r,t,a,l=e;for(o=0,i=l.length;o<i;o+=1){if(r=l[o],a=!1,Wp.call(r)!=="[object Object]")return!1;for(t in r)if(Up.call(r,t))if(!a)a=!0;else return!1;if(!a)return!1;if(n.indexOf(t)===-1)n.push(t);else return!1}return!0}function Yp(e){return e!==null?e:[]}Na.exports=new Bp("tag:yaml.org,2002:omap",{kind:"sequence",resolve:Vp,construct:Yp})});var fr=v((Og,Ha)=>{"use strict";var Jp=V(),Gp=Object.prototype.toString;function Kp(e){if(e===null)return!0;var n,o,i,r,t,a=e;for(t=new Array(a.length),n=0,o=a.length;n<o;n+=1){if(i=a[n],Gp.call(i)!=="[object Object]"||(r=Object.keys(i),r.length!==1))return!1;t[n]=[r[0],i[r[0]]]}return!0}function zp(e){if(e===null)return[];var n,o,i,r,t,a=e;for(t=new Array(a.length),n=0,o=a.length;n<o;n+=1)i=a[n],r=Object.keys(i),t[n]=[r[0],i[r[0]]];return t}Ha.exports=new Jp("tag:yaml.org,2002:pairs",{kind:"sequence",resolve:Kp,construct:zp})});var mr=v((wg,Fa)=>{"use strict";var Qp=V(),Xp=Object.prototype.hasOwnProperty;function Zp(e){if(e===null)return!0;var n,o=e;for(n in o)if(Xp.call(o,n)&&o[n]!==null)return!1;return!0}function ef(e){return e!==null?e:{}}Fa.exports=new Qp("tag:yaml.org,2002:set",{kind:"mapping",resolve:Zp,construct:ef})});var st=v((kg,$a)=>{"use strict";$a.exports=ir().extend({implicit:[lr(),sr()],explicit:[cr(),pr(),fr(),mr()]})});var ni=v((Cg,vr)=>{"use strict";var Je=cn(),Ya=pn(),nf=ha(),tf=st(),Fe=Object.prototype.hasOwnProperty,ut=1,Ja=2,Ga=3,ct=4,dr=1,rf=2,La=3,of=/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/,af=/[\x85\u2028\u2029]/,lf=/[,\[\]\{\}]/,Ka=/^(?:!|!!|![a-z\-]+!)$/i,za=/^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;function Ma(e){return Object.prototype.toString.call(e)}function ge(e){return e===10||e===13}function Ge(e){return e===9||e===32}function ne(e){return e===9||e===32||e===10||e===13}function fn(e){return e===44||e===91||e===93||e===123||e===125}function sf(e){var n;return 48<=e&&e<=57?e-48:(n=e|32,97<=n&&n<=102?n-97+10:-1)}function uf(e){return e===120?2:e===117?4:e===85?8:0}function cf(e){return 48<=e&&e<=57?e-48:-1}function Ba(e){return e===48?"\0":e===97?"\x07":e===98?"\b":e===116||e===9?"	":e===110?`
+`:e===118?"\v":e===102?"\f":e===114?"\r":e===101?"\x1B":e===32?" ":e===34?'"':e===47?"/":e===92?"\\":e===78?"\x85":e===95?"\xA0":e===76?"\u2028":e===80?"\u2029":""}function pf(e){return e<=65535?String.fromCharCode(e):String.fromCharCode((e-65536>>10)+55296,(e-65536&1023)+56320)}var Qa=new Array(256),Xa=new Array(256);for(Ye=0;Ye<256;Ye++)Qa[Ye]=Ba(Ye)?1:0,Xa[Ye]=Ba(Ye);var Ye;function ff(e,n){this.input=e,this.filename=n.filename||null,this.schema=n.schema||tf,this.onWarning=n.onWarning||null,this.legacy=n.legacy||!1,this.json=n.json||!1,this.listener=n.listener||null,this.implicitTypes=this.schema.compiledImplicit,this.typeMap=this.schema.compiledTypeMap,this.length=e.length,this.position=0,this.line=0,this.lineStart=0,this.lineIndent=0,this.firstTabInLine=-1,this.documents=[]}function Za(e,n){var o={name:e.filename,buffer:e.input.slice(0,-1),position:e.position,line:e.line,column:e.position-e.lineStart};return o.snippet=nf(o),new Ya(n,o)}function O(e,n){throw Za(e,n)}function pt(e,n){e.onWarning&&e.onWarning.call(null,Za(e,n))}var Ua={YAML:function(n,o,i){var r,t,a;n.version!==null&&O(n,"duplication of %YAML directive"),i.length!==1&&O(n,"YAML directive accepts exactly one argument"),r=/^([0-9]+)\.([0-9]+)$/.exec(i[0]),r===null&&O(n,"ill-formed argument of the YAML directive"),t=parseInt(r[1],10),a=parseInt(r[2],10),t!==1&&O(n,"unacceptable YAML version of the document"),n.version=i[0],n.checkLineBreaks=a<2,a!==1&&a!==2&&pt(n,"unsupported YAML version of the document")},TAG:function(n,o,i){var r,t;i.length!==2&&O(n,"TAG directive accepts exactly two arguments"),r=i[0],t=i[1],Ka.test(r)||O(n,"ill-formed tag handle (first argument) of the TAG directive"),Fe.call(n.tagMap,r)&&O(n,'there is a previously declared suffix for "'+r+'" tag handle'),za.test(t)||O(n,"ill-formed tag prefix (second argument) of the TAG directive");try{t=decodeURIComponent(t)}catch{O(n,"tag prefix is malformed: "+t)}n.tagMap[r]=t}};function He(e,n,o,i){var r,t,a,l;if(n<o){if(l=e.input.slice(n,o),i)for(r=0,t=l.length;r<t;r+=1)a=l.charCodeAt(r),a===9||32<=a&&a<=1114111||O(e,"expected valid JSON character");else of.test(l)&&O(e,"the stream contains non-printable characters");e.result+=l}}function Wa(e,n,o,i){var r,t,a,l;for(Je.isObject(o)||O(e,"cannot merge mappings; the provided source object is unacceptable"),r=Object.keys(o),a=0,l=r.length;a<l;a+=1)t=r[a],Fe.call(n,t)||(n[t]=o[t],i[t]=!0)}function mn(e,n,o,i,r,t,a,l,s){var u,p;if(Array.isArray(r))for(r=Array.prototype.slice.call(r),u=0,p=r.length;u<p;u+=1)Array.isArray(r[u])&&O(e,"nested arrays are not supported inside keys"),typeof r=="object"&&Ma(r[u])==="[object Object]"&&(r[u]="[object Object]");if(typeof r=="object"&&Ma(r)==="[object Object]"&&(r="[object Object]"),r=String(r),n===null&&(n={}),i==="tag:yaml.org,2002:merge")if(Array.isArray(t))for(u=0,p=t.length;u<p;u+=1)Wa(e,n,t[u],o);else Wa(e,n,t,o);else!e.json&&!Fe.call(o,r)&&Fe.call(n,r)&&(e.line=a||e.line,e.lineStart=l||e.lineStart,e.position=s||e.position,O(e,"duplicated mapping key")),r==="__proto__"?Object.defineProperty(n,r,{configurable:!0,enumerable:!0,writable:!0,value:t}):n[r]=t,delete o[r];return n}function hr(e){var n;n=e.input.charCodeAt(e.position),n===10?e.position++:n===13?(e.position++,e.input.charCodeAt(e.position)===10&&e.position++):O(e,"a line break is expected"),e.line+=1,e.lineStart=e.position,e.firstTabInLine=-1}function $(e,n,o){for(var i=0,r=e.input.charCodeAt(e.position);r!==0;){for(;Ge(r);)r===9&&e.firstTabInLine===-1&&(e.firstTabInLine=e.position),r=e.input.charCodeAt(++e.position);if(n&&r===35)do r=e.input.charCodeAt(++e.position);while(r!==10&&r!==13&&r!==0);if(ge(r))for(hr(e),r=e.input.charCodeAt(e.position),i++,e.lineIndent=0;r===32;)e.lineIndent++,r=e.input.charCodeAt(++e.position);else break}return o!==-1&&i!==0&&e.lineIndent<o&&pt(e,"deficient indentation"),i}function ft(e){var n=e.position,o;return o=e.input.charCodeAt(n),!!((o===45||o===46)&&o===e.input.charCodeAt(n+1)&&o===e.input.charCodeAt(n+2)&&(n+=3,o=e.input.charCodeAt(n),o===0||ne(o)))}function yr(e,n){n===1?e.result+=" ":n>1&&(e.result+=Je.repeat(`
+`,n-1))}function mf(e,n,o){var i,r,t,a,l,s,u,p,c=e.kind,f=e.result,m;if(m=e.input.charCodeAt(e.position),ne(m)||fn(m)||m===35||m===38||m===42||m===33||m===124||m===62||m===39||m===34||m===37||m===64||m===96||(m===63||m===45)&&(r=e.input.charCodeAt(e.position+1),ne(r)||o&&fn(r)))return!1;for(e.kind="scalar",e.result="",t=a=e.position,l=!1;m!==0;){if(m===58){if(r=e.input.charCodeAt(e.position+1),ne(r)||o&&fn(r))break}else if(m===35){if(i=e.input.charCodeAt(e.position-1),ne(i))break}else{if(e.position===e.lineStart&&ft(e)||o&&fn(m))break;if(ge(m))if(s=e.line,u=e.lineStart,p=e.lineIndent,$(e,!1,-1),e.lineIndent>=n){l=!0,m=e.input.charCodeAt(e.position);continue}else{e.position=a,e.line=s,e.lineStart=u,e.lineIndent=p;break}}l&&(He(e,t,a,!1),yr(e,e.line-s),t=a=e.position,l=!1),Ge(m)||(a=e.position+1),m=e.input.charCodeAt(++e.position)}return He(e,t,a,!1),e.result?!0:(e.kind=c,e.result=f,!1)}function df(e,n){var o,i,r;if(o=e.input.charCodeAt(e.position),o!==39)return!1;for(e.kind="scalar",e.result="",e.position++,i=r=e.position;(o=e.input.charCodeAt(e.position))!==0;)if(o===39)if(He(e,i,e.position,!0),o=e.input.charCodeAt(++e.position),o===39)i=e.position,e.position++,r=e.position;else return!0;else ge(o)?(He(e,i,r,!0),yr(e,$(e,!1,n)),i=r=e.position):e.position===e.lineStart&&ft(e)?O(e,"unexpected end of the document within a single quoted scalar"):(e.position++,r=e.position);O(e,"unexpected end of the stream within a single quoted scalar")}function hf(e,n){var o,i,r,t,a,l;if(l=e.input.charCodeAt(e.position),l!==34)return!1;for(e.kind="scalar",e.result="",e.position++,o=i=e.position;(l=e.input.charCodeAt(e.position))!==0;){if(l===34)return He(e,o,e.position,!0),e.position++,!0;if(l===92){if(He(e,o,e.position,!0),l=e.input.charCodeAt(++e.position),ge(l))$(e,!1,n);else if(l<256&&Qa[l])e.result+=Xa[l],e.position++;else if((a=uf(l))>0){for(r=a,t=0;r>0;r--)l=e.input.charCodeAt(++e.position),(a=sf(l))>=0?t=(t<<4)+a:O(e,"expected hexadecimal character");e.result+=pf(t),e.position++}else O(e,"unknown escape sequence");o=i=e.position}else ge(l)?(He(e,o,i,!0),yr(e,$(e,!1,n)),o=i=e.position):e.position===e.lineStart&&ft(e)?O(e,"unexpected end of the document within a double quoted scalar"):(e.position++,i=e.position)}O(e,"unexpected end of the stream within a double quoted scalar")}function yf(e,n){var o=!0,i,r,t,a=e.tag,l,s=e.anchor,u,p,c,f,m,d=Object.create(null),y,g,P,x;if(x=e.input.charCodeAt(e.position),x===91)p=93,m=!1,l=[];else if(x===123)p=125,m=!0,l={};else return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=l),x=e.input.charCodeAt(++e.position);x!==0;){if($(e,!0,n),x=e.input.charCodeAt(e.position),x===p)return e.position++,e.tag=a,e.anchor=s,e.kind=m?"mapping":"sequence",e.result=l,!0;o?x===44&&O(e,"expected the node content, but found ','"):O(e,"missed comma between flow collection entries"),g=y=P=null,c=f=!1,x===63&&(u=e.input.charCodeAt(e.position+1),ne(u)&&(c=f=!0,e.position++,$(e,!0,n))),i=e.line,r=e.lineStart,t=e.position,dn(e,n,ut,!1,!0),g=e.tag,y=e.result,$(e,!0,n),x=e.input.charCodeAt(e.position),(f||e.line===i)&&x===58&&(c=!0,x=e.input.charCodeAt(++e.position),$(e,!0,n),dn(e,n,ut,!1,!0),P=e.result),m?mn(e,l,d,g,y,P,i,r,t):c?l.push(mn(e,null,d,g,y,P,i,r,t)):l.push(y),$(e,!0,n),x=e.input.charCodeAt(e.position),x===44?(o=!0,x=e.input.charCodeAt(++e.position)):o=!1}O(e,"unexpected end of the stream within a flow collection")}function vf(e,n){var o,i,r=dr,t=!1,a=!1,l=n,s=0,u=!1,p,c;if(c=e.input.charCodeAt(e.position),c===124)i=!1;else if(c===62)i=!0;else return!1;for(e.kind="scalar",e.result="";c!==0;)if(c=e.input.charCodeAt(++e.position),c===43||c===45)dr===r?r=c===43?La:rf:O(e,"repeat of a chomping mode identifier");else if((p=cf(c))>=0)p===0?O(e,"bad explicit indentation width of a block scalar; it cannot be less than one"):a?O(e,"repeat of an indentation width identifier"):(l=n+p-1,a=!0);else break;if(Ge(c)){do c=e.input.charCodeAt(++e.position);while(Ge(c));if(c===35)do c=e.input.charCodeAt(++e.position);while(!ge(c)&&c!==0)}for(;c!==0;){for(hr(e),e.lineIndent=0,c=e.input.charCodeAt(e.position);(!a||e.lineIndent<l)&&c===32;)e.lineIndent++,c=e.input.charCodeAt(++e.position);if(!a&&e.lineIndent>l&&(l=e.lineIndent),ge(c)){s++;continue}if(e.lineIndent<l){r===La?e.result+=Je.repeat(`
+`,t?1+s:s):r===dr&&t&&(e.result+=`
+`);break}for(i?Ge(c)?(u=!0,e.result+=Je.repeat(`
+`,t?1+s:s)):u?(u=!1,e.result+=Je.repeat(`
+`,s+1)):s===0?t&&(e.result+=" "):e.result+=Je.repeat(`
+`,s):e.result+=Je.repeat(`
+`,t?1+s:s),t=!0,a=!0,s=0,o=e.position;!ge(c)&&c!==0;)c=e.input.charCodeAt(++e.position);He(e,o,e.position,!1)}return!0}function Va(e,n){var o,i=e.tag,r=e.anchor,t=[],a,l=!1,s;if(e.firstTabInLine!==-1)return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=t),s=e.input.charCodeAt(e.position);s!==0&&(e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,O(e,"tab characters must not be used in indentation")),!(s!==45||(a=e.input.charCodeAt(e.position+1),!ne(a))));){if(l=!0,e.position++,$(e,!0,-1)&&e.lineIndent<=n){t.push(null),s=e.input.charCodeAt(e.position);continue}if(o=e.line,dn(e,n,Ga,!1,!0),t.push(e.result),$(e,!0,-1),s=e.input.charCodeAt(e.position),(e.line===o||e.lineIndent>n)&&s!==0)O(e,"bad indentation of a sequence entry");else if(e.lineIndent<n)break}return l?(e.tag=i,e.anchor=r,e.kind="sequence",e.result=t,!0):!1}function gf(e,n,o){var i,r,t,a,l,s,u=e.tag,p=e.anchor,c={},f=Object.create(null),m=null,d=null,y=null,g=!1,P=!1,x;if(e.firstTabInLine!==-1)return!1;for(e.anchor!==null&&(e.anchorMap[e.anchor]=c),x=e.input.charCodeAt(e.position);x!==0;){if(!g&&e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,O(e,"tab characters must not be used in indentation")),i=e.input.charCodeAt(e.position+1),t=e.line,(x===63||x===58)&&ne(i))x===63?(g&&(mn(e,c,f,m,d,null,a,l,s),m=d=y=null),P=!0,g=!0,r=!0):g?(g=!1,r=!0):O(e,"incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line"),e.position+=1,x=i;else{if(a=e.line,l=e.lineStart,s=e.position,!dn(e,o,Ja,!1,!0))break;if(e.line===t){for(x=e.input.charCodeAt(e.position);Ge(x);)x=e.input.charCodeAt(++e.position);if(x===58)x=e.input.charCodeAt(++e.position),ne(x)||O(e,"a whitespace character is expected after the key-value separator within a block mapping"),g&&(mn(e,c,f,m,d,null,a,l,s),m=d=y=null),P=!0,g=!1,r=!1,m=e.tag,d=e.result;else if(P)O(e,"can not read an implicit mapping pair; a colon is missed");else return e.tag=u,e.anchor=p,!0}else if(P)O(e,"can not read a block mapping entry; a multiline key may not be an implicit key");else return e.tag=u,e.anchor=p,!0}if((e.line===t||e.lineIndent>n)&&(g&&(a=e.line,l=e.lineStart,s=e.position),dn(e,n,ct,!0,r)&&(g?d=e.result:y=e.result),g||(mn(e,c,f,m,d,y,a,l,s),m=d=y=null),$(e,!0,-1),x=e.input.charCodeAt(e.position)),(e.line===t||e.lineIndent>n)&&x!==0)O(e,"bad indentation of a mapping entry");else if(e.lineIndent<n)break}return g&&mn(e,c,f,m,d,null,a,l,s),P&&(e.tag=u,e.anchor=p,e.kind="mapping",e.result=c),P}function xf(e){var n,o=!1,i=!1,r,t,a;if(a=e.input.charCodeAt(e.position),a!==33)return!1;if(e.tag!==null&&O(e,"duplication of a tag property"),a=e.input.charCodeAt(++e.position),a===60?(o=!0,a=e.input.charCodeAt(++e.position)):a===33?(i=!0,r="!!",a=e.input.charCodeAt(++e.position)):r="!",n=e.position,o){do a=e.input.charCodeAt(++e.position);while(a!==0&&a!==62);e.position<e.length?(t=e.input.slice(n,e.position),a=e.input.charCodeAt(++e.position)):O(e,"unexpected end of the stream within a verbatim tag")}else{for(;a!==0&&!ne(a);)a===33&&(i?O(e,"tag suffix cannot contain exclamation marks"):(r=e.input.slice(n-1,e.position+1),Ka.test(r)||O(e,"named tag handle cannot contain such characters"),i=!0,n=e.position+1)),a=e.input.charCodeAt(++e.position);t=e.input.slice(n,e.position),lf.test(t)&&O(e,"tag suffix cannot contain flow indicator characters")}t&&!za.test(t)&&O(e,"tag name cannot contain such characters: "+t);try{t=decodeURIComponent(t)}catch{O(e,"tag name is malformed: "+t)}return o?e.tag=t:Fe.call(e.tagMap,r)?e.tag=e.tagMap[r]+t:r==="!"?e.tag="!"+t:r==="!!"?e.tag="tag:yaml.org,2002:"+t:O(e,'undeclared tag handle "'+r+'"'),!0}function Pf(e){var n,o;if(o=e.input.charCodeAt(e.position),o!==38)return!1;for(e.anchor!==null&&O(e,"duplication of an anchor property"),o=e.input.charCodeAt(++e.position),n=e.position;o!==0&&!ne(o)&&!fn(o);)o=e.input.charCodeAt(++e.position);return e.position===n&&O(e,"name of an anchor node must contain at least one character"),e.anchor=e.input.slice(n,e.position),!0}function bf(e){var n,o,i;if(i=e.input.charCodeAt(e.position),i!==42)return!1;for(i=e.input.charCodeAt(++e.position),n=e.position;i!==0&&!ne(i)&&!fn(i);)i=e.input.charCodeAt(++e.position);return e.position===n&&O(e,"name of an alias node must contain at least one character"),o=e.input.slice(n,e.position),Fe.call(e.anchorMap,o)||O(e,'unidentified alias "'+o+'"'),e.result=e.anchorMap[o],$(e,!0,-1),!0}function dn(e,n,o,i,r){var t,a,l,s=1,u=!1,p=!1,c,f,m,d,y,g;if(e.listener!==null&&e.listener("open",e),e.tag=null,e.anchor=null,e.kind=null,e.result=null,t=a=l=ct===o||Ga===o,i&&$(e,!0,-1)&&(u=!0,e.lineIndent>n?s=1:e.lineIndent===n?s=0:e.lineIndent<n&&(s=-1)),s===1)for(;xf(e)||Pf(e);)$(e,!0,-1)?(u=!0,l=t,e.lineIndent>n?s=1:e.lineIndent===n?s=0:e.lineIndent<n&&(s=-1)):l=!1;if(l&&(l=u||r),(s===1||ct===o)&&(ut===o||Ja===o?y=n:y=n+1,g=e.position-e.lineStart,s===1?l&&(Va(e,g)||gf(e,g,y))||yf(e,y)?p=!0:(a&&vf(e,y)||df(e,y)||hf(e,y)?p=!0:bf(e)?(p=!0,(e.tag!==null||e.anchor!==null)&&O(e,"alias node should not have any properties")):mf(e,y,ut===o)&&(p=!0,e.tag===null&&(e.tag="?")),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):s===0&&(p=l&&Va(e,g))),e.tag===null)e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);else if(e.tag==="?"){for(e.result!==null&&e.kind!=="scalar"&&O(e,'unacceptable node kind for !<?> tag; it should be "scalar", not "'+e.kind+'"'),c=0,f=e.implicitTypes.length;c<f;c+=1)if(d=e.implicitTypes[c],d.resolve(e.result)){e.result=d.construct(e.result),e.tag=d.tag,e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);break}}else if(e.tag!=="!"){if(Fe.call(e.typeMap[e.kind||"fallback"],e.tag))d=e.typeMap[e.kind||"fallback"][e.tag];else for(d=null,m=e.typeMap.multi[e.kind||"fallback"],c=0,f=m.length;c<f;c+=1)if(e.tag.slice(0,m[c].tag.length)===m[c].tag){d=m[c];break}d||O(e,"unknown tag !<"+e.tag+">"),e.result!==null&&d.kind!==e.kind&&O(e,"unacceptable node kind for !<"+e.tag+'> tag; it should be "'+d.kind+'", not "'+e.kind+'"'),d.resolve(e.result,e.tag)?(e.result=d.construct(e.result,e.tag),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):O(e,"cannot resolve a node with !<"+e.tag+"> explicit tag")}return e.listener!==null&&e.listener("close",e),e.tag!==null||e.anchor!==null||p}function Of(e){var n=e.position,o,i,r,t=!1,a;for(e.version=null,e.checkLineBreaks=e.legacy,e.tagMap=Object.create(null),e.anchorMap=Object.create(null);(a=e.input.charCodeAt(e.position))!==0&&($(e,!0,-1),a=e.input.charCodeAt(e.position),!(e.lineIndent>0||a!==37));){for(t=!0,a=e.input.charCodeAt(++e.position),o=e.position;a!==0&&!ne(a);)a=e.input.charCodeAt(++e.position);for(i=e.input.slice(o,e.position),r=[],i.length<1&&O(e,"directive name must not be less than one character in length");a!==0;){for(;Ge(a);)a=e.input.charCodeAt(++e.position);if(a===35){do a=e.input.charCodeAt(++e.position);while(a!==0&&!ge(a));break}if(ge(a))break;for(o=e.position;a!==0&&!ne(a);)a=e.input.charCodeAt(++e.position);r.push(e.input.slice(o,e.position))}a!==0&&hr(e),Fe.call(Ua,i)?Ua[i](e,i,r):pt(e,'unknown document directive "'+i+'"')}if($(e,!0,-1),e.lineIndent===0&&e.input.charCodeAt(e.position)===45&&e.input.charCodeAt(e.position+1)===45&&e.input.charCodeAt(e.position+2)===45?(e.position+=3,$(e,!0,-1)):t&&O(e,"directives end mark is expected"),dn(e,e.lineIndent-1,ct,!1,!0),$(e,!0,-1),e.checkLineBreaks&&af.test(e.input.slice(n,e.position))&&pt(e,"non-ASCII line breaks are interpreted as content"),e.documents.push(e.result),e.position===e.lineStart&&ft(e)){e.input.charCodeAt(e.position)===46&&(e.position+=3,$(e,!0,-1));return}if(e.position<e.length-1)O(e,"end of the stream or a document separator is expected");else return}function ei(e,n){e=String(e),n=n||{},e.length!==0&&(e.charCodeAt(e.length-1)!==10&&e.charCodeAt(e.length-1)!==13&&(e+=`
+`),e.charCodeAt(0)===65279&&(e=e.slice(1)));var o=new ff(e,n),i=e.indexOf("\0");for(i!==-1&&(o.position=i,O(o,"null byte is not allowed in input")),o.input+="\0";o.input.charCodeAt(o.position)===32;)o.lineIndent+=1,o.position+=1;for(;o.position<o.length-1;)Of(o);return o.documents}function wf(e,n,o){n!==null&&typeof n=="object"&&typeof o>"u"&&(o=n,n=null);var i=ei(e,o);if(typeof n!="function")return i;for(var r=0,t=i.length;r<t;r+=1)n(i[r])}function kf(e,n){var o=ei(e,n);if(o.length!==0){if(o.length===1)return o[0];throw new Ya("expected a single document in the stream, but found more")}}vr.exports.loadAll=wf;vr.exports.load=kf});var Oi=v((Sg,bi)=>{"use strict";var ht=cn(),Nn=pn(),Cf=st(),ci=Object.prototype.toString,pi=Object.prototype.hasOwnProperty,Or=65279,Sf=9,_n=10,Ef=13,Rf=32,qf=33,Af=34,gr=35,Tf=37,If=38,_f=39,jf=42,fi=44,Df=45,mt=58,Nf=61,Hf=62,Ff=63,$f=64,mi=91,di=93,Lf=96,hi=123,Mf=124,yi=125,Y={};Y[0]="\\0";Y[7]="\\a";Y[8]="\\b";Y[9]="\\t";Y[10]="\\n";Y[11]="\\v";Y[12]="\\f";Y[13]="\\r";Y[27]="\\e";Y[34]='\\"';Y[92]="\\\\";Y[133]="\\N";Y[160]="\\_";Y[8232]="\\L";Y[8233]="\\P";var Bf=["y","Y","yes","Yes","YES","on","On","ON","n","N","no","No","NO","off","Off","OFF"],Uf=/^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;function Wf(e,n){var o,i,r,t,a,l,s;if(n===null)return{};for(o={},i=Object.keys(n),r=0,t=i.length;r<t;r+=1)a=i[r],l=String(n[a]),a.slice(0,2)==="!!"&&(a="tag:yaml.org,2002:"+a.slice(2)),s=e.compiledTypeMap.fallback[a],s&&pi.call(s.styleAliases,l)&&(l=s.styleAliases[l]),o[a]=l;return o}function Vf(e){var n,o,i;if(n=e.toString(16).toUpperCase(),e<=255)o="x",i=2;else if(e<=65535)o="u",i=4;else if(e<=4294967295)o="U",i=8;else throw new Nn("code point within a string may not be greater than 0xFFFFFFFF");return"\\"+o+ht.repeat("0",i-n.length)+n}var Yf=1,jn=2;function Jf(e){this.schema=e.schema||Cf,this.indent=Math.max(1,e.indent||2),this.noArrayIndent=e.noArrayIndent||!1,this.skipInvalid=e.skipInvalid||!1,this.flowLevel=ht.isNothing(e.flowLevel)?-1:e.flowLevel,this.styleMap=Wf(this.schema,e.styles||null),this.sortKeys=e.sortKeys||!1,this.lineWidth=e.lineWidth||80,this.noRefs=e.noRefs||!1,this.noCompatMode=e.noCompatMode||!1,this.condenseFlow=e.condenseFlow||!1,this.quotingType=e.quotingType==='"'?jn:Yf,this.forceQuotes=e.forceQuotes||!1,this.replacer=typeof e.replacer=="function"?e.replacer:null,this.implicitTypes=this.schema.compiledImplicit,this.explicitTypes=this.schema.compiledExplicit,this.tag=null,this.result="",this.duplicates=[],this.usedDuplicates=null}function ti(e,n){for(var o=ht.repeat(" ",n),i=0,r=-1,t="",a,l=e.length;i<l;)r=e.indexOf(`
+`,i),r===-1?(a=e.slice(i),i=l):(a=e.slice(i,r+1),i=r+1),a.length&&a!==`
+`&&(t+=o),t+=a;return t}function xr(e,n){return`
+`+ht.repeat(" ",e.indent*n)}function Gf(e,n){var o,i,r;for(o=0,i=e.implicitTypes.length;o<i;o+=1)if(r=e.implicitTypes[o],r.resolve(n))return!0;return!1}function dt(e){return e===Rf||e===Sf}function Dn(e){return 32<=e&&e<=126||161<=e&&e<=55295&&e!==8232&&e!==8233||57344<=e&&e<=65533&&e!==Or||65536<=e&&e<=1114111}function ri(e){return Dn(e)&&e!==Or&&e!==Ef&&e!==_n}function oi(e,n,o){var i=ri(e),r=i&&!dt(e);return(o?i:i&&e!==fi&&e!==mi&&e!==di&&e!==hi&&e!==yi)&&e!==gr&&!(n===mt&&!r)||ri(n)&&!dt(n)&&e===gr||n===mt&&r}function Kf(e){return Dn(e)&&e!==Or&&!dt(e)&&e!==Df&&e!==Ff&&e!==mt&&e!==fi&&e!==mi&&e!==di&&e!==hi&&e!==yi&&e!==gr&&e!==If&&e!==jf&&e!==qf&&e!==Mf&&e!==Nf&&e!==Hf&&e!==_f&&e!==Af&&e!==Tf&&e!==$f&&e!==Lf}function zf(e){return!dt(e)&&e!==mt}function In(e,n){var o=e.charCodeAt(n),i;return o>=55296&&o<=56319&&n+1<e.length&&(i=e.charCodeAt(n+1),i>=56320&&i<=57343)?(o-55296)*1024+i-56320+65536:o}function vi(e){var n=/^\n* /;return n.test(e)}var gi=1,Pr=2,xi=3,Pi=4,hn=5;function Qf(e,n,o,i,r,t,a,l){var s,u=0,p=null,c=!1,f=!1,m=i!==-1,d=-1,y=Kf(In(e,0))&&zf(In(e,e.length-1));if(n||a)for(s=0;s<e.length;u>=65536?s+=2:s++){if(u=In(e,s),!Dn(u))return hn;y=y&&oi(u,p,l),p=u}else{for(s=0;s<e.length;u>=65536?s+=2:s++){if(u=In(e,s),u===_n)c=!0,m&&(f=f||s-d-1>i&&e[d+1]!==" ",d=s);else if(!Dn(u))return hn;y=y&&oi(u,p,l),p=u}f=f||m&&s-d-1>i&&e[d+1]!==" "}return!c&&!f?y&&!a&&!r(e)?gi:t===jn?hn:Pr:o>9&&vi(e)?hn:a?t===jn?hn:Pr:f?Pi:xi}function Xf(e,n,o,i,r){e.dump=function(){if(n.length===0)return e.quotingType===jn?'""':"''";if(!e.noCompatMode&&(Bf.indexOf(n)!==-1||Uf.test(n)))return e.quotingType===jn?'"'+n+'"':"'"+n+"'";var t=e.indent*Math.max(1,o),a=e.lineWidth===-1?-1:Math.max(Math.min(e.lineWidth,40),e.lineWidth-t),l=i||e.flowLevel>-1&&o>=e.flowLevel;function s(u){return Gf(e,u)}switch(Qf(n,l,e.indent,a,s,e.quotingType,e.forceQuotes&&!i,r)){case gi:return n;case Pr:return"'"+n.replace(/'/g,"''")+"'";case xi:return"|"+ai(n,e.indent)+ii(ti(n,t));case Pi:return">"+ai(n,e.indent)+ii(ti(Zf(n,a),t));case hn:return'"'+em(n,a)+'"';default:throw new Nn("impossible error: invalid scalar style")}}()}function ai(e,n){var o=vi(e)?String(n):"",i=e[e.length-1]===`
+`,r=i&&(e[e.length-2]===`
+`||e===`
+`),t=r?"+":i?"":"-";return o+t+`
+`}function ii(e){return e[e.length-1]===`
+`?e.slice(0,-1):e}function Zf(e,n){for(var o=/(\n+)([^\n]*)/g,i=function(){var u=e.indexOf(`
+`);return u=u!==-1?u:e.length,o.lastIndex=u,li(e.slice(0,u),n)}(),r=e[0]===`
+`||e[0]===" ",t,a;a=o.exec(e);){var l=a[1],s=a[2];t=s[0]===" ",i+=l+(!r&&!t&&s!==""?`
+`:"")+li(s,n),r=t}return i}function li(e,n){if(e===""||e[0]===" ")return e;for(var o=/ [^ ]/g,i,r=0,t,a=0,l=0,s="";i=o.exec(e);)l=i.index,l-r>n&&(t=a>r?a:l,s+=`
+`+e.slice(r,t),r=t+1),a=l;return s+=`
+`,e.length-r>n&&a>r?s+=e.slice(r,a)+`
+`+e.slice(a+1):s+=e.slice(r),s.slice(1)}function em(e){for(var n="",o=0,i,r=0;r<e.length;o>=65536?r+=2:r++)o=In(e,r),i=Y[o],!i&&Dn(o)?(n+=e[r],o>=65536&&(n+=e[r+1])):n+=i||Vf(o);return n}function nm(e,n,o){var i="",r=e.tag,t,a,l;for(t=0,a=o.length;t<a;t+=1)l=o[t],e.replacer&&(l=e.replacer.call(o,String(t),l)),(ke(e,n,l,!1,!1)||typeof l>"u"&&ke(e,n,null,!1,!1))&&(i!==""&&(i+=","+(e.condenseFlow?"":" ")),i+=e.dump);e.tag=r,e.dump="["+i+"]"}function si(e,n,o,i){var r="",t=e.tag,a,l,s;for(a=0,l=o.length;a<l;a+=1)s=o[a],e.replacer&&(s=e.replacer.call(o,String(a),s)),(ke(e,n+1,s,!0,!0,!1,!0)||typeof s>"u"&&ke(e,n+1,null,!0,!0,!1,!0))&&((!i||r!=="")&&(r+=xr(e,n)),e.dump&&_n===e.dump.charCodeAt(0)?r+="-":r+="- ",r+=e.dump);e.tag=t,e.dump=r||"[]"}function tm(e,n,o){var i="",r=e.tag,t=Object.keys(o),a,l,s,u,p;for(a=0,l=t.length;a<l;a+=1)p="",i!==""&&(p+=", "),e.condenseFlow&&(p+='"'),s=t[a],u=o[s],e.replacer&&(u=e.replacer.call(o,s,u)),ke(e,n,s,!1,!1)&&(e.dump.length>1024&&(p+="? "),p+=e.dump+(e.condenseFlow?'"':"")+":"+(e.condenseFlow?"":" "),ke(e,n,u,!1,!1)&&(p+=e.dump,i+=p));e.tag=r,e.dump="{"+i+"}"}function rm(e,n,o,i){var r="",t=e.tag,a=Object.keys(o),l,s,u,p,c,f;if(e.sortKeys===!0)a.sort();else if(typeof e.sortKeys=="function")a.sort(e.sortKeys);else if(e.sortKeys)throw new Nn("sortKeys must be a boolean or a function");for(l=0,s=a.length;l<s;l+=1)f="",(!i||r!=="")&&(f+=xr(e,n)),u=a[l],p=o[u],e.replacer&&(p=e.replacer.call(o,u,p)),ke(e,n+1,u,!0,!0,!0)&&(c=e.tag!==null&&e.tag!=="?"||e.dump&&e.dump.length>1024,c&&(e.dump&&_n===e.dump.charCodeAt(0)?f+="?":f+="? "),f+=e.dump,c&&(f+=xr(e,n)),ke(e,n+1,p,!0,c)&&(e.dump&&_n===e.dump.charCodeAt(0)?f+=":":f+=": ",f+=e.dump,r+=f));e.tag=t,e.dump=r||"{}"}function ui(e,n,o){var i,r,t,a,l,s;for(r=o?e.explicitTypes:e.implicitTypes,t=0,a=r.length;t<a;t+=1)if(l=r[t],(l.instanceOf||l.predicate)&&(!l.instanceOf||typeof n=="object"&&n instanceof l.instanceOf)&&(!l.predicate||l.predicate(n))){if(o?l.multi&&l.representName?e.tag=l.representName(n):e.tag=l.tag:e.tag="?",l.represent){if(s=e.styleMap[l.tag]||l.defaultStyle,ci.call(l.represent)==="[object Function]")i=l.represent(n,s);else if(pi.call(l.represent,s))i=l.represent[s](n,s);else throw new Nn("!<"+l.tag+'> tag resolver accepts not "'+s+'" style');e.dump=i}return!0}return!1}function ke(e,n,o,i,r,t,a){e.tag=null,e.dump=o,ui(e,o,!1)||ui(e,o,!0);var l=ci.call(e.dump),s=i,u;i&&(i=e.flowLevel<0||e.flowLevel>n);var p=l==="[object Object]"||l==="[object Array]",c,f;if(p&&(c=e.duplicates.indexOf(o),f=c!==-1),(e.tag!==null&&e.tag!=="?"||f||e.indent!==2&&n>0)&&(r=!1),f&&e.usedDuplicates[c])e.dump="*ref_"+c;else{if(p&&f&&!e.usedDuplicates[c]&&(e.usedDuplicates[c]=!0),l==="[object Object]")i&&Object.keys(e.dump).length!==0?(rm(e,n,e.dump,r),f&&(e.dump="&ref_"+c+e.dump)):(tm(e,n,e.dump),f&&(e.dump="&ref_"+c+" "+e.dump));else if(l==="[object Array]")i&&e.dump.length!==0?(e.noArrayIndent&&!a&&n>0?si(e,n-1,e.dump,r):si(e,n,e.dump,r),f&&(e.dump="&ref_"+c+e.dump)):(nm(e,n,e.dump),f&&(e.dump="&ref_"+c+" "+e.dump));else if(l==="[object String]")e.tag!=="?"&&Xf(e,e.dump,n,t,s);else{if(l==="[object Undefined]")return!1;if(e.skipInvalid)return!1;throw new Nn("unacceptable kind of an object to dump "+l)}e.tag!==null&&e.tag!=="?"&&(u=encodeURI(e.tag[0]==="!"?e.tag.slice(1):e.tag).replace(/!/g,"%21"),e.tag[0]==="!"?u="!"+u:u.slice(0,18)==="tag:yaml.org,2002:"?u="!!"+u.slice(18):u="!<"+u+">",e.dump=u+" "+e.dump)}return!0}function om(e,n){var o=[],i=[],r,t;for(br(e,o,i),r=0,t=i.length;r<t;r+=1)n.duplicates.push(o[i[r]]);n.usedDuplicates=new Array(t)}function br(e,n,o){var i,r,t;if(e!==null&&typeof e=="object")if(r=n.indexOf(e),r!==-1)o.indexOf(r)===-1&&o.push(r);else if(n.push(e),Array.isArray(e))for(r=0,t=e.length;r<t;r+=1)br(e[r],n,o);else for(i=Object.keys(e),r=0,t=i.length;r<t;r+=1)br(e[i[r]],n,o)}function am(e,n){n=n||{};var o=new Jf(n);o.noRefs||om(e,o);var i=e;return o.replacer&&(i=o.replacer.call({"":i},"",i)),ke(o,0,i,!0,!0)?o.dump+`
+`:""}bi.exports.dump=am});var ki=v((Eg,K)=>{"use strict";var wi=ni(),im=Oi();function wr(e,n){return function(){throw new Error("Function yaml."+e+" is removed in js-yaml 4. Use yaml."+n+" instead, which is now safe by default.")}}K.exports.Type=V();K.exports.Schema=zt();K.exports.FAILSAFE_SCHEMA=er();K.exports.JSON_SCHEMA=ar();K.exports.CORE_SCHEMA=ir();K.exports.DEFAULT_SCHEMA=st();K.exports.load=wi.load;K.exports.loadAll=wi.loadAll;K.exports.dump=im.dump;K.exports.YAMLException=pn();K.exports.types={binary:cr(),float:or(),map:Zt(),null:nr(),pairs:fr(),set:mr(),timestamp:lr(),bool:tr(),int:rr(),merge:sr(),omap:pr(),seq:Xt(),str:Qt()};K.exports.safeLoad=wr("safeLoad","load");K.exports.safeLoadAll=wr("safeLoadAll","loadAll");K.exports.safeDump=wr("safeDump","dump")});var Si=v((Rg,Ci)=>{"use strict";var{ParserError:lm}=pe(),sm=ki();Ci.exports={order:200,allowEmpty:!0,canParse:[".yaml",".yml",".json"],async parse(e){let n=e.data;if(Buffer.isBuffer(n)&&(n=n.toString()),typeof n=="string")try{return sm.load(n)}catch(o){throw new lm(o.message,e.url)}else return n}}});var Ri=v((qg,Ei)=>{"use strict";var{ParserError:um}=pe(),cm=/\.(txt|htm|html|md|xml|js|min|map|css|scss|less|svg)$/i;Ei.exports={order:300,allowEmpty:!0,encoding:"utf8",canParse(e){return(typeof e.data=="string"||Buffer.isBuffer(e.data))&&cm.test(e.url)},parse(e){if(typeof e.data=="string")return e.data;if(Buffer.isBuffer(e.data))return e.data.toString(this.encoding);throw new um("data is not text",e.url)}}});var Ai=v((Ag,qi)=>{"use strict";var pm=/\.(jpeg|jpg|gif|png|bmp|ico)$/i;qi.exports={order:400,allowEmpty:!0,canParse(e){return Buffer.isBuffer(e.data)&&pm.test(e.url)},parse(e){return Buffer.isBuffer(e.data)?e.data:Buffer.from(e.data)}}});var _i=v((Tg,Ii)=>{"use strict";var fm=require("fs"),{ono:kr}=Te(),Ti=ie(),{ResolverError:Cr}=pe();Ii.exports={order:100,canRead(e){return Ti.isFileSystemPath(e.url)},read(e){return new Promise((n,o)=>{let i;try{i=Ti.toFileSystemPath(e.url)}catch(r){o(new Cr(kr.uri(r,`Malformed URI: ${e.url}`),e.url))}try{fm.readFile(i,(r,t)=>{r?o(new Cr(kr(r,`Error opening file "${i}"`),i)):n(t)})}catch(r){o(new Cr(kr(r,`Error opening file "${i}"`),i))}})}}});var Hi=v((Ig,Ni)=>{"use strict";var mm=require("http"),dm=require("https"),{ono:yt}=Te(),Hn=ie(),{ResolverError:ji}=pe();Ni.exports={order:200,headers:null,timeout:5e3,redirects:5,withCredentials:!1,canRead(e){return Hn.isHttp(e.url)},read(e){let n=Hn.parse(e.url);return process.browser&&!n.protocol&&(n.protocol=Hn.parse(location.href).protocol),Di(n,this)}};function Di(e,n,o){return new Promise((i,r)=>{e=Hn.parse(e),o=o||[],o.push(e.href),hm(e,n).then(t=>{if(t.statusCode>=400)throw yt({status:t.statusCode},`HTTP ERROR ${t.statusCode}`);if(t.statusCode>=300)if(o.length>n.redirects)r(new ji(yt({status:t.statusCode},`Error downloading ${o[0]}. 
+Too many redirects: 
+  ${o.join(` 
+  `)}`)));else if(t.headers.location){let a=Hn.resolve(e,t.headers.location);Di(a,n,o).then(i,r)}else throw yt({status:t.statusCode},`HTTP ${t.statusCode} redirect with no location header`);else i(t.body||Buffer.alloc(0))}).catch(t=>{r(new ji(yt(t,`Error downloading ${e.href}`),e.href))})})}function hm(e,n){return new Promise((o,i)=>{let t=(e.protocol==="https:"?dm:mm).get({hostname:e.hostname,port:e.port,path:e.path,auth:e.auth,protocol:e.protocol,headers:n.headers||{},withCredentials:n.withCredentials});typeof t.setTimeout=="function"&&t.setTimeout(n.timeout),t.on("timeout",()=>{t.abort()}),t.on("error",i),t.once("response",a=>{a.body=Buffer.alloc(0),a.on("data",l=>{a.body=Buffer.concat([a.body,Buffer.from(l)])}),a.on("error",i),a.on("end",()=>{o(a)})})})}});var Li=v((_g,$i)=>{"use strict";var ym=ca(),vm=Si(),gm=Ri(),xm=Ai(),Pm=_i(),bm=Hi();$i.exports=Er;function Er(e){Sr(this,Er.defaults),Sr(this,e)}Er.defaults={parse:{json:ym,yaml:vm,text:gm,binary:xm},resolve:{file:Pm,http:bm,external:!0},continueOnError:!1,dereference:{circular:!0}};function Sr(e,n){if(Fi(n)){let o=Object.keys(n);for(let i=0;i<o.length;i++){let r=o[i],t=n[r],a=e[r];Fi(t)?e[r]=Sr(a||{},t):t!==void 0&&(e[r]=t)}}return e}function Fi(e){return e&&typeof e=="object"&&!Array.isArray(e)&&!(e instanceof RegExp)&&!(e instanceof Date)}});var Ui=v((jg,Bi)=>{"use strict";var Mi=Li();Bi.exports=Om;function Om(e){let n,o,i,r;return e=Array.prototype.slice.call(e),typeof e[e.length-1]=="function"&&(r=e.pop()),typeof e[0]=="string"?(n=e[0],typeof e[2]=="object"?(o=e[1],i=e[2]):(o=void 0,i=e[1])):(n="",o=e[0],i=e[1]),i instanceof Mi||(i=new Mi(i)),{path:n,schema:o,options:i,callback:r}}});var Ji=v((Dg,Yi)=>{"use strict";var Wi=un(),wm=En(),km=Vt(),Fn=ie(),{isHandledError:Cm}=pe();Yi.exports=Sm;function Sm(e,n){if(!n.resolve.external)return Promise.resolve();try{let o=Rr(e.schema,e.$refs._root$Ref.path+"#",e.$refs,n);return Promise.all(o)}catch(o){return Promise.reject(o)}}function Rr(e,n,o,i,r){r=r||new Set;let t=[];if(e&&typeof e=="object"&&!ArrayBuffer.isView(e)&&!r.has(e))if(r.add(e),Wi.isExternal$Ref(e))t.push(Vi(e,n,o,i));else for(let a of Object.keys(e)){let l=wm.join(n,a),s=e[a];Wi.isExternal$Ref(s)?t.push(Vi(s,l,o,i)):t=t.concat(Rr(s,l,o,i,r))}return t}async function Vi(e,n,o,i){let r=Fn.resolve(n,e.$ref),t=Fn.stripHash(r);if(e=o._$refs[t],e)return Promise.resolve(e.value);try{let a=await km(r,o,i),l=Rr(a,t+"#",o,i);return Promise.all(l)}catch(a){if(!i.continueOnError||!Cm(a))throw a;return o._$refs[t]&&(a.source=Fn.stripHash(n),a.path=Fn.safePointerToPath(Fn.getHash(n))),[]}}});var zi=v((Ng,Ki)=>{"use strict";var vt=un(),$n=En(),qr=ie();Ki.exports=Em;function Em(e,n){let o=[];Ar(e,"schema",e.$refs._root$Ref.path+"#","#",0,o,e.$refs,n),Rm(o)}function Ar(e,n,o,i,r,t,a,l){let s=n===null?e:e[n];if(s&&typeof s=="object"&&!ArrayBuffer.isView(s))if(vt.isAllowed$Ref(s))Gi(e,n,o,i,r,t,a,l);else{let u=Object.keys(s).sort((p,c)=>p==="definitions"?-1:c==="definitions"?1:p.length-c.length);for(let p of u){let c=$n.join(o,p),f=$n.join(i,p),m=s[p];vt.isAllowed$Ref(m)?Gi(s,p,o,f,r,t,a,l):Ar(s,p,c,f,r,t,a,l)}}}function Gi(e,n,o,i,r,t,a,l){let s=n===null?e:e[n],u=qr.resolve(o,s.$ref),p=a._resolve(u,i,l);if(p===null)return;let c=$n.parse(i).length,f=qr.stripHash(p.path),m=qr.getHash(p.path),d=f!==a._root$Ref.path,y=vt.isExtended$Ref(s);r+=p.indirections;let g=qm(t,e,n);if(g)if(c<g.depth||r<g.indirections)Am(t,g);else return;t.push({$ref:s,parent:e,key:n,pathFromRoot:i,depth:c,file:f,hash:m,value:p.value,circular:p.circular,extended:y,external:d,indirections:r}),g||Ar(p.value,null,p.path,i,r+1,t,a,l)}function Rm(e){e.sort((r,t)=>{if(r.file!==t.file)return r.file<t.file?-1:1;if(r.hash!==t.hash)return r.hash<t.hash?-1:1;if(r.circular!==t.circular)return r.circular?-1:1;if(r.extended!==t.extended)return r.extended?1:-1;if(r.indirections!==t.indirections)return r.indirections-t.indirections;if(r.depth!==t.depth)return r.depth-t.depth;{let a=r.pathFromRoot.lastIndexOf("/definitions"),l=t.pathFromRoot.lastIndexOf("/definitions");return a!==l?l-a:r.pathFromRoot.length-t.pathFromRoot.length}});let n,o,i;for(let r of e)r.external?r.file===n&&r.hash===o?r.$ref.$ref=i:r.file===n&&r.hash.indexOf(o+"/")===0?r.$ref.$ref=$n.join(i,$n.parse(r.hash.replace(o,"#"))):(n=r.file,o=r.hash,i=r.pathFromRoot,r.$ref=r.parent[r.key]=vt.dereference(r.$ref,r.value),r.circular&&(r.$ref.$ref=r.pathFromRoot)):r.$ref.$ref=r.hash}function qm(e,n,o){for(let i=0;i<e.length;i++){let r=e[i];if(r.parent===n&&r.key===o)return r}}function Am(e,n){let o=e.indexOf(n);e.splice(o,1)}});var nl=v((Hg,el)=>{"use strict";var Tr=un(),Qi=En(),{ono:Tm}=Te(),Im=ie();el.exports=_m;function _m(e,n){let o=Ir(e.schema,e.$refs._root$Ref.path,"#",new Set,new Set,new Map,e.$refs,n);e.$refs.circular=o.circular,e.schema=o.value}function Ir(e,n,o,i,r,t,a,l){let s,u={value:e,circular:!1};if((l.dereference.circular==="ignore"||!r.has(e))&&e&&typeof e=="object"&&!ArrayBuffer.isView(e)){if(i.add(e),r.add(e),Tr.isAllowed$Ref(e,l))s=Xi(e,n,o,i,r,t,a,l),u.circular=s.circular,u.value=s.value;else for(let p of Object.keys(e)){let c=Qi.join(n,p),f=Qi.join(o,p),m=e[p],d=!1;Tr.isAllowed$Ref(m,l)?(s=Xi(m,c,f,i,r,t,a,l),d=s.circular,e[p]!==s.value&&(e[p]=s.value)):i.has(m)?d=Zi(c,a,l):(s=Ir(m,c,f,i,r,t,a,l),d=s.circular,e[p]!==s.value&&(e[p]=s.value)),u.circular=u.circular||d}i.delete(e)}return u}function Xi(e,n,o,i,r,t,a,l){let s=Im.resolve(n,e.$ref),u=t.get(s);if(u){let y=Object.keys(e);if(y.length>1){let g={};for(let P of y)P!=="$ref"&&!(P in u.value)&&(g[P]=e[P]);return{circular:u.circular,value:Object.assign({},u.value,g)}}return u}let p=a._resolve(s,n,l);if(p===null)return{circular:!1,value:null};let c=p.circular,f=c||i.has(p.value);f&&Zi(n,a,l);let m=Tr.dereference(e,p.value);if(!f){let y=Ir(m,p.path,o,i,r,t,a,l);f=y.circular,m=y.value}f&&!c&&l.dereference.circular==="ignore"&&(m=e),c&&(m.$ref=o);let d={circular:f,value:m};return Object.keys(e).length===1&&t.set(s,d),d}function Zi(e,n,o){if(n.circular=!0,!o.dereference.circular)throw Tm.reference(`Circular $ref pointer found at ${e}`);return!0}});var rl=v((Fg,tl)=>{"use strict";function jm(){return typeof process=="object"&&typeof process.nextTick=="function"?process.nextTick:typeof setImmediate=="function"?setImmediate:function(n){setTimeout(n,0)}}tl.exports=jm()});var il=v(($g,al)=>{"use strict";var ol=rl();al.exports=function(n,o){if(n){o.then(function(i){ol(function(){n(null,i)})},function(i){ol(function(){n(i)})});return}else return o}});var cl=v((Lg,Pe)=>{"use strict";var ul=ta(),Dm=Vt(),gt=Ui(),Nm=Ji(),Hm=zi(),Fm=nl(),yn=ie(),{JSONParserError:$m,InvalidPointerError:Lm,MissingPointerError:Mm,ResolverError:Bm,ParserError:Um,UnmatchedParserError:Wm,UnmatchedResolverError:Vm,isHandledError:Ym,JSONParserErrorGroup:ll}=pe(),me=il(),{ono:sl}=Te();Pe.exports=xe;Pe.exports.default=xe;Pe.exports.JSONParserError=$m;Pe.exports.InvalidPointerError=Lm;Pe.exports.MissingPointerError=Mm;Pe.exports.ResolverError=Bm;Pe.exports.ParserError=Um;Pe.exports.UnmatchedParserError=Wm;Pe.exports.UnmatchedResolverError=Vm;function xe(){this.schema=null,this.$refs=new ul}xe.parse=function(n,o,i,r){let t=this,a=new t;return a.parse.apply(a,arguments)};xe.prototype.parse=async function(n,o,i,r){let t=gt(arguments),a;if(!t.path&&!t.schema){let u=sl(`Expected a file path, URL, or object. Got ${t.path||t.schema}`);return me(t.callback,Promise.reject(u))}this.schema=null,this.$refs=new ul;let l="http";if(yn.isFileSystemPath(t.path)&&(t.path=yn.fromFileSystemPath(t.path),l="file"),t.path=yn.resolve(yn.cwd(),t.path),t.schema&&typeof t.schema=="object"){let u=this.$refs._add(t.path);u.value=t.schema,u.pathType=l,a=Promise.resolve(t.schema)}else a=Dm(t.path,this.$refs,t.options);let s=this;try{let u=await a;if(u!==null&&typeof u=="object"&&!Buffer.isBuffer(u))return s.schema=u,me(t.callback,Promise.resolve(s.schema));if(t.options.continueOnError)return s.schema=null,me(t.callback,Promise.resolve(s.schema));throw sl.syntax(`"${s.$refs._root$Ref.path||u}" is not a valid JSON Schema`)}catch(u){return!t.options.continueOnError||!Ym(u)?me(t.callback,Promise.reject(u)):(this.$refs._$refs[yn.stripHash(t.path)]&&this.$refs._$refs[yn.stripHash(t.path)].addError(u),me(t.callback,Promise.resolve(null)))}};xe.resolve=function(n,o,i,r){let t=this,a=new t;return a.resolve.apply(a,arguments)};xe.prototype.resolve=async function(n,o,i,r){let t=this,a=gt(arguments);try{return await this.parse(a.path,a.schema,a.options),await Nm(t,a.options),_r(t),me(a.callback,Promise.resolve(t.$refs))}catch(l){return me(a.callback,Promise.reject(l))}};xe.bundle=function(n,o,i,r){let t=this,a=new t;return a.bundle.apply(a,arguments)};xe.prototype.bundle=async function(n,o,i,r){let t=this,a=gt(arguments);try{return await this.resolve(a.path,a.schema,a.options),Hm(t,a.options),_r(t),me(a.callback,Promise.resolve(t.schema))}catch(l){return me(a.callback,Promise.reject(l))}};xe.dereference=function(n,o,i,r){let t=this,a=new t;return a.dereference.apply(a,arguments)};xe.prototype.dereference=async function(n,o,i,r){let t=this,a=gt(arguments);try{return await this.resolve(a.path,a.schema,a.options),Fm(t,a.options),_r(t),me(a.callback,Promise.resolve(t.schema))}catch(l){return me(a.callback,Promise.reject(l))}};function _r(e){if(ll.getParserErrors(e).length>0)throw new ll(e)}});var fl=v((Mg,pl)=>{"use strict";pl.exports=cl()});var M=v(jr=>{"use strict";jr.fromCallback=function(e){return Object.defineProperty(function(...n){if(typeof n[n.length-1]=="function")e.apply(this,n);else return new Promise((o,i)=>{n.push((r,t)=>r!=null?i(r):o(t)),e.apply(this,n)})},"name",{value:e.name})};jr.fromPromise=function(e){return Object.defineProperty(function(...n){let o=n[n.length-1];if(typeof o!="function")return e.apply(this,n);n.pop(),e.apply(this,n).then(i=>o(null,i),o)},"name",{value:e.name})}});var dl=v((Ug,ml)=>{var $e=require("constants"),Jm=process.cwd,xt=null,Gm=process.env.GRACEFUL_FS_PLATFORM||process.platform;process.cwd=function(){return xt||(xt=Jm.call(process)),xt};try{process.cwd()}catch{}typeof process.chdir=="function"&&(Dr=process.chdir,process.chdir=function(e){xt=null,Dr.call(process,e)},Object.setPrototypeOf&&Object.setPrototypeOf(process.chdir,Dr));var Dr;ml.exports=Km;function Km(e){$e.hasOwnProperty("O_SYMLINK")&&process.version.match(/^v0\.6\.[0-2]|^v0\.5\./)&&n(e),e.lutimes||o(e),e.chown=t(e.chown),e.fchown=t(e.fchown),e.lchown=t(e.lchown),e.chmod=i(e.chmod),e.fchmod=i(e.fchmod),e.lchmod=i(e.lchmod),e.chownSync=a(e.chownSync),e.fchownSync=a(e.fchownSync),e.lchownSync=a(e.lchownSync),e.chmodSync=r(e.chmodSync),e.fchmodSync=r(e.fchmodSync),e.lchmodSync=r(e.lchmodSync),e.stat=l(e.stat),e.fstat=l(e.fstat),e.lstat=l(e.lstat),e.statSync=s(e.statSync),e.fstatSync=s(e.fstatSync),e.lstatSync=s(e.lstatSync),e.chmod&&!e.lchmod&&(e.lchmod=function(p,c,f){f&&process.nextTick(f)},e.lchmodSync=function(){}),e.chown&&!e.lchown&&(e.lchown=function(p,c,f,m){m&&process.nextTick(m)},e.lchownSync=function(){}),Gm==="win32"&&(e.rename=typeof e.rename!="function"?e.rename:function(p){function c(f,m,d){var y=Date.now(),g=0;p(f,m,function P(x){if(x&&(x.code==="EACCES"||x.code==="EPERM"||x.code==="EBUSY")&&Date.now()-y<6e4){setTimeout(function(){e.stat(m,function(S,L){S&&S.code==="ENOENT"?p(f,m,P):d(x)})},g),g<100&&(g+=10);return}d&&d(x)})}return Object.setPrototypeOf&&Object.setPrototypeOf(c,p),c}(e.rename)),e.read=typeof e.read!="function"?e.read:function(p){function c(f,m,d,y,g,P){var x;if(P&&typeof P=="function"){var S=0;x=function(L,ae,_){if(L&&L.code==="EAGAIN"&&S<10)return S++,p.call(e,f,m,d,y,g,x);P.apply(this,arguments)}}return p.call(e,f,m,d,y,g,x)}return Object.setPrototypeOf&&Object.setPrototypeOf(c,p),c}(e.read),e.readSync=typeof e.readSync!="function"?e.readSync:function(p){return function(c,f,m,d,y){for(var g=0;;)try{return p.call(e,c,f,m,d,y)}catch(P){if(P.code==="EAGAIN"&&g<10){g++;continue}throw P}}}(e.readSync);function n(p){p.lchmod=function(c,f,m){p.open(c,$e.O_WRONLY|$e.O_SYMLINK,f,function(d,y){if(d){m&&m(d);return}p.fchmod(y,f,function(g){p.close(y,function(P){m&&m(g||P)})})})},p.lchmodSync=function(c,f){var m=p.openSync(c,$e.O_WRONLY|$e.O_SYMLINK,f),d=!0,y;try{y=p.fchmodSync(m,f),d=!1}finally{if(d)try{p.closeSync(m)}catch{}else p.closeSync(m)}return y}}function o(p){$e.hasOwnProperty("O_SYMLINK")&&p.futimes?(p.lutimes=function(c,f,m,d){p.open(c,$e.O_SYMLINK,function(y,g){if(y){d&&d(y);return}p.futimes(g,f,m,function(P){p.close(g,function(x){d&&d(P||x)})})})},p.lutimesSync=function(c,f,m){var d=p.openSync(c,$e.O_SYMLINK),y,g=!0;try{y=p.futimesSync(d,f,m),g=!1}finally{if(g)try{p.closeSync(d)}catch{}else p.closeSync(d)}return y}):p.futimes&&(p.lutimes=function(c,f,m,d){d&&process.nextTick(d)},p.lutimesSync=function(){})}function i(p){return p&&function(c,f,m){return p.call(e,c,f,function(d){u(d)&&(d=null),m&&m.apply(this,arguments)})}}function r(p){return p&&function(c,f){try{return p.call(e,c,f)}catch(m){if(!u(m))throw m}}}function t(p){return p&&function(c,f,m,d){return p.call(e,c,f,m,function(y){u(y)&&(y=null),d&&d.apply(this,arguments)})}}function a(p){return p&&function(c,f,m){try{return p.call(e,c,f,m)}catch(d){if(!u(d))throw d}}}function l(p){return p&&function(c,f,m){typeof f=="function"&&(m=f,f=null);function d(y,g){g&&(g.uid<0&&(g.uid+=4294967296),g.gid<0&&(g.gid+=4294967296)),m&&m.apply(this,arguments)}return f?p.call(e,c,f,d):p.call(e,c,d)}}function s(p){return p&&function(c,f){var m=f?p.call(e,c,f):p.call(e,c);return m&&(m.uid<0&&(m.uid+=4294967296),m.gid<0&&(m.gid+=4294967296)),m}}function u(p){if(!p||p.code==="ENOSYS")return!0;var c=!process.getuid||process.getuid()!==0;return!!(c&&(p.code==="EINVAL"||p.code==="EPERM"))}}});var vl=v((Wg,yl)=>{var hl=require("stream").Stream;yl.exports=zm;function zm(e){return{ReadStream:n,WriteStream:o};function n(i,r){if(!(this instanceof n))return new n(i,r);hl.call(this);var t=this;this.path=i,this.fd=null,this.readable=!0,this.paused=!1,this.flags="r",this.mode=438,this.bufferSize=64*1024,r=r||{};for(var a=Object.keys(r),l=0,s=a.length;l<s;l++){var u=a[l];this[u]=r[u]}if(this.encoding&&this.setEncoding(this.encoding),this.start!==void 0){if(typeof this.start!="number")throw TypeError("start must be a Number");if(this.end===void 0)this.end=1/0;else if(typeof this.end!="number")throw TypeError("end must be a Number");if(this.start>this.end)throw new Error("start must be <= end");this.pos=this.start}if(this.fd!==null){process.nextTick(function(){t._read()});return}e.open(this.path,this.flags,this.mode,function(p,c){if(p){t.emit("error",p),t.readable=!1;return}t.fd=c,t.emit("open",c),t._read()})}function o(i,r){if(!(this instanceof o))return new o(i,r);hl.call(this),this.path=i,this.fd=null,this.writable=!0,this.flags="w",this.encoding="binary",this.mode=438,this.bytesWritten=0,r=r||{};for(var t=Object.keys(r),a=0,l=t.length;a<l;a++){var s=t[a];this[s]=r[s]}if(this.start!==void 0){if(typeof this.start!="number")throw TypeError("start must be a Number");if(this.start<0)throw new Error("start must be >= zero");this.pos=this.start}this.busy=!1,this._queue=[],this.fd===null&&(this._open=e.open,this._queue.push([this._open,this.path,this.flags,this.mode,void 0]),this.flush())}}});var xl=v((Vg,gl)=>{"use strict";gl.exports=Xm;var Qm=Object.getPrototypeOf||function(e){return e.__proto__};function Xm(e){if(e===null||typeof e!="object")return e;if(e instanceof Object)var n={__proto__:Qm(e)};else var n=Object.create(null);return Object.getOwnPropertyNames(e).forEach(function(o){Object.defineProperty(n,o,Object.getOwnPropertyDescriptor(e,o))}),n}});var gn=v((Yg,Fr)=>{var D=require("fs"),Zm=dl(),ed=vl(),nd=xl(),Pt=require("util"),W,Ot;typeof Symbol=="function"&&typeof Symbol.for=="function"?(W=Symbol.for("graceful-fs.queue"),Ot=Symbol.for("graceful-fs.previous")):(W="___graceful-fs.queue",Ot="___graceful-fs.previous");function td(){}function Ol(e,n){Object.defineProperty(e,W,{get:function(){return n}})}var Ke=td;Pt.debuglog?Ke=Pt.debuglog("gfs4"):/\bgfs4\b/i.test(process.env.NODE_DEBUG||"")&&(Ke=function(){var e=Pt.format.apply(Pt,arguments);e="GFS4: "+e.split(/\n/).join(`
+GFS4: `),console.error(e)});D[W]||(Pl=global[W]||[],Ol(D,Pl),D.close=function(e){function n(o,i){return e.call(D,o,function(r){r||bl(),typeof i=="function"&&i.apply(this,arguments)})}return Object.defineProperty(n,Ot,{value:e}),n}(D.close),D.closeSync=function(e){function n(o){e.apply(D,arguments),bl()}return Object.defineProperty(n,Ot,{value:e}),n}(D.closeSync),/\bgfs4\b/i.test(process.env.NODE_DEBUG||"")&&process.on("exit",function(){Ke(D[W]),require("assert").equal(D[W].length,0)}));var Pl;global[W]||Ol(global,D[W]);Fr.exports=Nr(nd(D));process.env.TEST_GRACEFUL_FS_GLOBAL_PATCH&&!D.__patched&&(Fr.exports=Nr(D),D.__patched=!0);function Nr(e){Zm(e),e.gracefulify=Nr,e.createReadStream=ae,e.createWriteStream=_;var n=e.readFile;e.readFile=o;function o(b,w,k){return typeof w=="function"&&(k=w,w=null),E(b,w,k);function E(q,C,R,T){return n(q,C,function(A){A&&(A.code==="EMFILE"||A.code==="ENFILE")?vn([E,[q,C,R],A,T||Date.now(),Date.now()]):typeof R=="function"&&R.apply(this,arguments)})}}var i=e.writeFile;e.writeFile=r;function r(b,w,k,E){return typeof k=="function"&&(E=k,k=null),q(b,w,k,E);function q(C,R,T,A,U){return i(C,R,T,function(I){I&&(I.code==="EMFILE"||I.code==="ENFILE")?vn([q,[C,R,T,A],I,U||Date.now(),Date.now()]):typeof A=="function"&&A.apply(this,arguments)})}}var t=e.appendFile;t&&(e.appendFile=a);function a(b,w,k,E){return typeof k=="function"&&(E=k,k=null),q(b,w,k,E);function q(C,R,T,A,U){return t(C,R,T,function(I){I&&(I.code==="EMFILE"||I.code==="ENFILE")?vn([q,[C,R,T,A],I,U||Date.now(),Date.now()]):typeof A=="function"&&A.apply(this,arguments)})}}var l=e.copyFile;l&&(e.copyFile=s);function s(b,w,k,E){return typeof k=="function"&&(E=k,k=0),q(b,w,k,E);function q(C,R,T,A,U){return l(C,R,T,function(I){I&&(I.code==="EMFILE"||I.code==="ENFILE")?vn([q,[C,R,T,A],I,U||Date.now(),Date.now()]):typeof A=="function"&&A.apply(this,arguments)})}}var u=e.readdir;e.readdir=c;var p=/^v[0-5]\./;function c(b,w,k){typeof w=="function"&&(k=w,w=null);var E=p.test(process.version)?function(R,T,A,U){return u(R,q(R,T,A,U))}:function(R,T,A,U){return u(R,T,q(R,T,A,U))};return E(b,w,k);function q(C,R,T,A){return function(U,I){U&&(U.code==="EMFILE"||U.code==="ENFILE")?vn([E,[C,R,T],U,A||Date.now(),Date.now()]):(I&&I.sort&&I.sort(),typeof T=="function"&&T.call(this,U,I))}}}if(process.version.substr(0,4)==="v0.8"){var f=ed(e);P=f.ReadStream,S=f.WriteStream}var m=e.ReadStream;m&&(P.prototype=Object.create(m.prototype),P.prototype.open=x);var d=e.WriteStream;d&&(S.prototype=Object.create(d.prototype),S.prototype.open=L),Object.defineProperty(e,"ReadStream",{get:function(){return P},set:function(b){P=b},enumerable:!0,configurable:!0}),Object.defineProperty(e,"WriteStream",{get:function(){return S},set:function(b){S=b},enumerable:!0,configurable:!0});var y=P;Object.defineProperty(e,"FileReadStream",{get:function(){return y},set:function(b){y=b},enumerable:!0,configurable:!0});var g=S;Object.defineProperty(e,"FileWriteStream",{get:function(){return g},set:function(b){g=b},enumerable:!0,configurable:!0});function P(b,w){return this instanceof P?(m.apply(this,arguments),this):P.apply(Object.create(P.prototype),arguments)}function x(){var b=this;j(b.path,b.flags,b.mode,function(w,k){w?(b.autoClose&&b.destroy(),b.emit("error",w)):(b.fd=k,b.emit("open",k),b.read())})}function S(b,w){return this instanceof S?(d.apply(this,arguments),this):S.apply(Object.create(S.prototype),arguments)}function L(){var b=this;j(b.path,b.flags,b.mode,function(w,k){w?(b.destroy(),b.emit("error",w)):(b.fd=k,b.emit("open",k))})}function ae(b,w){return new e.ReadStream(b,w)}function _(b,w){return new e.WriteStream(b,w)}var F=e.open;e.open=j;function j(b,w,k,E){return typeof k=="function"&&(E=k,k=null),q(b,w,k,E);function q(C,R,T,A,U){return F(C,R,T,function(I,Tv){I&&(I.code==="EMFILE"||I.code==="ENFILE")?vn([q,[C,R,T,A],I,U||Date.now(),Date.now()]):typeof A=="function"&&A.apply(this,arguments)})}}return e}function vn(e){Ke("ENQUEUE",e[0].name,e[1]),D[W].push(e),Hr()}var bt;function bl(){for(var e=Date.now(),n=0;n<D[W].length;++n)D[W][n].length>2&&(D[W][n][3]=e,D[W][n][4]=e);Hr()}function Hr(){if(clearTimeout(bt),bt=void 0,D[W].length!==0){var e=D[W].shift(),n=e[0],o=e[1],i=e[2],r=e[3],t=e[4];if(r===void 0)Ke("RETRY",n.name,o),n.apply(null,o);else if(Date.now()-r>=6e4){Ke("TIMEOUT",n.name,o);var a=o.pop();typeof a=="function"&&a.call(null,i)}else{var l=Date.now()-t,s=Math.max(t-r,1),u=Math.min(s*1.2,100);l>=u?(Ke("RETRY",n.name,o),n.apply(null,o.concat([r]))):D[W].push(e)}bt===void 0&&(bt=setTimeout(Hr,0))}}});var Q=v(Ce=>{"use strict";var wl=M().fromCallback,z=gn(),rd=["access","appendFile","chmod","chown","close","copyFile","fchmod","fchown","fdatasync","fstat","fsync","ftruncate","futimes","lchmod","lchown","link","lstat","mkdir","mkdtemp","open","opendir","readdir","readFile","readlink","realpath","rename","rm","rmdir","stat","symlink","truncate","unlink","utimes","writeFile"].filter(e=>typeof z[e]=="function");Object.assign(Ce,z);rd.forEach(e=>{Ce[e]=wl(z[e])});Ce.exists=function(e,n){return typeof n=="function"?z.exists(e,n):new Promise(o=>z.exists(e,o))};Ce.read=function(e,n,o,i,r,t){return typeof t=="function"?z.read(e,n,o,i,r,t):new Promise((a,l)=>{z.read(e,n,o,i,r,(s,u,p)=>{if(s)return l(s);a({bytesRead:u,buffer:p})})})};Ce.write=function(e,n,...o){return typeof o[o.length-1]=="function"?z.write(e,n,...o):new Promise((i,r)=>{z.write(e,n,...o,(t,a,l)=>{if(t)return r(t);i({bytesWritten:a,buffer:l})})})};Ce.readv=function(e,n,...o){return typeof o[o.length-1]=="function"?z.readv(e,n,...o):new Promise((i,r)=>{z.readv(e,n,...o,(t,a,l)=>{if(t)return r(t);i({bytesRead:a,buffers:l})})})};Ce.writev=function(e,n,...o){return typeof o[o.length-1]=="function"?z.writev(e,n,...o):new Promise((i,r)=>{z.writev(e,n,...o,(t,a,l)=>{if(t)return r(t);i({bytesWritten:a,buffers:l})})})};typeof z.realpath.native=="function"?Ce.realpath.native=wl(z.realpath.native):process.emitWarning("fs.realpath.native is not a function. Is fs being monkey-patched?","Warning","fs-extra-WARN0003")});var Cl=v((Gg,kl)=>{"use strict";var od=require("path");kl.exports.checkPath=function(n){if(process.platform==="win32"&&/[<>:"|?*]/.test(n.replace(od.parse(n).root,""))){let i=new Error(`Path contains invalid characters: ${n}`);throw i.code="EINVAL",i}}});var ql=v((Kg,$r)=>{"use strict";var Sl=Q(),{checkPath:El}=Cl(),Rl=e=>{let n={mode:511};return typeof e=="number"?e:{...n,...e}.mode};$r.exports.makeDir=async(e,n)=>(El(e),Sl.mkdir(e,{mode:Rl(n),recursive:!0}));$r.exports.makeDirSync=(e,n)=>(El(e),Sl.mkdirSync(e,{mode:Rl(n),recursive:!0}))});var de=v((zg,Al)=>{"use strict";var ad=M().fromPromise,{makeDir:id,makeDirSync:Lr}=ql(),Mr=ad(id);Al.exports={mkdirs:Mr,mkdirsSync:Lr,mkdirp:Mr,mkdirpSync:Lr,ensureDir:Mr,ensureDirSync:Lr}});var Le=v((Qg,Il)=>{"use strict";var ld=M().fromPromise,Tl=Q();function sd(e){return Tl.access(e).then(()=>!0).catch(()=>!1)}Il.exports={pathExists:ld(sd),pathExistsSync:Tl.existsSync}});var Br=v((Xg,_l)=>{"use strict";var xn=Q(),ud=M().fromPromise;async function cd(e,n,o){let i=await xn.open(e,"r+"),r=null;try{await xn.futimes(i,n,o)}finally{try{await xn.close(i)}catch(t){r=t}}if(r)throw r}function pd(e,n,o){let i=xn.openSync(e,"r+");return xn.futimesSync(i,n,o),xn.closeSync(i)}_l.exports={utimesMillis:ud(cd),utimesMillisSync:pd}});var ze=v((Zg,Hl)=>{"use strict";var Pn=Q(),B=require("path"),jl=M().fromPromise;function fd(e,n,o){let i=o.dereference?r=>Pn.stat(r,{bigint:!0}):r=>Pn.lstat(r,{bigint:!0});return Promise.all([i(e),i(n).catch(r=>{if(r.code==="ENOENT")return null;throw r})]).then(([r,t])=>({srcStat:r,destStat:t}))}function md(e,n,o){let i,r=o.dereference?a=>Pn.statSync(a,{bigint:!0}):a=>Pn.lstatSync(a,{bigint:!0}),t=r(e);try{i=r(n)}catch(a){if(a.code==="ENOENT")return{srcStat:t,destStat:null};throw a}return{srcStat:t,destStat:i}}async function dd(e,n,o,i){let{srcStat:r,destStat:t}=await fd(e,n,i);if(t){if(Ln(r,t)){let a=B.basename(e),l=B.basename(n);if(o==="move"&&a!==l&&a.toLowerCase()===l.toLowerCase())return{srcStat:r,destStat:t,isChangingCase:!0};throw new Error("Source and destination must not be the same.")}if(r.isDirectory()&&!t.isDirectory())throw new Error(`Cannot overwrite non-directory '${n}' with directory '${e}'.`);if(!r.isDirectory()&&t.isDirectory())throw new Error(`Cannot overwrite directory '${n}' with non-directory '${e}'.`)}if(r.isDirectory()&&Ur(e,n))throw new Error(wt(e,n,o));return{srcStat:r,destStat:t}}function hd(e,n,o,i){let{srcStat:r,destStat:t}=md(e,n,i);if(t){if(Ln(r,t)){let a=B.basename(e),l=B.basename(n);if(o==="move"&&a!==l&&a.toLowerCase()===l.toLowerCase())return{srcStat:r,destStat:t,isChangingCase:!0};throw new Error("Source and destination must not be the same.")}if(r.isDirectory()&&!t.isDirectory())throw new Error(`Cannot overwrite non-directory '${n}' with directory '${e}'.`);if(!r.isDirectory()&&t.isDirectory())throw new Error(`Cannot overwrite directory '${n}' with non-directory '${e}'.`)}if(r.isDirectory()&&Ur(e,n))throw new Error(wt(e,n,o));return{srcStat:r,destStat:t}}async function Dl(e,n,o,i){let r=B.resolve(B.dirname(e)),t=B.resolve(B.dirname(o));if(t===r||t===B.parse(t).root)return;let a;try{a=await Pn.stat(t,{bigint:!0})}catch(l){if(l.code==="ENOENT")return;throw l}if(Ln(n,a))throw new Error(wt(e,o,i));return Dl(e,n,t,i)}function Nl(e,n,o,i){let r=B.resolve(B.dirname(e)),t=B.resolve(B.dirname(o));if(t===r||t===B.parse(t).root)return;let a;try{a=Pn.statSync(t,{bigint:!0})}catch(l){if(l.code==="ENOENT")return;throw l}if(Ln(n,a))throw new Error(wt(e,o,i));return Nl(e,n,t,i)}function Ln(e,n){return n.ino&&n.dev&&n.ino===e.ino&&n.dev===e.dev}function Ur(e,n){let o=B.resolve(e).split(B.sep).filter(r=>r),i=B.resolve(n).split(B.sep).filter(r=>r);return o.every((r,t)=>i[t]===r)}function wt(e,n,o){return`Cannot ${o} '${e}' to a subdirectory of itself, '${n}'.`}Hl.exports={checkPaths:jl(dd),checkPathsSync:hd,checkParentPaths:jl(Dl),checkParentPathsSync:Nl,isSrcSubdir:Ur,areIdentical:Ln}});var Bl=v((ex,Ml)=>{"use strict";var J=Q(),Mn=require("path"),{mkdirs:yd}=de(),{pathExists:vd}=Le(),{utimesMillis:gd}=Br(),Bn=ze();async function xd(e,n,o={}){typeof o=="function"&&(o={filter:o}),o.clobber="clobber"in o?!!o.clobber:!0,o.overwrite="overwrite"in o?!!o.overwrite:o.clobber,o.preserveTimestamps&&process.arch==="ia32"&&process.emitWarning(`Using the preserveTimestamps option in 32-bit node is not recommended;
+
+	see https://github.com/jprichardson/node-fs-extra/issues/269`,"Warning","fs-extra-WARN0001");let{srcStat:i,destStat:r}=await Bn.checkPaths(e,n,"copy",o);if(await Bn.checkParentPaths(e,i,n,"copy"),!await $l(e,n,o))return;let a=Mn.dirname(n);await vd(a)||await yd(a),await Ll(r,e,n,o)}async function $l(e,n,o){return o.filter?o.filter(e,n):!0}async function Ll(e,n,o,i){let t=await(i.dereference?J.stat:J.lstat)(n);if(t.isDirectory())return wd(t,e,n,o,i);if(t.isFile()||t.isCharacterDevice()||t.isBlockDevice())return Pd(t,e,n,o,i);if(t.isSymbolicLink())return kd(e,n,o,i);throw t.isSocket()?new Error(`Cannot copy a socket file: ${n}`):t.isFIFO()?new Error(`Cannot copy a FIFO pipe: ${n}`):new Error(`Unknown file: ${n}`)}async function Pd(e,n,o,i,r){if(!n)return Fl(e,o,i,r);if(r.overwrite)return await J.unlink(i),Fl(e,o,i,r);if(r.errorOnExist)throw new Error(`'${i}' already exists`)}async function Fl(e,n,o,i){if(await J.copyFile(n,o),i.preserveTimestamps){bd(e.mode)&&await Od(o,e.mode);let r=await J.stat(n);await gd(o,r.atime,r.mtime)}return J.chmod(o,e.mode)}function bd(e){return(e&128)===0}function Od(e,n){return J.chmod(e,n|128)}async function wd(e,n,o,i,r){n||await J.mkdir(i);let t=await J.readdir(o);await Promise.all(t.map(async a=>{let l=Mn.join(o,a),s=Mn.join(i,a);if(!await $l(l,s,r))return;let{destStat:p}=await Bn.checkPaths(l,s,"copy",r);return Ll(p,l,s,r)})),n||await J.chmod(i,e.mode)}async function kd(e,n,o,i){let r=await J.readlink(n);if(i.dereference&&(r=Mn.resolve(process.cwd(),r)),!e)return J.symlink(r,o);let t=null;try{t=await J.readlink(o)}catch(a){if(a.code==="EINVAL"||a.code==="UNKNOWN")return J.symlink(r,o);throw a}if(i.dereference&&(t=Mn.resolve(process.cwd(),t)),Bn.isSrcSubdir(r,t))throw new Error(`Cannot copy '${r}' to a subdirectory of itself, '${t}'.`);if(Bn.isSrcSubdir(t,r))throw new Error(`Cannot overwrite '${t}' with '${r}'.`);return await J.unlink(o),J.symlink(r,o)}Ml.exports=xd});var Jl=v((nx,Yl)=>{"use strict";var X=gn(),Un=require("path"),Cd=de().mkdirsSync,Sd=Br().utimesMillisSync,Wn=ze();function Ed(e,n,o){typeof o=="function"&&(o={filter:o}),o=o||{},o.clobber="clobber"in o?!!o.clobber:!0,o.overwrite="overwrite"in o?!!o.overwrite:o.clobber,o.preserveTimestamps&&process.arch==="ia32"&&process.emitWarning(`Using the preserveTimestamps option in 32-bit node is not recommended;
+
+	see https://github.com/jprichardson/node-fs-extra/issues/269`,"Warning","fs-extra-WARN0002");let{srcStat:i,destStat:r}=Wn.checkPathsSync(e,n,"copy",o);if(Wn.checkParentPathsSync(e,i,n,"copy"),o.filter&&!o.filter(e,n))return;let t=Un.dirname(n);return X.existsSync(t)||Cd(t),Ul(r,e,n,o)}function Ul(e,n,o,i){let t=(i.dereference?X.statSync:X.lstatSync)(n);if(t.isDirectory())return jd(t,e,n,o,i);if(t.isFile()||t.isCharacterDevice()||t.isBlockDevice())return Rd(t,e,n,o,i);if(t.isSymbolicLink())return Hd(e,n,o,i);throw t.isSocket()?new Error(`Cannot copy a socket file: ${n}`):t.isFIFO()?new Error(`Cannot copy a FIFO pipe: ${n}`):new Error(`Unknown file: ${n}`)}function Rd(e,n,o,i,r){return n?qd(e,o,i,r):Wl(e,o,i,r)}function qd(e,n,o,i){if(i.overwrite)return X.unlinkSync(o),Wl(e,n,o,i);if(i.errorOnExist)throw new Error(`'${o}' already exists`)}function Wl(e,n,o,i){return X.copyFileSync(n,o),i.preserveTimestamps&&Ad(e.mode,n,o),Wr(o,e.mode)}function Ad(e,n,o){return Td(e)&&Id(o,e),_d(n,o)}function Td(e){return(e&128)===0}function Id(e,n){return Wr(e,n|128)}function Wr(e,n){return X.chmodSync(e,n)}function _d(e,n){let o=X.statSync(e);return Sd(n,o.atime,o.mtime)}function jd(e,n,o,i,r){return n?Vl(o,i,r):Dd(e.mode,o,i,r)}function Dd(e,n,o,i){return X.mkdirSync(o),Vl(n,o,i),Wr(o,e)}function Vl(e,n,o){X.readdirSync(e).forEach(i=>Nd(i,e,n,o))}function Nd(e,n,o,i){let r=Un.join(n,e),t=Un.join(o,e);if(i.filter&&!i.filter(r,t))return;let{destStat:a}=Wn.checkPathsSync(r,t,"copy",i);return Ul(a,r,t,i)}function Hd(e,n,o,i){let r=X.readlinkSync(n);if(i.dereference&&(r=Un.resolve(process.cwd(),r)),e){let t;try{t=X.readlinkSync(o)}catch(a){if(a.code==="EINVAL"||a.code==="UNKNOWN")return X.symlinkSync(r,o);throw a}if(i.dereference&&(t=Un.resolve(process.cwd(),t)),Wn.isSrcSubdir(r,t))throw new Error(`Cannot copy '${r}' to a subdirectory of itself, '${t}'.`);if(Wn.isSrcSubdir(t,r))throw new Error(`Cannot overwrite '${t}' with '${r}'.`);return Fd(r,o)}else return X.symlinkSync(r,o)}function Fd(e,n){return X.unlinkSync(n),X.symlinkSync(e,n)}Yl.exports=Ed});var kt=v((tx,Gl)=>{"use strict";var $d=M().fromPromise;Gl.exports={copy:$d(Bl()),copySync:Jl()}});var Vn=v((rx,zl)=>{"use strict";var Kl=gn(),Ld=M().fromCallback;function Md(e,n){Kl.rm(e,{recursive:!0,force:!0},n)}function Bd(e){Kl.rmSync(e,{recursive:!0,force:!0})}zl.exports={remove:Ld(Md),removeSync:Bd}});var os=v((ox,rs)=>{"use strict";var Ud=M().fromPromise,Zl=Q(),es=require("path"),ns=de(),ts=Vn(),Ql=Ud(async function(n){let o;try{o=await Zl.readdir(n)}catch{return ns.mkdirs(n)}return Promise.all(o.map(i=>ts.remove(es.join(n,i))))});function Xl(e){let n;try{n=Zl.readdirSync(e)}catch{return ns.mkdirsSync(e)}n.forEach(o=>{o=es.join(e,o),ts.removeSync(o)})}rs.exports={emptyDirSync:Xl,emptydirSync:Xl,emptyDir:Ql,emptydir:Ql}});var ss=v((ax,ls)=>{"use strict";var Wd=M().fromPromise,as=require("path"),Se=Q(),is=de();async function Vd(e){let n;try{n=await Se.stat(e)}catch{}if(n&&n.isFile())return;let o=as.dirname(e),i=null;try{i=await Se.stat(o)}catch(r){if(r.code==="ENOENT"){await is.mkdirs(o),await Se.writeFile(e,"");return}else throw r}i.isDirectory()?await Se.writeFile(e,""):await Se.readdir(o)}function Yd(e){let n;try{n=Se.statSync(e)}catch{}if(n&&n.isFile())return;let o=as.dirname(e);try{Se.statSync(o).isDirectory()||Se.readdirSync(o)}catch(i){if(i&&i.code==="ENOENT")is.mkdirsSync(o);else throw i}Se.writeFileSync(e,"")}ls.exports={createFile:Wd(Vd),createFileSync:Yd}});var ms=v((ix,fs)=>{"use strict";var Jd=M().fromPromise,us=require("path"),Me=Q(),cs=de(),{pathExists:Gd}=Le(),{areIdentical:ps}=ze();async function Kd(e,n){let o;try{o=await Me.lstat(n)}catch{}let i;try{i=await Me.lstat(e)}catch(a){throw a.message=a.message.replace("lstat","ensureLink"),a}if(o&&ps(i,o))return;let r=us.dirname(n);await Gd(r)||await cs.mkdirs(r),await Me.link(e,n)}function zd(e,n){let o;try{o=Me.lstatSync(n)}catch{}try{let t=Me.lstatSync(e);if(o&&ps(t,o))return}catch(t){throw t.message=t.message.replace("lstat","ensureLink"),t}let i=us.dirname(n);return Me.existsSync(i)||cs.mkdirsSync(i),Me.linkSync(e,n)}fs.exports={createLink:Jd(Kd),createLinkSync:zd}});var hs=v((lx,ds)=>{"use strict";var Be=require("path"),Yn=Q(),{pathExists:Qd}=Le(),Xd=M().fromPromise;async function Zd(e,n){if(Be.isAbsolute(e)){try{await Yn.lstat(e)}catch(t){throw t.message=t.message.replace("lstat","ensureSymlink"),t}return{toCwd:e,toDst:e}}let o=Be.dirname(n),i=Be.join(o,e);if(await Qd(i))return{toCwd:i,toDst:e};try{await Yn.lstat(e)}catch(t){throw t.message=t.message.replace("lstat","ensureSymlink"),t}return{toCwd:e,toDst:Be.relative(o,e)}}function eh(e,n){if(Be.isAbsolute(e)){if(!Yn.existsSync(e))throw new Error("absolute srcpath does not exist");return{toCwd:e,toDst:e}}let o=Be.dirname(n),i=Be.join(o,e);if(Yn.existsSync(i))return{toCwd:i,toDst:e};if(!Yn.existsSync(e))throw new Error("relative srcpath does not exist");return{toCwd:e,toDst:Be.relative(o,e)}}ds.exports={symlinkPaths:Xd(Zd),symlinkPathsSync:eh}});var gs=v((sx,vs)=>{"use strict";var ys=Q(),nh=M().fromPromise;async function th(e,n){if(n)return n;let o;try{o=await ys.lstat(e)}catch{return"file"}return o&&o.isDirectory()?"dir":"file"}function rh(e,n){if(n)return n;let o;try{o=ys.lstatSync(e)}catch{return"file"}return o&&o.isDirectory()?"dir":"file"}vs.exports={symlinkType:nh(th),symlinkTypeSync:rh}});var Os=v((ux,bs)=>{"use strict";var oh=M().fromPromise,xs=require("path"),be=Q(),{mkdirs:ah,mkdirsSync:ih}=de(),{symlinkPaths:lh,symlinkPathsSync:sh}=hs(),{symlinkType:uh,symlinkTypeSync:ch}=gs(),{pathExists:ph}=Le(),{areIdentical:Ps}=ze();async function fh(e,n,o){let i;try{i=await be.lstat(n)}catch{}if(i&&i.isSymbolicLink()){let[l,s]=await Promise.all([be.stat(e),be.stat(n)]);if(Ps(l,s))return}let r=await lh(e,n);e=r.toDst;let t=await uh(r.toCwd,o),a=xs.dirname(n);return await ph(a)||await ah(a),be.symlink(e,n,t)}function mh(e,n,o){let i;try{i=be.lstatSync(n)}catch{}if(i&&i.isSymbolicLink()){let l=be.statSync(e),s=be.statSync(n);if(Ps(l,s))return}let r=sh(e,n);e=r.toDst,o=ch(r.toCwd,o);let t=xs.dirname(n);return be.existsSync(t)||ih(t),be.symlinkSync(e,n,o)}bs.exports={createSymlink:oh(fh),createSymlinkSync:mh}});var As=v((cx,qs)=>{"use strict";var{createFile:ws,createFileSync:ks}=ss(),{createLink:Cs,createLinkSync:Ss}=ms(),{createSymlink:Es,createSymlinkSync:Rs}=Os();qs.exports={createFile:ws,createFileSync:ks,ensureFile:ws,ensureFileSync:ks,createLink:Cs,createLinkSync:Ss,ensureLink:Cs,ensureLinkSync:Ss,createSymlink:Es,createSymlinkSync:Rs,ensureSymlink:Es,ensureSymlinkSync:Rs}});var Ct=v((px,Ts)=>{function dh(e,{EOL:n=`
+`,finalEOL:o=!0,replacer:i=null,spaces:r}={}){let t=o?n:"";return JSON.stringify(e,i,r).replace(/\n/g,n)+t}function hh(e){return Buffer.isBuffer(e)&&(e=e.toString("utf8")),e.replace(/^\uFEFF/,"")}Ts.exports={stringify:dh,stripBom:hh}});var Ds=v((fx,js)=>{var bn;try{bn=gn()}catch{bn=require("fs")}var St=M(),{stringify:Is,stripBom:_s}=Ct();async function yh(e,n={}){typeof n=="string"&&(n={encoding:n});let o=n.fs||bn,i="throws"in n?n.throws:!0,r=await St.fromCallback(o.readFile)(e,n);r=_s(r);let t;try{t=JSON.parse(r,n?n.reviver:null)}catch(a){if(i)throw a.message=`${e}: ${a.message}`,a;return null}return t}var vh=St.fromPromise(yh);function gh(e,n={}){typeof n=="string"&&(n={encoding:n});let o=n.fs||bn,i="throws"in n?n.throws:!0;try{let r=o.readFileSync(e,n);return r=_s(r),JSON.parse(r,n.reviver)}catch(r){if(i)throw r.message=`${e}: ${r.message}`,r;return null}}async function xh(e,n,o={}){let i=o.fs||bn,r=Is(n,o);await St.fromCallback(i.writeFile)(e,r,o)}var Ph=St.fromPromise(xh);function bh(e,n,o={}){let i=o.fs||bn,r=Is(n,o);return i.writeFileSync(e,r,o)}var Oh={readFile:vh,readFileSync:gh,writeFile:Ph,writeFileSync:bh};js.exports=Oh});var Hs=v((mx,Ns)=>{"use strict";var Et=Ds();Ns.exports={readJson:Et.readFile,readJsonSync:Et.readFileSync,writeJson:Et.writeFile,writeJsonSync:Et.writeFileSync}});var Rt=v((dx,Ls)=>{"use strict";var wh=M().fromPromise,Vr=Q(),Fs=require("path"),$s=de(),kh=Le().pathExists;async function Ch(e,n,o="utf-8"){let i=Fs.dirname(e);return await kh(i)||await $s.mkdirs(i),Vr.writeFile(e,n,o)}function Sh(e,...n){let o=Fs.dirname(e);Vr.existsSync(o)||$s.mkdirsSync(o),Vr.writeFileSync(e,...n)}Ls.exports={outputFile:wh(Ch),outputFileSync:Sh}});var Bs=v((hx,Ms)=>{"use strict";var{stringify:Eh}=Ct(),{outputFile:Rh}=Rt();async function qh(e,n,o={}){let i=Eh(n,o);await Rh(e,i,o)}Ms.exports=qh});var Ws=v((yx,Us)=>{"use strict";var{stringify:Ah}=Ct(),{outputFileSync:Th}=Rt();function Ih(e,n,o){let i=Ah(n,o);Th(e,i,o)}Us.exports=Ih});var Ys=v((vx,Vs)=>{"use strict";var _h=M().fromPromise,Z=Hs();Z.outputJson=_h(Bs());Z.outputJsonSync=Ws();Z.outputJSON=Z.outputJson;Z.outputJSONSync=Z.outputJsonSync;Z.writeJSON=Z.writeJson;Z.writeJSONSync=Z.writeJsonSync;Z.readJSON=Z.readJson;Z.readJSONSync=Z.readJsonSync;Vs.exports=Z});var Qs=v((gx,zs)=>{"use strict";var jh=Q(),Js=require("path"),{copy:Dh}=kt(),{remove:Ks}=Vn(),{mkdirp:Nh}=de(),{pathExists:Hh}=Le(),Gs=ze();async function Fh(e,n,o={}){let i=o.overwrite||o.clobber||!1,{srcStat:r,isChangingCase:t=!1}=await Gs.checkPaths(e,n,"move",o);await Gs.checkParentPaths(e,r,n,"move");let a=Js.dirname(n);return Js.parse(a).root!==a&&await Nh(a),$h(e,n,i,t)}async function $h(e,n,o,i){if(!i){if(o)await Ks(n);else if(await Hh(n))throw new Error("dest already exists.")}try{await jh.rename(e,n)}catch(r){if(r.code!=="EXDEV")throw r;await Lh(e,n,o)}}async function Lh(e,n,o){return await Dh(e,n,{overwrite:o,errorOnExist:!0,preserveTimestamps:!0}),Ks(e)}zs.exports=Fh});var tu=v((xx,nu)=>{"use strict";var Zs=gn(),Jr=require("path"),Mh=kt().copySync,eu=Vn().removeSync,Bh=de().mkdirpSync,Xs=ze();function Uh(e,n,o){o=o||{};let i=o.overwrite||o.clobber||!1,{srcStat:r,isChangingCase:t=!1}=Xs.checkPathsSync(e,n,"move",o);return Xs.checkParentPathsSync(e,r,n,"move"),Wh(n)||Bh(Jr.dirname(n)),Vh(e,n,i,t)}function Wh(e){let n=Jr.dirname(e);return Jr.parse(n).root===n}function Vh(e,n,o,i){if(i)return Yr(e,n,o);if(o)return eu(n),Yr(e,n,o);if(Zs.existsSync(n))throw new Error("dest already exists.");return Yr(e,n,o)}function Yr(e,n,o){try{Zs.renameSync(e,n)}catch(i){if(i.code!=="EXDEV")throw i;return Yh(e,n,o)}}function Yh(e,n,o){return Mh(e,n,{overwrite:o,errorOnExist:!0,preserveTimestamps:!0}),eu(e)}nu.exports=Uh});var ou=v((Px,ru)=>{"use strict";var Jh=M().fromPromise;ru.exports={move:Jh(Qs()),moveSync:tu()}});var iu=v((bx,au)=>{"use strict";au.exports={...Q(),...kt(),...os(),...As(),...Ys(),...de(),...ou(),...Rt(),...Le(),...Vn()}});Object.defineProperty(exports,"__esModule",{value:!0});var Jn,Gr,Ae=So(),Gh=fl(),Cn=require("os"),N=require("path"),Zn=iu();exports.HttpClient=void 0,(Jn=exports.HttpClient||(exports.HttpClient={})).FETCH="fetch",Jn.XHR="xhr",Jn.NODE="node",Jn.AXIOS="axios",Jn.ANGULAR="angular",exports.Indent=void 0,(Gr=exports.Indent||(exports.Indent={})).SPACE_4="4",Gr.SPACE_2="2",Gr.TAB="tab";var zn=/^(arguments|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)$/g,we=e=>e?.replace(/\\/g,"\\\\").replace(/'/g,"\\'"),Qn=e=>typeof e=="string",Pu=(e,n)=>{var o,i;let r=(o=n["x-enum-varnames"])===null||o===void 0?void 0:o.filter(Qn),t=(i=n["x-enum-descriptions"])===null||i===void 0?void 0:i.filter(Qn);return e.map((a,l)=>({name:r?.[l]||a.name,description:t?.[l]||a.description,value:a.value,type:a.type}))},bu=e=>Array.isArray(e)?e.filter((n,o,i)=>i.indexOf(n)===o).filter(n=>typeof n=="number"||typeof n=="string").map(n=>typeof n=="number"?{name:`'_${n}'`,value:String(n),type:"number",description:null}:{name:String(n).replace(/\W+/g,"_").replace(/^(\d+)/g,"_$1").replace(/([a-z])([A-Z]+)/g,"$1_$2").toUpperCase(),value:`'${n.replace(/'/g,"\\'")}'`,type:"string",description:null}):[],lu=e=>(e||e==="")&&!/^[a-zA-Z_$][\w$]+$/g.test(e)?`'${e}'`:e,Kh=new Map([["file","binary"],["any","any"],["object","any"],["array","any[]"],["boolean","boolean"],["byte","number"],["int","number"],["integer","number"],["float","number"],["double","number"],["short","number"],["long","number"],["number","number"],["char","string"],["date","string"],["date-time","string"],["password","string"],["string","string"],["void","void"],["null","null"]]),Kr=e=>e.replace(/^[^a-zA-Z_$]+/g,"").replace(/[^\w$]+/g,"_"),te=(e="any",n)=>{let o={type:"any",base:"any",template:null,imports:[],isNullable:!1},i=((t,a)=>a==="binary"?"binary":Kh.get(t))(e,n);if(i)return o.type=i,o.base=i,o;let r=decodeURIComponent(e.trim().replace(/^#\/definitions\//,"").replace(/^#\/parameters\//,"").replace(/^#\/responses\//,"").replace(/^#\/securityDefinitions\//,""));if(/\[.*\]$/g.test(r)){let t=r.match(/(.*?)\[(.*)\]$/);if(t?.length){let a=te(Kr(t[1])),l=te(Kr(t[2]));return a.type==="any[]"?(o.type=`${l.type}[]`,o.base=l.type,a.imports=[]):l.type?(o.type=`${a.type}<${l.type}>`,o.base=a.type,o.template=l.type):(o.type=a.type,o.base=a.type,o.template=a.type),o.imports.push(...a.imports),o.imports.push(...l.imports),o}}if(r){let t=Kr(r);return o.type=t,o.base=t,o.imports.push(t),o}return o},Ou=(e,n,o)=>{var i;let r=[];for(let t in n.properties)if(n.properties.hasOwnProperty(t)){let a=n.properties[t],l=!!(!((i=n.required)===null||i===void 0)&&i.includes(t));if(a.$ref){let s=te(a.$ref);r.push({name:lu(t),export:"reference",type:s.type,base:s.base,template:s.template,link:null,description:a.description||null,isDefinition:!1,isReadOnly:a.readOnly===!0,isRequired:l,isNullable:a["x-nullable"]===!0,format:a.format,maximum:a.maximum,exclusiveMaximum:a.exclusiveMaximum,minimum:a.minimum,exclusiveMinimum:a.exclusiveMinimum,multipleOf:a.multipleOf,maxLength:a.maxLength,minLength:a.minLength,maxItems:a.maxItems,minItems:a.minItems,uniqueItems:a.uniqueItems,maxProperties:a.maxProperties,minProperties:a.minProperties,pattern:we(a.pattern),imports:s.imports,enum:[],enums:[],properties:[]})}else{let s=o(e,a);r.push({name:lu(t),export:s.export,type:s.type,base:s.base,template:s.template,link:s.link,description:a.description||null,isDefinition:!1,isReadOnly:a.readOnly===!0,isRequired:l,isNullable:a["x-nullable"]===!0,format:a.format,maximum:a.maximum,exclusiveMaximum:a.exclusiveMaximum,minimum:a.minimum,exclusiveMinimum:a.exclusiveMinimum,multipleOf:a.multipleOf,maxLength:a.maxLength,minLength:a.minLength,maxItems:a.maxItems,minItems:a.minItems,uniqueItems:a.uniqueItems,maxProperties:a.maxProperties,minProperties:a.minProperties,pattern:we(a.pattern),imports:s.imports,enum:s.enum,enums:s.enums,properties:s.properties})}}return r},zh=/~1/g,Qh=/~0/g,Xn=(e,n)=>{if(n.$ref){let o=n.$ref.replace(/^#/g,"").split("/").filter(r=>r),i=e;return o.forEach(r=>{let t=decodeURIComponent(r.replace(zh,"/").replace(Qh,"~"));if(!i.hasOwnProperty(t))throw new Error(`Could not find reference: "${n.$ref}"`);i=i[t]}),i}return n},Xh=(e,n,o,i,r)=>{let t={type:i,imports:[],enums:[],properties:[]},a=[];if(o.map(l=>r(e,l)).filter(l=>{let s=l.properties.length,u=l.enums.length;return!(l.type==="any"&&!s&&!u)}).forEach(l=>{t.imports.push(...l.imports),t.enums.push(...l.enums),t.properties.push(l)}),n.required){let l=((s,u,p,c)=>p.reduce((f,m)=>{if(m.$ref){let d=Xn(s,m);return[...f,...c(s,d).properties]}return[...f,...c(s,m).properties]},[]).filter(f=>!f.isRequired&&u.includes(f.name)).map(f=>({...f,isRequired:!0})))(e,n.required,o,r);l.forEach(s=>{t.imports.push(...s.imports),t.enums.push(...s.enums)}),a.push(...l)}if(n.properties){let l=Ou(e,n,r);l.forEach(s=>{t.imports.push(...s.imports),t.enums.push(...s.enums),s.export==="enum"&&t.enums.push(s)}),a.push(...l)}return a.length&&t.properties.push({name:"properties",export:"interface",type:"any",base:"any",template:null,link:null,description:"",isDefinition:!1,isReadOnly:!1,isNullable:!1,isRequired:!1,imports:[],enum:[],enums:[],properties:a}),t},Ze=(e,n,o=!1,i="")=>{var r;let t={name:i,export:"interface",type:"any",base:"any",template:null,link:null,description:n.description||null,isDefinition:o,isReadOnly:n.readOnly===!0,isNullable:n["x-nullable"]===!0,isRequired:!1,format:n.format,maximum:n.maximum,exclusiveMaximum:n.exclusiveMaximum,minimum:n.minimum,exclusiveMinimum:n.exclusiveMinimum,multipleOf:n.multipleOf,maxLength:n.maxLength,minLength:n.minLength,maxItems:n.maxItems,minItems:n.minItems,uniqueItems:n.uniqueItems,maxProperties:n.maxProperties,minProperties:n.minProperties,pattern:we(n.pattern),imports:[],enum:[],enums:[],properties:[]};if(n.$ref){let a=te(n.$ref);return t.export="reference",t.type=a.type,t.base=a.base,t.template=a.template,t.imports.push(...a.imports),t}if(n.enum&&n.type!=="boolean"){let a=bu(n.enum),l=Pu(a,n);if(l.length)return t.export="enum",t.type="string",t.base="string",t.enum.push(...l),t}if(n.type==="array"&&n.items){if(n.items.$ref){let a=te(n.items.$ref);return t.export="array",t.type=a.type,t.base=a.base,t.template=a.template,t.imports.push(...a.imports),t}{let a=Ze(e,n.items);return t.export="array",t.type=a.type,t.base=a.base,t.template=a.template,t.link=a,t.imports.push(...a.imports),t}}if(n.type==="object"&&typeof n.additionalProperties=="object"){if(n.additionalProperties.$ref){let a=te(n.additionalProperties.$ref);return t.export="dictionary",t.type=a.type,t.base=a.base,t.template=a.template,t.imports.push(...a.imports),t}{let a=Ze(e,n.additionalProperties);return t.export="dictionary",t.type=a.type,t.base=a.base,t.template=a.template,t.link=a,t.imports.push(...a.imports),t}}if(!((r=n.allOf)===null||r===void 0)&&r.length){let a=Xh(e,n,n.allOf,"all-of",Ze);return t.export=a.type,t.imports.push(...a.imports),t.properties.push(...a.properties),t.enums.push(...a.enums),t}if(n.type==="object")return t.export="interface",t.type="any",t.base="any",n.properties&&Ou(e,n,Ze).forEach(a=>{t.imports.push(...a.imports),t.enums.push(...a.enums),t.properties.push(a),a.export==="enum"&&t.enums.push(a)}),t;if(n.type){let a=te(n.type,n.format);return t.export="generic",t.type=a.type,t.base=a.base,t.template=a.template,t.imports.push(...a.imports),t}return t},nn=(e,n,o)=>o.indexOf(e)===n,Qe=(e,n)=>{var o;if(e.default!==void 0){if(e.default===null)return"null";switch(e.type||typeof e.default){case"int":case"integer":case"number":return n.export==="enum"&&(!((o=n.enum)===null||o===void 0)&&o[e.default])?n.enum[e.default].value:e.default;case"boolean":return JSON.stringify(e.default);case"string":return`'${e.default}'`;case"object":try{return JSON.stringify(e.default,null,4)}catch{}}}},Zh=e=>{let n=e.replace(/^[^a-zA-Z]+/g,"").replace(/[^\w\-]+/g,"-").trim();return Ae(n).replace(zn,"_$1")},wu=(e,n)=>{let o={imports:[],parameters:[],parametersPath:[],parametersQuery:[],parametersForm:[],parametersCookie:[],parametersHeader:[],parametersBody:null};return n.forEach(i=>{let r=Xn(e,i),t=((a,l)=>{var s;let u={in:l.in,prop:l.name,export:"interface",name:Zh(l.name),type:"any",base:"any",template:null,link:null,description:l.description||null,isDefinition:!1,isReadOnly:!1,isRequired:l.required===!0,isNullable:l["x-nullable"]===!0,format:l.format,maximum:l.maximum,exclusiveMaximum:l.exclusiveMaximum,minimum:l.minimum,exclusiveMinimum:l.exclusiveMinimum,multipleOf:l.multipleOf,maxLength:l.maxLength,minLength:l.minLength,maxItems:l.maxItems,minItems:l.minItems,uniqueItems:l.uniqueItems,pattern:we(l.pattern),imports:[],enum:[],enums:[],properties:[],mediaType:null};if(l.$ref){let c=te(l.$ref);return u.export="reference",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Qe(l,u),u}if(l.enum){let c=bu(l.enum),f=Pu(c,l);if(f.length)return u.export="enum",u.type="string",u.base="string",u.enum.push(...f),u.default=Qe(l,u),u}if(l.type==="array"&&l.items){let c=te(l.items.type,l.items.format);return u.export="array",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Qe(l,u),u}if(l.type==="object"&&l.items){let c=te(l.items.type,l.items.format);return u.export="dictionary",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Qe(l,u),u}let p=l.schema;if(p){if(!((s=p.$ref)===null||s===void 0)&&s.startsWith("#/parameters/")&&(p=Xn(a,p)),p.$ref){let c=te(p.$ref);return u.export="reference",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Qe(l,u),u}{let c=Ze(a,p);return u.export=c.export,u.type=c.type,u.base=c.base,u.template=c.template,u.link=c.link,u.imports.push(...c.imports),u.enum.push(...c.enum),u.enums.push(...c.enums),u.properties.push(...c.properties),u.default=Qe(l,u),u}}if(l.type){let c=te(l.type,l.format);return u.export="generic",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Qe(l,u),u}return u})(e,r);if(t.prop!=="api-version")switch(t.in){case"path":o.parametersPath.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"query":o.parametersQuery.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"header":o.parametersHeader.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"formData":o.parametersForm.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"body":o.parametersBody=t,o.parameters.push(t),o.imports.push(...t.imports)}}),o},ey=(e,n,o)=>{var i;let r={in:"response",name:"",code:o,description:n.description||null,export:"generic",type:"any",base:"any",template:null,link:null,isDefinition:!1,isReadOnly:!1,isRequired:!1,isNullable:!1,imports:[],enum:[],enums:[],properties:[]},t=n.schema;if(t){if(!((i=t.$ref)===null||i===void 0)&&i.startsWith("#/responses/")&&(t=Xn(e,t)),t.$ref){let a=te(t.$ref);return r.export="reference",r.type=a.type,r.base=a.base,r.template=a.template,r.imports.push(...a.imports),r}{let a=Ze(e,t);return r.export=a.export,r.type=a.type,r.base=a.base,r.template=a.template,r.link=a.link,r.isReadOnly=a.isReadOnly,r.isRequired=a.isRequired,r.isNullable=a.isNullable,r.format=a.format,r.maximum=a.maximum,r.exclusiveMaximum=a.exclusiveMaximum,r.minimum=a.minimum,r.exclusiveMinimum=a.exclusiveMinimum,r.multipleOf=a.multipleOf,r.maxLength=a.maxLength,r.minLength=a.minLength,r.maxItems=a.maxItems,r.minItems=a.minItems,r.uniqueItems=a.uniqueItems,r.maxProperties=a.maxProperties,r.minProperties=a.minProperties,r.pattern=we(a.pattern),r.imports.push(...a.imports),r.enum.push(...a.enum),r.enums.push(...a.enums),r.properties.push(...a.properties),r}}if(n.headers){for(let a in n.headers)if(n.headers.hasOwnProperty(a))return r.in="header",r.name=a,r.type="string",r.base="string",r}return r},ny=e=>{if(e==="default")return 200;if(/[0-9]+/g.test(e)){let n=parseInt(e);if(Number.isInteger(n))return Math.abs(n)}return null},ku=(e,n)=>{let o=e.type===n.type&&e.base===n.base&&e.template===n.template;return o&&e.link&&n.link?ku(e.link,n.link):o},ty=(e,n)=>{let o=e.isRequired&&e.default===void 0,i=n.isRequired&&n.default===void 0;return o&&!i?-1:i&&!o?1:0},ry=(e,n,o,i,r,t)=>{let a=(u=>{let p=u.replace(/^[^a-zA-Z]+/g,"").replace(/[^\w\-]+/g,"-").trim();return Ae(p,{pascalCase:!0})})(i),l=((u,p,c)=>{if(c)return Ae(c.replace(/^[^a-zA-Z]+/g,"").replace(/[^\w\-]+/g,"-").trim());let f=u.replace(/[^/]*?{api-version}.*?\//g,"").replace(/{(.*?)}/g,"").replace(/\//g,"-");return Ae(`${p}-${f}`)})(n,o,r.operationId),s={service:a,name:l,summary:r.summary||null,description:r.description||null,deprecated:r.deprecated===!0,method:o.toUpperCase(),path:n,parameters:[...t.parameters],parametersPath:[...t.parametersPath],parametersQuery:[...t.parametersQuery],parametersForm:[...t.parametersForm],parametersHeader:[...t.parametersHeader],parametersCookie:[...t.parametersCookie],parametersBody:t.parametersBody,imports:[],errors:[],results:[],responseHeader:null};if(r.parameters){let u=wu(e,r.parameters);s.imports.push(...u.imports),s.parameters.push(...u.parameters),s.parametersPath.push(...u.parametersPath),s.parametersQuery.push(...u.parametersQuery),s.parametersForm.push(...u.parametersForm),s.parametersHeader.push(...u.parametersHeader),s.parametersCookie.push(...u.parametersCookie),s.parametersBody=u.parametersBody}if(r.responses){let u=((c,f)=>{let m=[];for(let d in f)if(f.hasOwnProperty(d)){let y=f[d],g=Xn(c,y),P=ny(d);if(P){let x=ey(c,g,P);m.push(x)}}return m.sort((d,y)=>d.code<y.code?-1:d.code>y.code?1:0)})(e,r.responses),p=(c=>{let f=[];return c.forEach(m=>{let{code:d}=m;d&&d!==204&&d>=200&&d<300&&f.push(m)}),f.length||f.push({in:"response",name:"",code:200,description:"",export:"generic",type:"void",base:"void",template:null,link:null,isDefinition:!1,isReadOnly:!1,isRequired:!1,isNullable:!1,imports:[],enum:[],enums:[],properties:[]}),f.filter((m,d,y)=>y.findIndex(g=>ku(g,m))===d)})(u);s.errors=(c=>c.filter(f=>f.code>=300&&f.description).map(f=>({code:f.code,description:f.description})))(u),s.responseHeader=(c=>{let f=c.find(m=>m.in==="header");return f?f.name:null})(p),p.forEach(c=>{s.results.push(c),s.imports.push(...c.imports)})}return s.parameters=s.parameters.sort(ty),s},oy=e=>{let n=((t="1.0")=>String(t).replace(/^v/gi,""))(e.info.version),o=(t=>{var a;let l=((a=t.schemes)===null||a===void 0?void 0:a[0])||"http",s=t.host,u=t.basePath||"";return(s?`${l}://${s}${u}`:u).replace(/\/$/g,"")})(e),i=(t=>{let a=[];for(let l in t.definitions)if(t.definitions.hasOwnProperty(l)){let s=t.definitions[l],u=te(l),p=Ze(t,s,!0,u.base.replace(zn,"_$1"));a.push(p)}return a})(e),r=(t=>{var a;let l=new Map;for(let s in t.paths)if(t.paths.hasOwnProperty(s)){let u=t.paths[s],p=wu(t,u.parameters||[]);for(let c in u)if(u.hasOwnProperty(c))switch(c){case"get":case"put":case"post":case"delete":case"options":case"head":case"patch":let f=u[c];(!((a=f.tags)===null||a===void 0)&&a.length?f.tags.filter(nn):["Default"]).forEach(m=>{let d=ry(t,s,c,m,f,p),y=l.get(d.service)||{name:d.service,operations:[],imports:[]};y.operations.push(d),y.imports.push(...d.imports),l.set(d.service,y)})}}return Array.from(l.values())})(e);return{version:n,server:o,models:i,services:r}},go=e=>e.trim().replace(/^#\/components\/schemas\//,"").replace(/^#\/components\/responses\//,"").replace(/^#\/components\/parameters\//,"").replace(/^#\/components\/examples\//,"").replace(/^#\/components\/requestBodies\//,"").replace(/^#\/components\/headers\//,"").replace(/^#\/components\/securitySchemes\//,"").replace(/^#\/components\/links\//,"").replace(/^#\/components\/callbacks\//,""),ay=(e,n)=>{if(e.mapping){let o=(r=>{let t={};for(let a in r)t[r[a]]=a;return t})(e.mapping),i=Object.keys(o).find(r=>go(r)==n.name);if(i&&o[i])return o[i]}return n.name},iy=e=>(e||e==="")&&!/^[a-zA-Z_$][\w$]+$/g.test(e)?`'${e}'`:e,en=e=>e!=null&&e!=="",ly=new Map([["file","binary"],["any","any"],["object","any"],["array","any[]"],["boolean","boolean"],["byte","number"],["int","number"],["integer","number"],["float","number"],["double","number"],["short","number"],["long","number"],["number","number"],["char","string"],["date","string"],["date-time","string"],["password","string"],["string","string"],["void","void"],["null","null"]]),su=(e,n)=>n==="binary"?"binary":ly.get(e),zr=e=>e.replace(/^[^a-zA-Z_$]+/g,"").replace(/[^\w$]+/g,"_"),oe=(e="any",n)=>{let o={type:"any",base:"any",template:null,imports:[],isNullable:!1};if(Array.isArray(e)){let t=e.filter(a=>a!=="null").map(a=>su(a,n)).filter(en).join(" | ");return o.type=t,o.base=t,o.isNullable=e.includes("null"),o}let i=su(e,n);if(i)return o.type=i,o.base=i,o;let r=decodeURIComponent(go(e));if(/\[.*\]$/g.test(r)){let t=r.match(/(.*?)\[(.*)\]$/);if(t?.length){let a=oe(zr(t[1])),l=oe(zr(t[2]));return a.type==="any[]"?(o.type=`${l.type}[]`,o.base=`${l.type}`,a.imports=[]):l.type?(o.type=`${a.type}<${l.type}>`,o.base=a.type,o.template=l.type):(o.type=a.type,o.base=a.type,o.template=a.type),o.imports.push(...a.imports),o.imports.push(...l.imports),o}}if(r){let t=zr(r);return o.type=t,o.base=t,o.imports.push(t),o}return o},Cu=(e,n,o,i)=>{var r;let t=[],a=((l,s)=>{var u;if(l.components&&s){for(let p in l.components.schemas)if(l.components.schemas.hasOwnProperty(p)){let c=l.components.schemas[p];if(c.discriminator&&(!((u=c.oneOf)===null||u===void 0)&&u.length)&&c.oneOf.some(f=>f.$ref&&go(f.$ref)==s.name))return c.discriminator}}})(e,i);for(let l in n.properties)if(n.properties.hasOwnProperty(l)){let s=n.properties[l],u=!!(!((r=n.required)===null||r===void 0)&&r.includes(l)),p={name:iy(l),description:s.description||null,deprecated:s.deprecated===!0,isDefinition:!1,isReadOnly:s.readOnly===!0,isRequired:u,format:s.format,maximum:s.maximum,exclusiveMaximum:s.exclusiveMaximum,minimum:s.minimum,exclusiveMinimum:s.exclusiveMinimum,multipleOf:s.multipleOf,maxLength:s.maxLength,minLength:s.minLength,maxItems:s.maxItems,minItems:s.minItems,uniqueItems:s.uniqueItems,maxProperties:s.maxProperties,minProperties:s.minProperties,pattern:we(s.pattern)};if(i&&a?.propertyName==l)t.push({export:"reference",type:"string",base:`'${ay(a,i)}'`,template:null,isNullable:s.nullable===!0,link:null,imports:[],enum:[],enums:[],properties:[],...p});else if(s.$ref){let c=oe(s.$ref);t.push({export:"reference",type:c.type,base:c.base,template:c.template,link:null,isNullable:c.isNullable||s.nullable===!0,imports:c.imports,enum:[],enums:[],properties:[],...p})}else{let c=o(e,s);t.push({export:c.export,type:c.type,base:c.base,template:c.template,link:c.link,isNullable:c.isNullable||s.nullable===!0,imports:c.imports,enum:c.enum,enums:c.enums,properties:c.properties,...p})}}return t},sy=/~1/g,uy=/~0/g,Sn=(e,n)=>{if(n.$ref){let o=n.$ref.replace(/^#/g,"").split("/").filter(r=>r),i=e;return o.forEach(r=>{let t=decodeURIComponent(r.replace(sy,"/").replace(uy,"~"));if(!i.hasOwnProperty(t))throw new Error(`Could not find reference: "${n.$ref}"`);i=i[t]}),i}return n},Qr=(e,n,o,i,r)=>{let t={type:i,imports:[],enums:[],properties:[]},a=[];if(o.map(l=>r(e,l)).filter(l=>{let s=l.properties.length,u=l.enums.length,p=l.type==="any",c=l.export==="dictionary";return!(p&&!s&&!u)||c}).forEach(l=>{t.imports.push(...l.imports),t.enums.push(...l.enums),t.properties.push(l)}),n.required){let l=((s,u,p,c)=>p.reduce((f,m)=>{if(m.$ref){let d=Sn(s,m);return[...f,...c(s,d).properties]}return[...f,...c(s,m).properties]},[]).filter(f=>!f.isRequired&&u.includes(f.name)).map(f=>({...f,isRequired:!0})))(e,n.required,o,r);l.forEach(s=>{t.imports.push(...s.imports),t.enums.push(...s.enums)}),a.push(...l)}if(n.properties){let l=Cu(e,n,r);l.forEach(s=>{t.imports.push(...s.imports),t.enums.push(...s.enums),s.export==="enum"&&t.enums.push(s)}),a.push(...l)}return a.length&&t.properties.push({name:"properties",export:"interface",type:"any",base:"any",template:null,link:null,description:"",isDefinition:!1,isReadOnly:!1,isNullable:!1,isRequired:!1,imports:[],enum:[],enums:[],properties:a}),t},Oe=(e,n)=>{var o;if(e.default!==void 0){if(e.default===null)return"null";switch(e.type||typeof e.default){case"int":case"integer":case"number":return n?.export==="enum"&&(!((o=n.enum)===null||o===void 0)&&o[e.default])?n.enum[e.default].value:e.default;case"boolean":return JSON.stringify(e.default);case"string":return`'${e.default}'`;case"object":try{return JSON.stringify(e.default,null,4)}catch{}}}},se=(e,n,o=!1,i="")=>{var r,t,a;let l={name:i,export:"interface",type:"any",base:"any",template:null,link:null,description:n.description||null,deprecated:n.deprecated===!0,isDefinition:o,isReadOnly:n.readOnly===!0,isNullable:n.nullable===!0,isRequired:!1,format:n.format,maximum:n.maximum,exclusiveMaximum:n.exclusiveMaximum,minimum:n.minimum,exclusiveMinimum:n.exclusiveMinimum,multipleOf:n.multipleOf,maxLength:n.maxLength,minLength:n.minLength,maxItems:n.maxItems,minItems:n.minItems,uniqueItems:n.uniqueItems,maxProperties:n.maxProperties,minProperties:n.minProperties,pattern:we(n.pattern),imports:[],enum:[],enums:[],properties:[]};if(n.$ref){let u=oe(n.$ref);return l.export="reference",l.type=u.type,l.base=u.base,l.template=u.template,l.imports.push(...u.imports),l.default=Oe(n,l),l}if(n.enum&&n.type!=="boolean"){let u=(s=n.enum,Array.isArray(s)?s.filter((c,f,m)=>m.indexOf(c)===f).filter(c=>typeof c=="number"||typeof c=="string").map(c=>typeof c=="number"?{name:`'_${c}'`,value:String(c),type:"number",description:null}:{name:String(c).replace(/\W+/g,"_").replace(/^(\d+)/g,"_$1").replace(/([a-z])([A-Z]+)/g,"$1_$2").toUpperCase(),value:`'${c.replace(/'/g,"\\'")}'`,type:"string",description:null}):[]),p=((c,f)=>{var m,d;let y=(m=f["x-enum-varnames"])===null||m===void 0?void 0:m.filter(Qn),g=(d=f["x-enum-descriptions"])===null||d===void 0?void 0:d.filter(Qn);return c.map((P,x)=>({name:y?.[x]||P.name,description:g?.[x]||P.description,value:P.value,type:P.type}))})(u,n);if(p.length)return l.export="enum",l.type="string",l.base="string",l.enum.push(...p),l.default=Oe(n,l),l}var s;if(n.type==="array"&&n.items){if(n.items.$ref){let u=oe(n.items.$ref);return l.export="array",l.type=u.type,l.base=u.base,l.template=u.template,l.imports.push(...u.imports),l.default=Oe(n,l),l}{let u=se(e,n.items);return l.export="array",l.type=u.type,l.base=u.base,l.template=u.template,l.link=u,l.imports.push(...u.imports),l.default=Oe(n,l),l}}if(n.type==="object"&&(typeof n.additionalProperties=="object"||n.additionalProperties===!0)){let u=typeof n.additionalProperties=="object"?n.additionalProperties:{};if(u.$ref){let p=oe(u.$ref);return l.export="dictionary",l.type=p.type,l.base=p.base,l.template=p.template,l.imports.push(...p.imports),l.default=Oe(n,l),l}{let p=se(e,u);return l.export="dictionary",l.type=p.type,l.base=p.base,l.template=p.template,l.link=p,l.imports.push(...p.imports),l.default=Oe(n,l),l}}if(!((r=n.oneOf)===null||r===void 0)&&r.length){let u=Qr(e,n,n.oneOf,"one-of",se);return l.export=u.type,l.imports.push(...u.imports),l.properties.push(...u.properties),l.enums.push(...u.enums),l}if(!((t=n.anyOf)===null||t===void 0)&&t.length){let u=Qr(e,n,n.anyOf,"any-of",se);return l.export=u.type,l.imports.push(...u.imports),l.properties.push(...u.properties),l.enums.push(...u.enums),l}if(!((a=n.allOf)===null||a===void 0)&&a.length){let u=Qr(e,n,n.allOf,"all-of",se);return l.export=u.type,l.imports.push(...u.imports),l.properties.push(...u.properties),l.enums.push(...u.enums),l}if(n.type==="object"){if(n.properties)return l.export="interface",l.type="any",l.base="any",l.default=Oe(n,l),Cu(e,n,se,l).forEach(u=>{l.imports.push(...u.imports),l.enums.push(...u.enums),l.properties.push(u),u.export==="enum"&&l.enums.push(u)}),l;{let u=se(e,{});return l.export="dictionary",l.type=u.type,l.base=u.base,l.template=u.template,l.link=u,l.imports.push(...u.imports),l.default=Oe(n,l),l}}if(n.type){let u=oe(n.type,n.format);return l.export="generic",l.type=u.type,l.base=u.base,l.template=u.template,l.isNullable=u.isNullable||l.isNullable,l.imports.push(...u.imports),l.default=Oe(n,l),l}return l},cy=e=>{let n=e.replace(/^[^a-zA-Z]+/g,"").replace("[]","Array").replace(/[^\w\-]+/g,"-").trim();return Ae(n).replace(zn,"_$1")},Su=(e,n)=>{let o={imports:[],parameters:[],parametersPath:[],parametersQuery:[],parametersForm:[],parametersCookie:[],parametersHeader:[],parametersBody:null};return n.forEach(i=>{let r=Sn(e,i),t=((a,l)=>{var s;let u={in:l.in,prop:l.name,export:"interface",name:cy(l.name),type:"any",base:"any",template:null,link:null,description:l.description||null,deprecated:l.deprecated===!0,isDefinition:!1,isReadOnly:!1,isRequired:l.required===!0,isNullable:l.nullable===!0,imports:[],enum:[],enums:[],properties:[],mediaType:null};if(l.$ref){let c=oe(l.$ref);return u.export="reference",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u}let p=l.schema;if(p){if(!((s=p.$ref)===null||s===void 0)&&s.startsWith("#/components/parameters/")&&(p=Sn(a,p)),p.$ref){let c=oe(p.$ref);return u.export="reference",u.type=c.type,u.base=c.base,u.template=c.template,u.imports.push(...c.imports),u.default=Oe(p),u}{let c=se(a,p);return u.export=c.export,u.type=c.type,u.base=c.base,u.template=c.template,u.link=c.link,u.isReadOnly=c.isReadOnly,u.isRequired=u.isRequired||c.isRequired,u.isNullable=u.isNullable||c.isNullable,u.format=c.format,u.maximum=c.maximum,u.exclusiveMaximum=c.exclusiveMaximum,u.minimum=c.minimum,u.exclusiveMinimum=c.exclusiveMinimum,u.multipleOf=c.multipleOf,u.maxLength=c.maxLength,u.minLength=c.minLength,u.maxItems=c.maxItems,u.minItems=c.minItems,u.uniqueItems=c.uniqueItems,u.maxProperties=c.maxProperties,u.minProperties=c.minProperties,u.pattern=we(c.pattern),u.default=c.default,u.imports.push(...c.imports),u.enum.push(...c.enum),u.enums.push(...c.enums),u.properties.push(...c.properties),u}}return u})(e,r);if(t.prop!=="api-version")switch(r.in){case"path":o.parametersPath.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"query":o.parametersQuery.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"formData":o.parametersForm.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"cookie":o.parametersCookie.push(t),o.parameters.push(t),o.imports.push(...t.imports);break;case"header":o.parametersHeader.push(t),o.parameters.push(t),o.imports.push(...t.imports)}}),o},py=["application/json-patch+json","application/json","application/x-www-form-urlencoded","text/json","text/plain","multipart/form-data","multipart/mixed","multipart/related","multipart/batch"],Eu=(e,n)=>{let o=Object.keys(n).filter(r=>{let t=r.split(";")[0].trim();return py.includes(t)}).find(r=>{var t;return en((t=n[r])===null||t===void 0?void 0:t.schema)});if(o)return{mediaType:o,schema:n[o].schema};let i=Object.keys(n).find(r=>{var t;return en((t=n[r])===null||t===void 0?void 0:t.schema)});return i?{mediaType:i,schema:n[i].schema}:null},fy=(e,n,o)=>{var i;let r={in:"response",name:"",code:o,description:n.description||null,export:"generic",type:"any",base:"any",template:null,link:null,isDefinition:!1,isReadOnly:!1,isRequired:!1,isNullable:!1,imports:[],enum:[],enums:[],properties:[]};if(n.content){let t=Eu(0,n.content);if(t){if(!((i=t.schema.$ref)===null||i===void 0)&&i.startsWith("#/components/responses/")&&(t.schema=Sn(e,t.schema)),t.schema.$ref){let a=oe(t.schema.$ref);return r.export="reference",r.type=a.type,r.base=a.base,r.template=a.template,r.imports.push(...a.imports),r}{let a=se(e,t.schema);return r.export=a.export,r.type=a.type,r.base=a.base,r.template=a.template,r.link=a.link,r.isReadOnly=a.isReadOnly,r.isRequired=a.isRequired,r.isNullable=a.isNullable,r.format=a.format,r.maximum=a.maximum,r.exclusiveMaximum=a.exclusiveMaximum,r.minimum=a.minimum,r.exclusiveMinimum=a.exclusiveMinimum,r.multipleOf=a.multipleOf,r.maxLength=a.maxLength,r.minLength=a.minLength,r.maxItems=a.maxItems,r.minItems=a.minItems,r.uniqueItems=a.uniqueItems,r.maxProperties=a.maxProperties,r.minProperties=a.minProperties,r.pattern=we(a.pattern),r.imports.push(...a.imports),r.enum.push(...a.enum),r.enums.push(...a.enums),r.properties.push(...a.properties),r}}}if(n.headers){for(let t in n.headers)if(n.headers.hasOwnProperty(t))return r.in="header",r.name=t,r.type="string",r.base="string",r}return r},my=e=>{if(e==="default")return 200;if(/[0-9]+/g.test(e)){let n=parseInt(e);if(Number.isInteger(n))return Math.abs(n)}return null},Ru=(e,n)=>{let o=e.type===n.type&&e.base===n.base&&e.template===n.template;return o&&e.link&&n.link?Ru(e.link,n.link):o},dy=(e,n)=>{let o=e.isRequired&&e.default===void 0,i=n.isRequired&&n.default===void 0;return o&&!i?-1:i&&!o?1:0},hy=(e,n,o,i,r,t)=>{let a=(u=>{let p=u.replace(/^[^a-zA-Z]+/g,"").replace(/[^\w\-]+/g,"-").trim();return Ae(p,{pascalCase:!0})})(i),l=((u,p,c)=>{if(c)return Ae(c.replace(/^[^a-zA-Z]+/g,"").replace(/[^\w\-]+/g,"-").trim());let f=u.replace(/[^/]*?{api-version}.*?\//g,"").replace(/{(.*?)}/g,"").replace(/\//g,"-");return Ae(`${p}-${f}`)})(n,o,r.operationId),s={service:a,name:l,summary:r.summary||null,description:r.description||null,deprecated:r.deprecated===!0,method:o.toUpperCase(),path:n,parameters:[...t.parameters],parametersPath:[...t.parametersPath],parametersQuery:[...t.parametersQuery],parametersForm:[...t.parametersForm],parametersHeader:[...t.parametersHeader],parametersCookie:[...t.parametersCookie],parametersBody:t.parametersBody,imports:[],errors:[],results:[],responseHeader:null};if(r.parameters){let u=Su(e,r.parameters);s.imports.push(...u.imports),s.parameters.push(...u.parameters),s.parametersPath.push(...u.parametersPath),s.parametersQuery.push(...u.parametersQuery),s.parametersForm.push(...u.parametersForm),s.parametersHeader.push(...u.parametersHeader),s.parametersCookie.push(...u.parametersCookie),s.parametersBody=u.parametersBody}if(r.requestBody){let u=((p,c)=>{let f={in:"body",export:"interface",prop:"requestBody",name:"requestBody",type:"any",base:"any",template:null,link:null,description:c.description||null,default:void 0,isDefinition:!1,isReadOnly:!1,isRequired:c.required===!0,isNullable:c.nullable===!0,imports:[],enum:[],enums:[],properties:[],mediaType:null};if(c.content){let m=Eu(0,c.content);if(m){switch(f.mediaType=m.mediaType,f.mediaType){case"application/x-www-form-urlencoded":case"multipart/form-data":f.in="formData",f.name="formData",f.prop="formData"}if(m.schema.$ref){let d=oe(m.schema.$ref);return f.export="reference",f.type=d.type,f.base=d.base,f.template=d.template,f.imports.push(...d.imports),f}{let d=se(p,m.schema);return f.export=d.export,f.type=d.type,f.base=d.base,f.template=d.template,f.link=d.link,f.isReadOnly=d.isReadOnly,f.isRequired=f.isRequired||d.isRequired,f.isNullable=f.isNullable||d.isNullable,f.format=d.format,f.maximum=d.maximum,f.exclusiveMaximum=d.exclusiveMaximum,f.minimum=d.minimum,f.exclusiveMinimum=d.exclusiveMinimum,f.multipleOf=d.multipleOf,f.maxLength=d.maxLength,f.minLength=d.minLength,f.maxItems=d.maxItems,f.minItems=d.minItems,f.uniqueItems=d.uniqueItems,f.maxProperties=d.maxProperties,f.minProperties=d.minProperties,f.pattern=we(d.pattern),f.imports.push(...d.imports),f.enum.push(...d.enum),f.enums.push(...d.enums),f.properties.push(...d.properties),f}}}return f})(e,Sn(e,r.requestBody));s.imports.push(...u.imports),s.parameters.push(u),s.parametersBody=u}if(r.responses){let u=((c,f)=>{let m=[];for(let d in f)if(f.hasOwnProperty(d)){let y=f[d],g=Sn(c,y),P=my(d);if(P){let x=fy(c,g,P);m.push(x)}}return m.sort((d,y)=>d.code<y.code?-1:d.code>y.code?1:0)})(e,r.responses),p=(c=>{let f=[];return c.forEach(m=>{let{code:d}=m;d&&d!==204&&d>=200&&d<300&&f.push(m)}),f.length||f.push({in:"response",name:"",code:200,description:"",export:"generic",type:"void",base:"void",template:null,link:null,isDefinition:!1,isReadOnly:!1,isRequired:!1,isNullable:!1,imports:[],enum:[],enums:[],properties:[]}),f.filter((m,d,y)=>y.findIndex(g=>Ru(g,m))===d)})(u);s.errors=(c=>c.filter(f=>f.code>=300&&f.description).map(f=>({code:f.code,description:f.description})))(u),s.responseHeader=(c=>{let f=c.find(m=>m.in==="header");return f?f.name:null})(p),p.forEach(c=>{s.results.push(c),s.imports.push(...c.imports)})}return s.parameters=s.parameters.sort(dy),s},yy=e=>{let n=((t="1.0")=>String(t).replace(/^v/gi,""))(e.info.version),o=(t=>{var a;let l=(a=t.servers)===null||a===void 0?void 0:a[0],s=l?.variables||{},u=l?.url||"";for(let p in s)s.hasOwnProperty(p)&&(u=u.replace(`{${p}}`,s[p].default));return u.replace(/\/$/g,"")})(e),i=(t=>{let a=[];if(t.components){for(let l in t.components.schemas)if(t.components.schemas.hasOwnProperty(l)){let s=t.components.schemas[l],u=oe(l),p=se(t,s,!0,u.base.replace(zn,"_$1"));a.push(p)}for(let l in t.components.parameters)if(t.components.parameters.hasOwnProperty(l)){let s=t.components.parameters[l],u=oe(l),p=s.schema;if(p){let c=se(t,p,!0,u.base.replace(zn,"_$1"));c.description=s.description||null,c.deprecated=s.deprecated,a.push(c)}}}return a})(e),r=(t=>{var a;let l=new Map;for(let s in t.paths)if(t.paths.hasOwnProperty(s)){let u=t.paths[s],p=Su(t,u.parameters||[]);for(let c in u)if(u.hasOwnProperty(c))switch(c){case"get":case"put":case"post":case"delete":case"options":case"head":case"patch":let f=u[c];(!((a=f.tags)===null||a===void 0)&&a.length?f.tags.filter(nn):["Default"]).forEach(m=>{let d=hy(t,s,c,m,f,p),y=l.get(d.service)||{name:d.service,operations:[],imports:[]};y.operations.push(d),y.imports.push(...d.imports),l.set(d.service,y)})}}return Array.from(l.values())})(e);return{version:n,server:o,models:i,services:r}},wn;(function(e){e[e.V2=2]="V2",e[e.V3=3]="V3"})(wn||(wn={}));var vy=e=>e.enum.filter((n,o,i)=>i.findIndex(r=>r.name===n.name)===o),gy=e=>e.enums.filter((n,o,i)=>i.findIndex(r=>r.name===n.name)===o),qu=(e,n)=>{let o=e.toLowerCase(),i=n.toLowerCase();return o.localeCompare(i,"en")},xy=e=>e.imports.filter(nn).sort(qu).filter(n=>e.name!==n),uu=(e,n)=>{let o=[];return e.map(n).forEach(i=>{o.push(...i)}),o},Py=e=>{let n={...e};return n.operations=(o=>{let i=new Map;return o.operations.map(r=>{let t={...r};t.imports.push(...uu(t.parameters,s=>s.imports)),t.imports.push(...uu(t.results,s=>s.imports));let a=t.name,l=i.get(a)||0;return l>0&&(t.name=`${a}${l}`),i.set(a,l+1),t})})(n),n.operations.forEach(o=>{n.imports.push(...o.imports)}),n.imports=(o=>o.imports.filter(nn).sort(qu))(n),n},cu=e=>({...e,models:e.models.map(n=>(o=>({...o,imports:xy(o),enums:gy(o),enum:vy(o)}))(n)),services:e.services.map(n=>Py(n))}),Gn=typeof globalThis<"u"?globalThis:typeof window<"u"?window:typeof global<"u"?global:typeof self<"u"?self:{};function by(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var no={exports:{}},he={},H={__esModule:!0};H.extend=pu,H.indexOf=function(e,n){for(var o=0,i=e.length;o<i;o++)if(e[o]===n)return o;return-1},H.escapeExpression=function(e){if(typeof e!="string"){if(e&&e.toHTML)return e.toHTML();if(e==null)return"";if(!e)return e+"";e=""+e}return ky.test(e)?e.replace(wy,Cy):e},H.isEmpty=function(e){return!e&&e!==0||!(!Au(e)||e.length!==0)},H.createFrame=function(e){var n=pu({},e);return n._parent=e,n},H.blockParams=function(e,n){return e.path=n,e},H.appendContextPath=function(e,n){return(e?e+".":"")+n};var Oy={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#x27;","`":"&#x60;","=":"&#x3D;"},wy=/[&<>"'`=]/g,ky=/[&<>"'`=]/;function Cy(e){return Oy[e]}function pu(e){for(var n=1;n<arguments.length;n++)for(var o in arguments[n])Object.prototype.hasOwnProperty.call(arguments[n],o)&&(e[o]=arguments[n][o]);return e}var xo=Object.prototype.toString;H.toString=xo;var Xr=function(e){return typeof e=="function"};Xr(/x/)&&(H.isFunction=Xr=function(e){return typeof e=="function"&&xo.call(e)==="[object Function]"}),H.isFunction=Xr;var Au=Array.isArray||function(e){return!(!e||typeof e!="object")&&xo.call(e)==="[object Array]"};H.isArray=Au;var to={exports:{}};(function(e,n){n.__esModule=!0;var o=["description","fileName","lineNumber","endLineNumber","message","name","number","stack"];function i(r,t){var a=t&&t.loc,l=void 0,s=void 0,u=void 0,p=void 0;a&&(l=a.start.line,s=a.end.line,u=a.start.column,p=a.end.column,r+=" - "+l+":"+u);for(var c=Error.prototype.constructor.call(this,r),f=0;f<o.length;f++)this[o[f]]=c[o[f]];Error.captureStackTrace&&Error.captureStackTrace(this,i);try{a&&(this.lineNumber=l,this.endLineNumber=s,Object.defineProperty?(Object.defineProperty(this,"column",{value:u,enumerable:!0}),Object.defineProperty(this,"endColumn",{value:p,enumerable:!0})):(this.column=u,this.endColumn=p))}catch{}}i.prototype=new Error,n.default=i,e.exports=n.default})(to,to.exports);var tn=to.exports,Kn={},ro={exports:{}};(function(e,n){n.__esModule=!0;var o=H;n.default=function(i){i.registerHelper("blockHelperMissing",function(r,t){var a=t.inverse,l=t.fn;if(r===!0)return l(this);if(r===!1||r==null)return a(this);if(o.isArray(r))return r.length>0?(t.ids&&(t.ids=[t.name]),i.helpers.each(r,t)):a(this);if(t.data&&t.ids){var s=o.createFrame(t.data);s.contextPath=o.appendContextPath(t.data.contextPath,t.name),t={data:s}}return l(r,t)})},e.exports=n.default})(ro,ro.exports);var Sy=ro.exports,oo={exports:{}};(function(e,n){n.__esModule=!0;var o,i=H,r=(o=tn)&&o.__esModule?o:{default:o};n.default=function(t){t.registerHelper("each",function(a,l){if(!l)throw new r.default("Must pass iterator to #each");var s,u=l.fn,p=l.inverse,c=0,f="",m=void 0,d=void 0;function y(L,ae,_){m&&(m.key=L,m.index=ae,m.first=ae===0,m.last=!!_,d&&(m.contextPath=d+L)),f+=u(a[L],{data:m,blockParams:i.blockParams([a[L],L],[d+L,null])})}if(l.data&&l.ids&&(d=i.appendContextPath(l.data.contextPath,l.ids[0])+"."),i.isFunction(a)&&(a=a.call(this)),l.data&&(m=i.createFrame(l.data)),a&&typeof a=="object")if(i.isArray(a))for(var g=a.length;c<g;c++)c in a&&y(c,c,c===a.length-1);else if(Gn.Symbol&&a[Gn.Symbol.iterator]){for(var P=[],x=a[Gn.Symbol.iterator](),S=x.next();!S.done;S=x.next())P.push(S.value);for(g=(a=P).length;c<g;c++)y(c,c,c===a.length-1)}else s=void 0,Object.keys(a).forEach(function(L){s!==void 0&&y(s,c-1),s=L,c++}),s!==void 0&&y(s,c-1,!0);return c===0&&(f=p(this)),f})},e.exports=n.default})(oo,oo.exports);var Ey=oo.exports,ao={exports:{}};(function(e,n){n.__esModule=!0;var o,i=(o=tn)&&o.__esModule?o:{default:o};n.default=function(r){r.registerHelper("helperMissing",function(){if(arguments.length!==1)throw new i.default('Missing helper: "'+arguments[arguments.length-1].name+'"')})},e.exports=n.default})(ao,ao.exports);var Ry=ao.exports,io={exports:{}};(function(e,n){n.__esModule=!0;var o,i=H,r=(o=tn)&&o.__esModule?o:{default:o};n.default=function(t){t.registerHelper("if",function(a,l){if(arguments.length!=2)throw new r.default("#if requires exactly one argument");return i.isFunction(a)&&(a=a.call(this)),!l.hash.includeZero&&!a||i.isEmpty(a)?l.inverse(this):l.fn(this)}),t.registerHelper("unless",function(a,l){if(arguments.length!=2)throw new r.default("#unless requires exactly one argument");return t.helpers.if.call(this,a,{fn:l.inverse,inverse:l.fn,hash:l.hash})})},e.exports=n.default})(io,io.exports);var qy=io.exports,lo={exports:{}};(function(e,n){n.__esModule=!0,n.default=function(o){o.registerHelper("log",function(){for(var i=[void 0],r=arguments[arguments.length-1],t=0;t<arguments.length-1;t++)i.push(arguments[t]);var a=1;r.hash.level!=null?a=r.hash.level:r.data&&r.data.level!=null&&(a=r.data.level),i[0]=a,o.log.apply(o,i)})},e.exports=n.default})(lo,lo.exports);var Ay=lo.exports,so={exports:{}};(function(e,n){n.__esModule=!0,n.default=function(o){o.registerHelper("lookup",function(i,r,t){return i&&t.lookupProperty(i,r)})},e.exports=n.default})(so,so.exports);var Ty=so.exports,uo={exports:{}};(function(e,n){n.__esModule=!0;var o,i=H,r=(o=tn)&&o.__esModule?o:{default:o};n.default=function(t){t.registerHelper("with",function(a,l){if(arguments.length!=2)throw new r.default("#with requires exactly one argument");i.isFunction(a)&&(a=a.call(this));var s=l.fn;if(i.isEmpty(a))return l.inverse(this);var u=l.data;return l.data&&l.ids&&((u=i.createFrame(l.data)).contextPath=i.appendContextPath(l.data.contextPath,l.ids[0])),s(a,{data:u,blockParams:i.blockParams([a],[u&&u.contextPath])})})},e.exports=n.default})(uo,uo.exports);var Iy=uo.exports;function rn(e){return e&&e.__esModule?e:{default:e}}Kn.__esModule=!0,Kn.registerDefaultHelpers=function(e){_y.default(e),jy.default(e),Dy.default(e),Ny.default(e),Hy.default(e),Fy.default(e),$y.default(e)},Kn.moveHelperToHooks=function(e,n,o){e.helpers[n]&&(e.hooks[n]=e.helpers[n],o||delete e.helpers[n])};var _y=rn(Sy),jy=rn(Ey),Dy=rn(Ry),Ny=rn(qy),Hy=rn(Ay),Fy=rn(Ty),$y=rn(Iy),co={},po={exports:{}};(function(e,n){n.__esModule=!0;var o=H;n.default=function(i){i.registerDecorator("inline",function(r,t,a,l){var s=r;return t.partials||(t.partials={},s=function(u,p){var c=a.partials;a.partials=o.extend({},c,t.partials);var f=r(u,p);return a.partials=c,f}),t.partials[l.args[0]]=l.fn,s})},e.exports=n.default})(po,po.exports);var Ly=po.exports;co.__esModule=!0,co.registerDefaultDecorators=function(e){My.default(e)};var qt,My=(qt=Ly)&&qt.__esModule?qt:{default:qt},fo={exports:{}};(function(e,n){n.__esModule=!0;var o=H,i={methodMap:["debug","info","warn","error"],level:"info",lookupLevel:function(r){if(typeof r=="string"){var t=o.indexOf(i.methodMap,r.toLowerCase());r=t>=0?t:parseInt(r,10)}return r},log:function(r){if(r=i.lookupLevel(r),typeof console<"u"&&i.lookupLevel(i.level)<=r){var t=i.methodMap[r];console[t]||(t="log");for(var a=arguments.length,l=Array(a>1?a-1:0),s=1;s<a;s++)l[s-1]=arguments[s];console[t].apply(console,l)}}};n.default=i,e.exports=n.default})(fo,fo.exports);var Tu=fo.exports,kn={},By={__esModule:!0,createNewLookupObject:function(){for(var e=arguments.length,n=Array(e),o=0;o<e;o++)n[o]=arguments[o];return Uy.extend.apply(void 0,[Object.create(null)].concat(n))}},Uy=H;kn.__esModule=!0,kn.createProtoAccessControl=function(e){var n=Object.create(null);n.constructor=!1,n.__defineGetter__=!1,n.__defineSetter__=!1,n.__lookupGetter__=!1;var o=Object.create(null);return o.__proto__=!1,{properties:{whitelist:fu.createNewLookupObject(o,e.allowedProtoProperties),defaultValue:e.allowProtoPropertiesByDefault},methods:{whitelist:fu.createNewLookupObject(n,e.allowedProtoMethods),defaultValue:e.allowProtoMethodsByDefault}}},kn.resultIsAllowed=function(e,n,o){return Vy(typeof e=="function"?n.methods:n.properties,o)},kn.resetLoggedProperties=function(){Object.keys(_t).forEach(function(e){delete _t[e]})};var fu=By,Wy=function(e){if(e&&e.__esModule)return e;var n={};if(e!=null)for(var o in e)Object.prototype.hasOwnProperty.call(e,o)&&(n[o]=e[o]);return n.default=e,n}(Tu),_t=Object.create(null);function Vy(e,n){return e.whitelist[n]!==void 0?e.whitelist[n]===!0:e.defaultValue!==void 0?e.defaultValue:(function(o){_t[o]!==!0&&(_t[o]=!0,Wy.log("error",'Handlebars: Access has been denied to resolve the property "'+o+`" because it is not an "own property" of its parent.
+You can add a runtime option to disable the check or this warning:
+See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details`))}(n),!1)}function Iu(e){return e&&e.__esModule?e:{default:e}}he.__esModule=!0,he.HandlebarsEnvironment=mo;var Xe=H,Zr=Iu(tn),Yy=Kn,Jy=co,jt=Iu(Tu),Gy=kn;he.VERSION="4.7.7";he.COMPILER_REVISION=8;he.LAST_COMPATIBLE_COMPILER_REVISION=7;he.REVISION_CHANGES={1:"<= 1.0.rc.2",2:"== 1.0.0-rc.3",3:"== 1.0.0-rc.4",4:"== 1.x.x",5:"== 2.0.0-alpha.x",6:">= 2.0.0-beta.1",7:">= 4.0.0 <4.3.0",8:">= 4.3.0"};var eo="[object Object]";function mo(e,n,o){this.helpers=e||{},this.partials=n||{},this.decorators=o||{},Yy.registerDefaultHelpers(this),Jy.registerDefaultDecorators(this)}mo.prototype={constructor:mo,logger:jt.default,log:jt.default.log,registerHelper:function(e,n){if(Xe.toString.call(e)===eo){if(n)throw new Zr.default("Arg not supported with multiple helpers");Xe.extend(this.helpers,e)}else this.helpers[e]=n},unregisterHelper:function(e){delete this.helpers[e]},registerPartial:function(e,n){if(Xe.toString.call(e)===eo)Xe.extend(this.partials,e);else{if(n===void 0)throw new Zr.default('Attempting to register a partial called "'+e+'" as undefined');this.partials[e]=n}},unregisterPartial:function(e){delete this.partials[e]},registerDecorator:function(e,n){if(Xe.toString.call(e)===eo){if(n)throw new Zr.default("Arg not supported with multiple decorators");Xe.extend(this.decorators,e)}else this.decorators[e]=n},unregisterDecorator:function(e){delete this.decorators[e]},resetLoggedPropertyAccesses:function(){Gy.resetLoggedProperties()}};var Ky=jt.default.log;he.log=Ky,he.createFrame=Xe.createFrame,he.logger=jt.default;var ho={exports:{}};(function(e,n){function o(i){this.string=i}n.__esModule=!0,o.prototype.toString=o.prototype.toHTML=function(){return""+this.string},n.default=o,e.exports=n.default})(ho,ho.exports);var zy=ho.exports,Ue={},yo={};yo.__esModule=!0,yo.wrapHelper=function(e,n){return typeof e!="function"?e:function(){return arguments[arguments.length-1]=n(arguments[arguments.length-1]),e.apply(this,arguments)}},Ue.__esModule=!0,Ue.checkRevision=function(e){var n=e&&e[0]||1,o=Re.COMPILER_REVISION;if(!(n>=Re.LAST_COMPATIBLE_COMPILER_REVISION&&n<=Re.COMPILER_REVISION)){if(n<Re.LAST_COMPATIBLE_COMPILER_REVISION){var i=Re.REVISION_CHANGES[o],r=Re.REVISION_CHANGES[n];throw new Ee.default("Template was precompiled with an older version of Handlebars than the current runtime. Please update your precompiler to a newer version ("+i+") or downgrade your runtime to an older version ("+r+").")}throw new Ee.default("Template was precompiled with a newer version of Handlebars than the current runtime. Please update your runtime to a newer version ("+e[1]+").")}},Ue.template=function(e,n){if(!n)throw new Ee.default("No environment passed to template");if(!e||!e.main)throw new Ee.default("Unknown template object: "+typeof e);e.main.decorator=e.main_d,n.VM.checkRevision(e.compiler);var o=e.compiler&&e.compiler[0]===7,i={strict:function(t,a,l){if(!t||!(a in t))throw new Ee.default('"'+a+'" not defined in '+t,{loc:l});return i.lookupProperty(t,a)},lookupProperty:function(t,a){var l=t[a];return l==null||Object.prototype.hasOwnProperty.call(t,a)||du.resultIsAllowed(l,i.protoAccessControl,a)?l:void 0},lookup:function(t,a){for(var l=t.length,s=0;s<l;s++)if((t[s]&&i.lookupProperty(t[s],a))!=null)return t[s][a]},lambda:function(t,a){return typeof t=="function"?t.call(a):t},escapeExpression:qe.escapeExpression,invokePartial:function(t,a,l){l.hash&&(a=qe.extend({},a,l.hash),l.ids&&(l.ids[0]=!0)),t=n.VM.resolvePartial.call(this,t,a,l);var s=qe.extend({},l,{hooks:this.hooks,protoAccessControl:this.protoAccessControl}),u=n.VM.invokePartial.call(this,t,a,s);if(u==null&&n.compile&&(l.partials[l.name]=n.compile(t,e.compilerOptions,n),u=l.partials[l.name](a,s)),u!=null){if(l.indent){for(var p=u.split(`
+`),c=0,f=p.length;c<f&&(p[c]||c+1!==f);c++)p[c]=l.indent+p[c];u=p.join(`
+`)}return u}throw new Ee.default("The partial "+l.name+" could not be compiled when running in runtime-only mode")},fn:function(t){var a=e[t];return a.decorator=e[t+"_d"],a},programs:[],program:function(t,a,l,s,u){var p=this.programs[t],c=this.fn(t);return a||u||s||l?p=At(this,t,c,a,l,s,u):p||(p=this.programs[t]=At(this,t,c)),p},data:function(t,a){for(;t&&a--;)t=t._parent;return t},mergeIfNeeded:function(t,a){var l=t||a;return t&&a&&t!==a&&(l=qe.extend({},a,t)),l},nullContext:Object.seal({}),noop:n.VM.noop,compilerInfo:e.compiler};function r(t){var a=arguments.length<=1||arguments[1]===void 0?{}:arguments[1],l=a.data;r._setup(a),!a.partial&&e.useData&&(l=function(c,f){return f&&"root"in f||((f=f?Re.createFrame(f):{}).root=c),f}(t,l));var s=void 0,u=e.useBlockParams?[]:void 0;function p(c){return""+e.main(i,c,i.helpers,i.partials,l,u,s)}return e.useDepths&&(s=a.depths?t!=a.depths[0]?[t].concat(a.depths):a.depths:[t]),(p=_u(e.main,p,i,a.depths||[],l,u))(t,a)}return r.isTop=!0,r._setup=function(t){if(t.partial)i.protoAccessControl=t.protoAccessControl,i.helpers=t.helpers,i.partials=t.partials,i.decorators=t.decorators,i.hooks=t.hooks;else{var a=qe.extend({},n.helpers,t.helpers);(function(s,u){Object.keys(s).forEach(function(p){var c=s[p];s[p]=function(f,m){var d=m.lookupProperty;return Qy.wrapHelper(f,function(y){return qe.extend({lookupProperty:d},y)})}(c,u)})})(a,i),i.helpers=a,e.usePartial&&(i.partials=i.mergeIfNeeded(t.partials,n.partials)),(e.usePartial||e.useDecorators)&&(i.decorators=qe.extend({},n.decorators,t.decorators)),i.hooks={},i.protoAccessControl=du.createProtoAccessControl(t);var l=t.allowCallsToHelperMissing||o;mu.moveHelperToHooks(i,"helperMissing",l),mu.moveHelperToHooks(i,"blockHelperMissing",l)}},r._child=function(t,a,l,s){if(e.useBlockParams&&!l)throw new Ee.default("must pass block params");if(e.useDepths&&!s)throw new Ee.default("must pass parent depths");return At(i,t,e[t],a,0,l,s)},r},Ue.wrapProgram=At,Ue.resolvePartial=function(e,n,o){return e?e.call||o.name||(o.name=e,e=o.partials[e]):e=o.name==="@partial-block"?o.data["partial-block"]:o.partials[o.name],e},Ue.invokePartial=function(e,n,o){var i=o.data&&o.data["partial-block"];o.partial=!0,o.ids&&(o.data.contextPath=o.ids[0]||o.data.contextPath);var r=void 0;if(o.fn&&o.fn!==hu&&function(){o.data=Re.createFrame(o.data);var t=o.fn;r=o.data["partial-block"]=function(a){var l=arguments.length<=1||arguments[1]===void 0?{}:arguments[1];return l.data=Re.createFrame(l.data),l.data["partial-block"]=i,t(a,l)},t.partials&&(o.partials=qe.extend({},o.partials,t.partials))}(),e===void 0&&r&&(e=r),e===void 0)throw new Ee.default("The partial "+o.name+" could not be found");if(e instanceof Function)return e(n,o)},Ue.noop=hu;var qe=function(e){if(e&&e.__esModule)return e;var n={};if(e!=null)for(var o in e)Object.prototype.hasOwnProperty.call(e,o)&&(n[o]=e[o]);return n.default=e,n}(H),Ee=function(e){return e&&e.__esModule?e:{default:e}}(tn),Re=he,mu=Kn,Qy=yo,du=kn;function At(e,n,o,i,r,t,a){function l(s){var u=arguments.length<=1||arguments[1]===void 0?{}:arguments[1],p=a;return!a||s==a[0]||s===e.nullContext&&a[0]===null||(p=[s].concat(a)),o(e,s,e.helpers,e.partials,u.data||i,t&&[u.blockParams].concat(t),p)}return(l=_u(o,l,e,a,i,t)).program=n,l.depth=a?a.length:0,l.blockParams=r||0,l}function hu(){return""}function _u(e,n,o,i,r,t){if(e.decorator){var a={};n=e.decorator(n,a,o,i&&i[0],r,t,i),qe.extend(n,a)}return n}var vo={exports:{}};(function(e,n){n.__esModule=!0,n.default=function(o){var i=Gn!==void 0?Gn:window,r=i.Handlebars;o.noConflict=function(){return i.Handlebars===o&&(i.Handlebars=r),o}},e.exports=n.default})(vo,vo.exports);var Xy=vo.exports;(function(e,n){function o(f){return f&&f.__esModule?f:{default:f}}function i(f){if(f&&f.__esModule)return f;var m={};if(f!=null)for(var d in f)Object.prototype.hasOwnProperty.call(f,d)&&(m[d]=f[d]);return m.default=f,m}n.__esModule=!0;var r=i(he),t=o(zy),a=o(tn),l=i(H),s=i(Ue),u=o(Xy);function p(){var f=new r.HandlebarsEnvironment;return l.extend(f,r),f.SafeString=t.default,f.Exception=a.default,f.Utils=l,f.escapeExpression=l.escapeExpression,f.VM=s,f.template=function(m){return s.template(m,f)},f}var c=p();c.create=p,u.default(c),c.default=c,n.default=c,e.exports=n.default})(no,no.exports);var h=by(no.exports.default),Zy={1:function(e,n,o,i,r){return`import { NgModule} from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+
+import { AngularHttpRequest } from './core/AngularHttpRequest';
+import { BaseHttpRequest } from './core/BaseHttpRequest';
+import type { OpenAPIConfig } from './core/OpenAPI';
+import { OpenAPI } from './core/OpenAPI';
+`},3:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return`import type { BaseHttpRequest } from './core/BaseHttpRequest';
+import type { OpenAPIConfig } from './core/OpenAPI';
+import { `+((t=l(a(n,"httpRequest",{start:{line:14,column:12},end:{line:14,column:23}}),n))!=null?t:"")+" } from './core/"+((t=l(a(n,"httpRequest",{start:{line:14,column:45},end:{line:14,column:56}}),n))!=null?t:"")+`';
+`},5:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"each").call(n??(e.nullContext||{}),a(n,"services"),{name:"each",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:18,column:0},end:{line:20,column:9}}}))!=null?t:""},6:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"import { "+((t=l(a(n,"name",{start:{line:19,column:12},end:{line:19,column:16}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfix",{start:{line:19,column:22},end:{line:19,column:35}}),n))!=null?t:"")+" } from './services/"+((t=l(a(n,"name",{start:{line:19,column:61},end:{line:19,column:65}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfix",{start:{line:19,column:71},end:{line:19,column:84}}),n))!=null?t:"")+`';
+`},8:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return`@NgModule({
+	imports: [HttpClientModule],
+	providers: [
+		{
+			provide: OpenAPI,
+			useValue: {
+				BASE: OpenAPI?.BASE ?? '`+((t=l(a(n,"server",{start:{line:30,column:31},end:{line:30,column:37}}),n))!=null?t:"")+`',
+				VERSION: OpenAPI?.VERSION ?? '`+((t=l(a(n,"version",{start:{line:31,column:37},end:{line:31,column:44}}),n))!=null?t:"")+`',
+				WITH_CREDENTIALS: OpenAPI?.WITH_CREDENTIALS ?? false,
+				CREDENTIALS: OpenAPI?.CREDENTIALS ?? 'include',
+				TOKEN: OpenAPI?.TOKEN,
+				USERNAME: OpenAPI?.USERNAME,
+				PASSWORD: OpenAPI?.PASSWORD,
+				HEADERS: OpenAPI?.HEADERS,
+				ENCODE_PATH: OpenAPI?.ENCODE_PATH,
+			} as OpenAPIConfig,
+		},
+		{
+			provide: BaseHttpRequest,
+			useClass: AngularHttpRequest,
+		},
+`+((t=s(o,"each").call(n??(e.nullContext||{}),s(n,"services"),{name:"each",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:45,column:2},end:{line:47,column:11}}}))!=null?t:"")+`	]
+})
+export class `+((t=l(a(n,"clientName",{start:{line:50,column:16},end:{line:50,column:26}}),n))!=null?t:"")+` {}
+`},9:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"		"+((t=l(a(n,"name",{start:{line:46,column:5},end:{line:46,column:9}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfix",{start:{line:46,column:15},end:{line:46,column:28}}),n))!=null?t:"")+`,
+`},11:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=n??(e.nullContext||{}),u=e.lookupProperty||function(p,c){if(Object.prototype.hasOwnProperty.call(p,c))return p[c]};return`type HttpRequestConstructor = new (config: OpenAPIConfig) => BaseHttpRequest;
+
+export class `+((t=l(a(n,"clientName",{start:{line:54,column:16},end:{line:54,column:26}}),n))!=null?t:"")+` {
+
+`+((t=u(o,"each").call(s,u(n,"services"),{name:"each",hash:{},fn:e.program(12,r,0),inverse:e.noop,data:r,loc:{start:{line:56,column:1},end:{line:58,column:10}}}))!=null?t:"")+`
+	public readonly request: BaseHttpRequest;
+
+	constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = `+((t=l(a(n,"httpRequest",{start:{line:62,column:87},end:{line:62,column:98}}),n))!=null?t:"")+`) {
+		this.request = new HttpRequest({
+			BASE: config?.BASE ?? '`+((t=l(a(n,"server",{start:{line:64,column:29},end:{line:64,column:35}}),n))!=null?t:"")+`',
+			VERSION: config?.VERSION ?? '`+((t=l(a(n,"version",{start:{line:65,column:35},end:{line:65,column:42}}),n))!=null?t:"")+`',
+			WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
+			CREDENTIALS: config?.CREDENTIALS ?? 'include',
+			TOKEN: config?.TOKEN,
+			USERNAME: config?.USERNAME,
+			PASSWORD: config?.PASSWORD,
+			HEADERS: config?.HEADERS,
+			ENCODE_PATH: config?.ENCODE_PATH,
+		});
+
+`+((t=u(o,"each").call(s,u(n,"services"),{name:"each",hash:{},fn:e.program(14,r,0),inverse:e.noop,data:r,loc:{start:{line:75,column:2},end:{line:77,column:11}}}))!=null?t:"")+`	}
+}
+`},12:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"	public readonly "+((t=s(o,"camelCase").call(n??(e.nullContext||{}),s(n,"name"),{name:"camelCase",hash:{},data:r,loc:{start:{line:57,column:17},end:{line:57,column:37}}}))!=null?t:"")+": "+((t=l(a(n,"name",{start:{line:57,column:42},end:{line:57,column:46}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfix",{start:{line:57,column:52},end:{line:57,column:65}}),n))!=null?t:"")+`;
+`},14:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"		this."+((t=s(o,"camelCase").call(n??(e.nullContext||{}),s(n,"name"),{name:"camelCase",hash:{},data:r,loc:{start:{line:76,column:7},end:{line:76,column:27}}}))!=null?t:"")+" = new "+((t=l(a(n,"name",{start:{line:76,column:37},end:{line:76,column:41}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfix",{start:{line:76,column:47},end:{line:76,column:60}}),n))!=null?t:"")+`(this.request);
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=e.invokePartial(l(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:3,column:0},end:{line:15,column:11}}}))!=null?t:"")+`
+`+((t=l(o,"if").call(a,l(n,"services"),{name:"if",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:17,column:0},end:{line:21,column:7}}}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(8,r,0),inverse:e.program(11,r,0),data:r,loc:{start:{line:23,column:0},end:{line:80,column:11}}}))!=null?t:"")},usePartial:!0,useData:!0},e0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): Observable<HttpHeaders> => {
+	return forkJoin({
+		token: resolve(options, config.TOKEN),
+		username: resolve(options, config.USERNAME),
+		password: resolve(options, config.PASSWORD),
+		additionalHeaders: resolve(options, config.HEADERS),
+	}).pipe(
+		map(({ token, username, password, additionalHeaders }) => {
+			const headers = Object.entries({
+				Accept: 'application/json',
+				...additionalHeaders,
+				...options.headers,
+			})
+				.filter(([_, value]) => isDefined(value))
+				.reduce((headers, [key, value]) => ({
+					...headers,
+					[key]: String(value),
+				}), {} as Record<string, string>);
+
+			if (isStringWithValue(token)) {
+				headers['Authorization'] = \`Bearer \${token}\`;
+			}
+
+			if (isStringWithValue(username) && isStringWithValue(password)) {
+				const credentials = base64(\`\${username}:\${password}\`);
+				headers['Authorization'] = \`Basic \${credentials}\`;
+			}
+
+			if (options.body) {
+				if (options.mediaType) {
+					headers['Content-Type'] = options.mediaType;
+				} else if (isBlob(options.body)) {
+					headers['Content-Type'] = options.body.type || 'application/octet-stream';
+				} else if (isString(options.body)) {
+					headers['Content-Type'] = 'text/plain';
+				} else if (!isFormData(options.body)) {
+					headers['Content-Type'] = 'application/json';
+				}
+			}
+
+			return new HttpHeaders(headers);
+		}),
+	);
+};`},useData:!0},n0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getRequestBody = (options: ApiRequestOptions): any => {
+	if (options.body) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
+};`},useData:!0},t0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseBody = <T>(response: HttpResponse<T>): T | undefined => {
+	if (response.status !== 204 && response.body !== null) {
+		return response.body;
+	}
+	return undefined;
+};`},useData:!0},r0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseHeader = <T>(response: HttpResponse<T>, responseHeader?: string): string | undefined => {
+	if (responseHeader) {
+		const value = response.headers.get(responseHeader);
+		if (isString(value)) {
+			return value;
+		}
+	}
+	return undefined;
+};`},useData:!0},o0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import type { HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { forkJoin, of, throwError } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import type { Observable } from 'rxjs';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import type { OpenAPIConfig } from './OpenAPI';
+
+`+((t=e.invokePartial(a(i,"functions/isDefined"),n,{name:"functions/isDefined",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isString"),n,{name:"functions/isString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isStringWithValue"),n,{name:"functions/isStringWithValue",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isBlob"),n,{name:"functions/isBlob",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isFormData"),n,{name:"functions/isFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/base64"),n,{name:"functions/base64",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getQueryString"),n,{name:"functions/getQueryString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getUrl"),n,{name:"functions/getUrl",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getFormData"),n,{name:"functions/getFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/resolve"),n,{name:"functions/resolve",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"angular/getHeaders"),n,{name:"angular/getHeaders",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"angular/getRequestBody"),n,{name:"angular/getRequestBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"angular/sendRequest"),n,{name:"angular/sendRequest",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"angular/getResponseHeader"),n,{name:"angular/getResponseHeader",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"angular/getResponseBody"),n,{name:"angular/getResponseBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/catchErrorCodes"),n,{name:"functions/catchErrorCodes",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param http The Angular HTTP client
+ * @param options The request options from the service
+ * @returns Observable<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, http: HttpClient, options: ApiRequestOptions): Observable<T> => {
+	const url = getUrl(config, options);
+	const formData = getFormData(options);
+	const body = getRequestBody(options);
+
+	return getHeaders(config, options).pipe(
+		switchMap(headers => {
+			return sendRequest<T>(config, options, http, url, formData, body, headers);
+		}),
+		map(response => {
+			const responseBody = getResponseBody(response);
+			const responseHeader = getResponseHeader(response, options.responseHeader);
+			return {
+				url,
+				ok: response.ok,
+				status: response.status,
+				statusText: response.statusText,
+				body: responseHeader ?? responseBody,
+			} as ApiResult;
+		}),
+		catchError((error: HttpErrorResponse) => {
+			if (!error.status) {
+				return throwError(error);
+			}
+			return of({
+				url,
+				ok: error.ok,
+				status: error.status,
+				statusText: error.statusText,
+				body: error.error ?? error.statusText,
+			} as ApiResult);
+		}),
+		map(result => {
+			catchErrorCodes(options, result);
+			return result.body as T;
+		}),
+		catchError((error: ApiError) => {
+			return throwError(error);
+		}),
+	);
+};`},usePartial:!0,useData:!0},a0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const sendRequest = <T>(
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	http: HttpClient,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: HttpHeaders
+): Observable<HttpResponse<T>> => {
+	return http.request<T>(options.method, url, {
+		headers,
+		body: body ?? formData,
+		withCredentials: config.WITH_CREDENTIALS,
+		observe: 'response',
+	});
+};`},useData:!0},i0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+	public readonly url: string;
+	public readonly status: number;
+	public readonly statusText: string;
+	public readonly body: any;
+	public readonly request: ApiRequestOptions;
+
+	constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+		super(message);
+
+		this.name = 'ApiError';
+		this.url = response.url;
+		this.status = response.status;
+		this.statusText = response.statusText;
+		this.body = response.body;
+		this.request = request;
+	}
+}`},usePartial:!0,useData:!0},l0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+export type ApiRequestOptions = {
+	readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+	readonly url: string;
+	readonly path?: Record<string, any>;
+	readonly cookies?: Record<string, any>;
+	readonly headers?: Record<string, any>;
+	readonly query?: Record<string, any>;
+	readonly formData?: Record<string, any>;
+	readonly body?: any;
+	readonly mediaType?: string;
+	readonly responseHeader?: string;
+	readonly errors?: Record<number, string>;
+};`},usePartial:!0,useData:!0},s0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+export type ApiResult = {
+	readonly url: string;
+	readonly ok: boolean;
+	readonly status: number;
+	readonly statusText: string;
+	readonly body: any;
+};`},usePartial:!0,useData:!0},u0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+	const token = await resolve(options, config.TOKEN);
+	const username = await resolve(options, config.USERNAME);
+	const password = await resolve(options, config.PASSWORD);
+	const additionalHeaders = await resolve(options, config.HEADERS);
+	const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+		...formHeaders,
+	})
+	.filter(([_, value]) => isDefined(value))
+	.reduce((headers, [key, value]) => ({
+		...headers,
+		[key]: String(value),
+	}), {} as Record<string, string>);
+
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
+
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
+
+	if (options.body) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
+
+	return headers;
+};`},useData:!0},c0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getRequestBody = (options: ApiRequestOptions): any => {
+	if (options.body) {
+		return options.body;
+	}
+	return undefined;
+};`},useData:!0},p0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseBody = (response: AxiosResponse<any>): any => {
+	if (response.status !== 204) {
+		return response.data;
+	}
+	return undefined;
+};`},useData:!0},f0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+	if (responseHeader) {
+		const content = response.headers[responseHeader];
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
+};`},useData:!0},m0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
+import FormData from 'form-data';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+`+((t=e.invokePartial(a(i,"functions/isDefined"),n,{name:"functions/isDefined",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isString"),n,{name:"functions/isString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isStringWithValue"),n,{name:"functions/isStringWithValue",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isBlob"),n,{name:"functions/isBlob",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isFormData"),n,{name:"functions/isFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isSuccess"),n,{name:"functions/isSuccess",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/base64"),n,{name:"functions/base64",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getQueryString"),n,{name:"functions/getQueryString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getUrl"),n,{name:"functions/getUrl",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getFormData"),n,{name:"functions/getFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/resolve"),n,{name:"functions/resolve",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"axios/getHeaders"),n,{name:"axios/getHeaders",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"axios/getRequestBody"),n,{name:"axios/getRequestBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"axios/sendRequest"),n,{name:"axios/sendRequest",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"axios/getResponseHeader"),n,{name:"axios/getResponseHeader",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"axios/getResponseBody"),n,{name:"axios/getResponseBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/catchErrorCodes"),n,{name:"functions/catchErrorCodes",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options, formData);
+
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
+				const responseBody = getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
+
+				const result: ApiResult = {
+					url,
+					ok: isSuccess(response.status),
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
+
+				catchErrorCodes(options, result);
+
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};`},usePartial:!0,useData:!0},d0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const sendRequest = async <T>(
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Record<string, string>,
+	onCancel: OnCancel,
+	axiosClient: AxiosInstance
+): Promise<AxiosResponse<T>> => {
+	const source = axios.CancelToken.source();
+
+	const requestConfig: AxiosRequestConfig = {
+		url,
+		headers,
+		data: body ?? formData,
+		method: options.method,
+		withCredentials: config.WITH_CREDENTIALS,
+		cancelToken: source.token,
+	};
+
+	onCancel(() => source.cancel('The user aborted a request.'));
+
+	try {
+		return await axiosClient.request(requestConfig);
+	} catch (error) {
+		const axiosError = error as AxiosError<T>;
+		if (axiosError.response) {
+			return axiosError.response;
+		}
+		throw error;
+	}
+};`},useData:!0},h0={1:function(e,n,o,i,r){return`import type { HttpClient } from '@angular/common/http';
+import type { Observable } from 'rxjs';
+
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { OpenAPIConfig } from './OpenAPI';
+`},3:function(e,n,o,i,r){return`import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { CancelablePromise } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+`},5:function(e,n,o,i,r){return`	constructor(
+		public readonly config: OpenAPIConfig,
+		public readonly http: HttpClient,
+	) {}
+`},7:function(e,n,o,i,r){return`	constructor(public readonly config: OpenAPIConfig) {}
+`},9:function(e,n,o,i,r){return`	public abstract request<T>(options: ApiRequestOptions): Observable<T>;
+`},11:function(e,n,o,i,r){return`	public abstract request<T>(options: ApiRequestOptions): CancelablePromise<T>;
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=e.invokePartial(l(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:3,column:0},end:{line:13,column:11}}}))!=null?t:"")+`
+export abstract class BaseHttpRequest {
+
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(5,r,0),inverse:e.program(7,r,0),data:r,loc:{start:{line:17,column:1},end:{line:24,column:12}}}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(9,r,0),inverse:e.program(11,r,0),data:r,loc:{start:{line:26,column:1},end:{line:30,column:12}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},y0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+export class CancelError extends Error {
+
+	constructor(message: string) {
+		super(message);
+		this.name = 'CancelError';
+	}
+
+	public get isCancelled(): boolean {
+		return true;
+	}
+}
+
+export interface OnCancel {
+	readonly isResolved: boolean;
+	readonly isRejected: boolean;
+	readonly isCancelled: boolean;
+
+	(cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+	#isResolved: boolean;
+	#isRejected: boolean;
+	#isCancelled: boolean;
+	readonly #cancelHandlers: (() => void)[];
+	readonly #promise: Promise<T>;
+	#resolve?: (value: T | PromiseLike<T>) => void;
+	#reject?: (reason?: any) => void;
+
+	constructor(
+		executor: (
+			resolve: (value: T | PromiseLike<T>) => void,
+			reject: (reason?: any) => void,
+			onCancel: OnCancel
+		) => void
+	) {
+		this.#isResolved = false;
+		this.#isRejected = false;
+		this.#isCancelled = false;
+		this.#cancelHandlers = [];
+		this.#promise = new Promise<T>((resolve, reject) => {
+			this.#resolve = resolve;
+			this.#reject = reject;
+
+			const onResolve = (value: T | PromiseLike<T>): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#isResolved = true;
+				this.#resolve?.(value);
+			};
+
+			const onReject = (reason?: any): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#isRejected = true;
+				this.#reject?.(reason);
+			};
+
+			const onCancel = (cancelHandler: () => void): void => {
+				if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+					return;
+				}
+				this.#cancelHandlers.push(cancelHandler);
+			};
+
+			Object.defineProperty(onCancel, 'isResolved', {
+				get: (): boolean => this.#isResolved,
+			});
+
+			Object.defineProperty(onCancel, 'isRejected', {
+				get: (): boolean => this.#isRejected,
+			});
+
+			Object.defineProperty(onCancel, 'isCancelled', {
+				get: (): boolean => this.#isCancelled,
+			});
+
+			return executor(onResolve, onReject, onCancel as OnCancel);
+		});
+	}
+
+	 get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+	public then<TResult1 = T, TResult2 = never>(
+		onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+		onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+	): Promise<TResult1 | TResult2> {
+		return this.#promise.then(onFulfilled, onRejected);
+	}
+
+	public catch<TResult = never>(
+		onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+	): Promise<T | TResult> {
+		return this.#promise.catch(onRejected);
+	}
+
+	public finally(onFinally?: (() => void) | null): Promise<T> {
+		return this.#promise.finally(onFinally);
+	}
+
+	public cancel(): void {
+		if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+			return;
+		}
+		this.#isCancelled = true;
+		if (this.#cancelHandlers.length) {
+			try {
+				for (const cancelHandler of this.#cancelHandlers) {
+					cancelHandler();
+				}
+			} catch (error) {
+				console.warn('Cancellation threw an error', error);
+				return;
+			}
+		}
+		this.#cancelHandlers.length = 0;
+		this.#reject?.(new CancelError('Request aborted'));
+	}
+
+	public get isCancelled(): boolean {
+		return this.#isCancelled;
+	}
+}`},usePartial:!0,useData:!0},v0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+	const token = await resolve(options, config.TOKEN);
+	const username = await resolve(options, config.USERNAME);
+	const password = await resolve(options, config.PASSWORD);
+	const additionalHeaders = await resolve(options, config.HEADERS);
+
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => isDefined(value))
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
+
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
+
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
+
+	if (options.body) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
+
+	return new Headers(headers);
+};`},useData:!0},g0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getRequestBody = (options: ApiRequestOptions): any => {
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
+};`},useData:!0},x0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseBody = async (response: Response): Promise<any> => {
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
+};`},useData:!0},P0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
+};`},useData:!0},b0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+`+((t=e.invokePartial(a(i,"functions/isDefined"),n,{name:"functions/isDefined",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isString"),n,{name:"functions/isString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isStringWithValue"),n,{name:"functions/isStringWithValue",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isBlob"),n,{name:"functions/isBlob",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isFormData"),n,{name:"functions/isFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/base64"),n,{name:"functions/base64",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getQueryString"),n,{name:"functions/getQueryString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getUrl"),n,{name:"functions/getUrl",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getFormData"),n,{name:"functions/getFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/resolve"),n,{name:"functions/resolve",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/getHeaders"),n,{name:"fetch/getHeaders",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/getRequestBody"),n,{name:"fetch/getRequestBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/sendRequest"),n,{name:"fetch/sendRequest",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/getResponseHeader"),n,{name:"fetch/getResponseHeader",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/getResponseBody"),n,{name:"fetch/getResponseBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/catchErrorCodes"),n,{name:"functions/catchErrorCodes",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
+
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
+
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
+
+				catchErrorCodes(options, result);
+
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};`},usePartial:!0,useData:!0},O0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const sendRequest = async (
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
+): Promise<Response> => {
+	const controller = new AbortController();
+
+	const request: RequestInit = {
+		headers,
+		body: body ?? formData,
+		method: options.method,
+		signal: controller.signal,
+	};
+
+	if (config.WITH_CREDENTIALS) {
+		request.credentials = config.CREDENTIALS;
+	}
+
+	onCancel(() => controller.abort());
+
+	return await fetch(url, request);
+};`},useData:!0},w0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const base64 = (str: string): string => {
+	try {
+		return btoa(str);
+	} catch (err) {
+		// @ts-ignore
+		return Buffer.from(str).toString('base64');
+	}
+};`},useData:!0},k0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+	const errors: Record<number, string> = {
+		400: 'Bad Request',
+		401: 'Unauthorized',
+		403: 'Forbidden',
+		404: 'Not Found',
+		500: 'Internal Server Error',
+		502: 'Bad Gateway',
+		503: 'Service Unavailable',
+		...options.errors,
+	}
+
+	const error = errors[result.status];
+	if (error) {
+		throw new ApiError(options, result, error);
+	}
+
+	if (!result.ok) {
+		const errorStatus = result.status ?? 'unknown';
+		const errorStatusText = result.statusText ?? 'unknown';
+		const errorBody = (() => {
+			try {
+				return JSON.stringify(result.body, null, 2);
+			} catch (e) {
+				return undefined;
+			}
+		})();
+
+		throw new ApiError(options, result,
+			\`Generic Error: status: \${errorStatus}; status text: \${errorStatusText}; body: \${errorBody}\`
+		);
+	}
+};`},useData:!0},C0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+	if (options.formData) {
+		const formData = new FormData();
+
+		const process = (key: string, value: any) => {
+			if (isString(value) || isBlob(value)) {
+				formData.append(key, value);
+			} else {
+				formData.append(key, JSON.stringify(value));
+			}
+		};
+
+		Object.entries(options.formData)
+			.filter(([_, value]) => isDefined(value))
+			.forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					value.forEach(v => process(key, v));
+				} else {
+					process(key, value);
+				}
+			});
+
+		return formData;
+	}
+	return undefined;
+};`},useData:!0},S0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getQueryString = (params: Record<string, any>): string => {
+	const qs: string[] = [];
+
+	const append = (key: string, value: any) => {
+		qs.push(\`\${encodeURIComponent(key)}=\${encodeURIComponent(String(value))}\`);
+	};
+
+	const process = (key: string, value: any) => {
+		if (isDefined(value)) {
+			if (Array.isArray(value)) {
+				value.forEach(v => {
+					process(key, v);
+				});
+			} else if (typeof value === 'object') {
+				Object.entries(value).forEach(([k, v]) => {
+					process(\`\${key}[\${k}]\`, v);
+				});
+			} else {
+				append(key, value);
+			}
+		}
+	};
+
+	Object.entries(params).forEach(([key, value]) => {
+		process(key, value);
+	});
+
+	if (qs.length > 0) {
+		return \`?\${qs.join('&')}\`;
+	}
+
+	return '';
+};`},useData:!0},E0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+	const encoder = config.ENCODE_PATH || encodeURI;
+
+	const path = options.url
+		.replace('{api-version}', config.VERSION)
+		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+			if (options.path?.hasOwnProperty(group)) {
+				return encoder(String(options.path[group]));
+			}
+			return substring;
+		});
+
+	const url = \`\${config.BASE}\${path}\`;
+	if (options.query) {
+		return \`\${url}\${getQueryString(options.query)}\`;
+	}
+	return url;
+};`},useData:!0},R0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isBlob = (value: any): value is Blob => {
+	return (
+		typeof value === 'object' &&
+		typeof value.type === 'string' &&
+		typeof value.stream === 'function' &&
+		typeof value.arrayBuffer === 'function' &&
+		typeof value.constructor === 'function' &&
+		typeof value.constructor.name === 'string' &&
+		/^(Blob|File)$/.test(value.constructor.name) &&
+		/^(Blob|File)$/.test(value[Symbol.toStringTag])
+	);
+};`},useData:!0},q0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+	return value !== undefined && value !== null;
+};`},useData:!0},A0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isFormData = (value: any): value is FormData => {
+	return value instanceof FormData;
+};`},useData:!0},T0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isString = (value: any): value is string => {
+	return typeof value === 'string';
+};`},useData:!0},I0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isStringWithValue = (value: any): value is string => {
+	return isString(value) && value !== '';
+};`},useData:!0},_0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const isSuccess = (status: number): boolean => {
+	return status >= 200 && status < 300;
+};`},useData:!0},j0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+	if (typeof resolver === 'function') {
+		return (resolver as Resolver<T>)(options);
+	}
+	return resolver;
+};`},useData:!0},D0={1:function(e,n,o,i,r){return`import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import type { Observable } from 'rxjs';
+
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import { BaseHttpRequest } from './BaseHttpRequest';
+import type { OpenAPIConfig } from './OpenAPI';
+import { OpenAPI } from './OpenAPI';
+import { request as __request } from './request';
+`},3:function(e,n,o,i,r){return`import type { ApiRequestOptions } from './ApiRequestOptions';
+import { BaseHttpRequest } from './BaseHttpRequest';
+import type { CancelablePromise } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+import { request as __request } from './request';
+`},5:function(e,n,o,i,r){return`@Injectable()
+`},7:function(e,n,o,i,r){return`	constructor(
+		@Inject(OpenAPI)
+		config: OpenAPIConfig,
+		http: HttpClient,
+	) {
+		super(config, http);
+	}
+`},9:function(e,n,o,i,r){return`	constructor(config: OpenAPIConfig) {
+		super(config);
+	}
+`},11:function(e,n,o,i,r){return`	/**
+	 * Request method
+	 * @param options The request options from the service
+	 * @returns Observable<T>
+	 * @throws ApiError
+	 */
+	public override request<T>(options: ApiRequestOptions): Observable<T> {
+		return __request(this.config, this.http, options);
+	}
+`},13:function(e,n,o,i,r){return`	/**
+	 * Request method
+	 * @param options The request options from the service
+	 * @returns CancelablePromise<T>
+	 * @throws ApiError
+	 */
+	public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+		return __request(this.config, options);
+	}
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=e.invokePartial(l(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:3,column:0},end:{line:19,column:11}}}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:21,column:0},end:{line:23,column:11}}}))!=null?t:"")+"export class "+((t=e.lambda(e.strict(n,"httpRequest",{start:{line:24,column:15},end:{line:24,column:26}}),n))!=null?t:"")+` extends BaseHttpRequest {
+
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(9,r,0),data:r,loc:{start:{line:26,column:1},end:{line:38,column:12}}}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(11,r,0),inverse:e.program(13,r,0),data:r,loc:{start:{line:40,column:1},end:{line:60,column:12}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},N0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+	const token = await resolve(options, config.TOKEN);
+	const username = await resolve(options, config.USERNAME);
+	const password = await resolve(options, config.PASSWORD);
+	const additionalHeaders = await resolve(options, config.HEADERS);
+
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => isDefined(value))
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
+
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
+
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
+
+	if (options.body) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
+
+	return new Headers(headers);
+};`},useData:!0},H0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getRequestBody = (options: ApiRequestOptions): any => {
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body as any;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
+};`},useData:!0},F0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseBody = async (response: Response): Promise<any> => {
+	if (response.status !== 204) {
+		try {
+			const contentType = response.headers.get('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return await response.json();
+				} else {
+					return await response.text();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
+};`},useData:!0},$0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseHeader = (response: Response, responseHeader?: string): string | undefined => {
+	if (responseHeader) {
+		const content = response.headers.get(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
+};`},useData:!0},L0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import FormData from 'form-data';
+import fetch, { Headers } from 'node-fetch';
+import type { RequestInit, Response } from 'node-fetch';
+import type { AbortSignal } from 'node-fetch/externals';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+`+((t=e.invokePartial(a(i,"functions/isDefined"),n,{name:"functions/isDefined",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isString"),n,{name:"functions/isString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isStringWithValue"),n,{name:"functions/isStringWithValue",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isBlob"),n,{name:"functions/isBlob",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isFormData"),n,{name:"functions/isFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/base64"),n,{name:"functions/base64",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getQueryString"),n,{name:"functions/getQueryString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getUrl"),n,{name:"functions/getUrl",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getFormData"),n,{name:"functions/getFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/resolve"),n,{name:"functions/resolve",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"node/getHeaders"),n,{name:"node/getHeaders",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"node/getRequestBody"),n,{name:"node/getRequestBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"node/sendRequest"),n,{name:"node/sendRequest",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"node/getResponseHeader"),n,{name:"node/getResponseHeader",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"node/getResponseBody"),n,{name:"node/getResponseBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/catchErrorCodes"),n,{name:"functions/catchErrorCodes",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
+
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(options, url, body, formData, headers, onCancel);
+				const responseBody = await getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
+
+				const result: ApiResult = {
+					url,
+					ok: response.ok,
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
+
+				catchErrorCodes(options, result);
+
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};`},usePartial:!0,useData:!0},M0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const sendRequest = async (
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
+): Promise<Response> => {
+	const controller = new AbortController();
+
+	const request: RequestInit = {
+		headers,
+		method: options.method,
+		body: body ?? formData,
+		signal: controller.signal as AbortSignal,
+	};
+
+	onCancel(() => controller.abort());
+
+	return await fetch(url, request);
+};`},useData:!0},B0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return((t=e.invokePartial(s(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+	BASE: string;
+	VERSION: string;
+	WITH_CREDENTIALS: boolean;
+	CREDENTIALS: 'include' | 'omit' | 'same-origin';
+	TOKEN?: string | Resolver<string> | undefined;
+	USERNAME?: string | Resolver<string> | undefined;
+	PASSWORD?: string | Resolver<string> | undefined;
+	HEADERS?: Headers | Resolver<Headers> | undefined;
+	ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+	BASE: '`+((t=l(a(n,"server",{start:{line:21,column:11},end:{line:21,column:17}}),n))!=null?t:"")+`',
+	VERSION: '`+((t=l(a(n,"version",{start:{line:22,column:14},end:{line:22,column:21}}),n))!=null?t:"")+`',
+	WITH_CREDENTIALS: false,
+	CREDENTIALS: 'include',
+	TOKEN: undefined,
+	USERNAME: undefined,
+	PASSWORD: undefined,
+	HEADERS: undefined,
+	ENCODE_PATH: undefined,
+};`},usePartial:!0,useData:!0},U0={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"fetch/request"),n,{name:"fetch/request",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"xhr/request"),n,{name:"xhr/request",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},5:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"axios/request"),n,{name:"axios/request",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"angular/request"),n,{name:"angular/request",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},9:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"node/request"),n,{name:"node/request",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"fetch",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:67}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"xhr",{name:"equals",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:0},end:{line:2,column:63}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"axios",{name:"equals",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:3,column:67}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:4,column:0},end:{line:4,column:71}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"node",{name:"equals",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:5,column:0},end:{line:5,column:65}}}))!=null?t:"")},usePartial:!0,useData:!0},W0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<Headers> => {
+	const token = await resolve(options, config.TOKEN);
+	const username = await resolve(options, config.USERNAME);
+	const password = await resolve(options, config.PASSWORD);
+	const additionalHeaders = await resolve(options, config.HEADERS);
+
+	const headers = Object.entries({
+		Accept: 'application/json',
+		...additionalHeaders,
+		...options.headers,
+	})
+		.filter(([_, value]) => isDefined(value))
+		.reduce((headers, [key, value]) => ({
+			...headers,
+			[key]: String(value),
+		}), {} as Record<string, string>);
+
+	if (isStringWithValue(token)) {
+		headers['Authorization'] = \`Bearer \${token}\`;
+	}
+
+	if (isStringWithValue(username) && isStringWithValue(password)) {
+		const credentials = base64(\`\${username}:\${password}\`);
+		headers['Authorization'] = \`Basic \${credentials}\`;
+	}
+
+	if (options.body) {
+		if (options.mediaType) {
+			headers['Content-Type'] = options.mediaType;
+		} else if (isBlob(options.body)) {
+			headers['Content-Type'] = options.body.type || 'application/octet-stream';
+		} else if (isString(options.body)) {
+			headers['Content-Type'] = 'text/plain';
+		} else if (!isFormData(options.body)) {
+			headers['Content-Type'] = 'application/json';
+		}
+	}
+
+	return new Headers(headers);
+};`},useData:!0},V0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getRequestBody = (options: ApiRequestOptions): any => {
+	if (options.body !== undefined) {
+		if (options.mediaType?.includes('/json')) {
+			return JSON.stringify(options.body)
+		} else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
+			return options.body;
+		} else {
+			return JSON.stringify(options.body);
+		}
+	}
+	return undefined;
+};`},useData:!0},Y0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseBody = (xhr: XMLHttpRequest): any => {
+	if (xhr.status !== 204) {
+		try {
+			const contentType = xhr.getResponseHeader('Content-Type');
+			if (contentType) {
+				const jsonTypes = ['application/json', 'application/problem+json']
+				const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
+				if (isJSON) {
+					return JSON.parse(xhr.responseText);
+				} else {
+					return xhr.responseText;
+				}
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	}
+	return undefined;
+};`},useData:!0},J0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const getResponseHeader = (xhr: XMLHttpRequest, responseHeader?: string): string | undefined => {
+	if (responseHeader) {
+		const content = xhr.getResponseHeader(responseHeader);
+		if (isString(content)) {
+			return content;
+		}
+	}
+	return undefined;
+};`},useData:!0},G0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+`+((t=e.invokePartial(a(i,"functions/isDefined"),n,{name:"functions/isDefined",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isString"),n,{name:"functions/isString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isStringWithValue"),n,{name:"functions/isStringWithValue",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isBlob"),n,{name:"functions/isBlob",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isFormData"),n,{name:"functions/isFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/isSuccess"),n,{name:"functions/isSuccess",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/base64"),n,{name:"functions/base64",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getQueryString"),n,{name:"functions/getQueryString",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getUrl"),n,{name:"functions/getUrl",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/getFormData"),n,{name:"functions/getFormData",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/resolve"),n,{name:"functions/resolve",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"fetch/getHeaders"),n,{name:"fetch/getHeaders",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"xhr/getRequestBody"),n,{name:"xhr/getRequestBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"xhr/sendRequest"),n,{name:"xhr/sendRequest",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"xhr/getResponseHeader"),n,{name:"xhr/getResponseHeader",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"xhr/getResponseBody"),n,{name:"xhr/getResponseBody",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+`+((t=e.invokePartial(a(i,"functions/catchErrorCodes"),n,{name:"functions/catchErrorCodes",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+	return new CancelablePromise(async (resolve, reject, onCancel) => {
+		try {
+			const url = getUrl(config, options);
+			const formData = getFormData(options);
+			const body = getRequestBody(options);
+			const headers = await getHeaders(config, options);
+
+			if (!onCancel.isCancelled) {
+				const response = await sendRequest(config, options, url, body, formData, headers, onCancel);
+				const responseBody = getResponseBody(response);
+				const responseHeader = getResponseHeader(response, options.responseHeader);
+
+				const result: ApiResult = {
+					url,
+					ok: isSuccess(response.status),
+					status: response.status,
+					statusText: response.statusText,
+					body: responseHeader ?? responseBody,
+				};
+
+				catchErrorCodes(options, result);
+
+				resolve(result.body);
+			}
+		} catch (error) {
+			reject(error);
+		}
+	});
+};`},usePartial:!0,useData:!0},K0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`export const sendRequest = async (
+	config: OpenAPIConfig,
+	options: ApiRequestOptions,
+	url: string,
+	body: any,
+	formData: FormData | undefined,
+	headers: Headers,
+	onCancel: OnCancel
+): Promise<XMLHttpRequest> => {
+	const xhr = new XMLHttpRequest();
+	xhr.open(options.method, url, true);
+	xhr.withCredentials = config.WITH_CREDENTIALS;
+
+	headers.forEach((value, key) => {
+		xhr.setRequestHeader(key, value);
+	});
+
+	return new Promise<XMLHttpRequest>((resolve, reject) => {
+		xhr.onload = () => resolve(xhr);
+		xhr.onabort = () => reject(new Error('Request aborted'));
+		xhr.onerror = () => reject(new Error('Network error'));
+		xhr.send(body ?? formData);
+
+		onCancel(() => xhr.abort());
+	});
+};`},useData:!0},z0={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"imports"),{name:"each",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:5,column:0},end:{line:7,column:9}}}))!=null?t:"")},2:function(e,n,o,i,r){var t,a=e.lambda;return"import type { "+((t=a(n,n))!=null?t:"")+" } from './"+((t=a(n,n))!=null?t:"")+`';
+`},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"exportInterface"),n,{name:"exportInterface",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"one-of",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(9,r,0),data:r,loc:{start:{line:12,column:0},end:{line:26,column:0}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"exportComposition"),n,{name:"exportComposition",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},9:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"any-of",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(10,r,0),data:r,loc:{start:{line:14,column:0},end:{line:26,column:0}}}))!=null?t:""},10:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"all-of",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(11,r,0),data:r,loc:{start:{line:16,column:0},end:{line:26,column:0}}}))!=null?t:""},11:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"enum",{name:"equals",hash:{},fn:e.program(12,r,0),inverse:e.program(13,r,0),data:r,loc:{start:{line:18,column:0},end:{line:26,column:0}}}))!=null?t:""},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"useUnionTypes"),{name:"if",hash:{},fn:e.program(13,r,0),inverse:e.program(15,r,0),data:r,loc:{start:{line:19,column:0},end:{line:23,column:7}}}))!=null?t:""},13:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"exportType"),n,{name:"exportType",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},15:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"exportEnum"),n,{name:"exportEnum",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=e.invokePartial(l(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=l(o,"if").call(a,l(n,"imports"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:8,column:7}}}))!=null?t:"")+`
+`+((t=l(o,"equals").call(a,l(n,"export"),"interface",{name:"equals",hash:{},fn:e.program(4,r,0),inverse:e.program(6,r,0),data:r,loc:{start:{line:10,column:0},end:{line:26,column:11}}}))!=null?t:"")},usePartial:!0,useData:!0},Q0={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+export const $`+((t=e.lambda(e.strict(n,"name",{start:{line:3,column:17},end:{line:3,column:21}}),n))!=null?t:"")+" = "+((t=e.invokePartial(a(i,"schema"),n,{name:"schema",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+" as const;"},usePartial:!0,useData:!0},X0={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.program(4,r,0),data:r,loc:{start:{line:4,column:0},end:{line:11,column:7}}}))!=null?t:"")+`
+`},2:function(e,n,o,i,r){return`import { Injectable } from '@angular/core';
+import type { Observable } from 'rxjs';
+`},4:function(e,n,o,i,r){return`import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import type { Observable } from 'rxjs';
+`},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"imports"),{name:"each",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:15,column:0},end:{line:17,column:9}}}))!=null?t:"")+`
+`},7:function(e,n,o,i,r){var t,a=e.lambda;return"import type { "+((t=a(n,n))!=null?t:"")+" } from '../models/"+((t=a(n,n))!=null?t:"")+`';
+`},9:function(e,n,o,i,r){return`import type { CancelablePromise } from '../core/CancelablePromise';
+`},11:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(a(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(12,r,0),inverse:e.program(14,r,0),data:r,loc:{start:{line:24,column:0},end:{line:28,column:11}}}))!=null?t:""},12:function(e,n,o,i,r){return`import { BaseHttpRequest } from '../core/BaseHttpRequest';
+`},14:function(e,n,o,i,r){return`import type { BaseHttpRequest } from '../core/BaseHttpRequest';
+`},16:function(e,n,o,i,r){return`import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+`},18:function(e,n,o,i,r){return`@Injectable({
+  providedIn: 'root',
+})
+`},20:function(e,n,o,i,r){return`
+	constructor(public readonly httpRequest: BaseHttpRequest) {}
+`},22:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(a(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(23,r,0),inverse:e.noop,data:r,loc:{start:{line:44,column:1},end:{line:47,column:12}}}))!=null?t:""},23:function(e,n,o,i,r){return`
+	constructor(public readonly http: HttpClient) {}
+`},25:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.strict,s=e.lambda,u=e.lookupProperty||function(p,c){if(Object.prototype.hasOwnProperty.call(p,c))return p[c]};return`	/**
+`+((t=u(o,"if").call(a,u(n,"deprecated"),{name:"if",hash:{},fn:e.program(26,r,0),inverse:e.noop,data:r,loc:{start:{line:52,column:1},end:{line:54,column:8}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"summary"),{name:"if",hash:{},fn:e.program(28,r,0),inverse:e.noop,data:r,loc:{start:{line:55,column:1},end:{line:57,column:8}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"description"),{name:"if",hash:{},fn:e.program(30,r,0),inverse:e.noop,data:r,loc:{start:{line:58,column:1},end:{line:60,column:8}}}))!=null?t:"")+((t=u(o,"unless").call(a,u(u(r,"root"),"useOptions"),{name:"unless",hash:{},fn:e.program(32,r,0),inverse:e.noop,data:r,loc:{start:{line:61,column:1},end:{line:67,column:12}}}))!=null?t:"")+((t=u(o,"each").call(a,u(n,"results"),{name:"each",hash:{},fn:e.program(37,r,0),inverse:e.noop,data:r,loc:{start:{line:68,column:1},end:{line:70,column:10}}}))!=null?t:"")+`	 * @throws ApiError
+	 */
+`+((t=u(o,"if").call(a,u(u(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(39,r,0),inverse:e.program(44,r,0),data:r,loc:{start:{line:73,column:1},end:{line:89,column:8}}}))!=null?t:"")+"			method: '"+((t=s(l(n,"method",{start:{line:90,column:15},end:{line:90,column:21}}),n))!=null?t:"")+`',
+			url: '`+((t=s(l(n,"path",{start:{line:91,column:12},end:{line:91,column:16}}),n))!=null?t:"")+`',
+`+((t=u(o,"if").call(a,u(n,"parametersPath"),{name:"if",hash:{},fn:e.program(49,r,0),inverse:e.noop,data:r,loc:{start:{line:92,column:3},end:{line:98,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"parametersCookie"),{name:"if",hash:{},fn:e.program(52,r,0),inverse:e.noop,data:r,loc:{start:{line:99,column:3},end:{line:105,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"parametersHeader"),{name:"if",hash:{},fn:e.program(54,r,0),inverse:e.noop,data:r,loc:{start:{line:106,column:3},end:{line:112,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"parametersQuery"),{name:"if",hash:{},fn:e.program(56,r,0),inverse:e.noop,data:r,loc:{start:{line:113,column:3},end:{line:119,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"parametersForm"),{name:"if",hash:{},fn:e.program(58,r,0),inverse:e.noop,data:r,loc:{start:{line:120,column:3},end:{line:126,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"parametersBody"),{name:"if",hash:{},fn:e.program(60,r,0),inverse:e.noop,data:r,loc:{start:{line:127,column:3},end:{line:137,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"responseHeader"),{name:"if",hash:{},fn:e.program(67,r,0),inverse:e.noop,data:r,loc:{start:{line:138,column:3},end:{line:140,column:10}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"errors"),{name:"if",hash:{},fn:e.program(69,r,0),inverse:e.noop,data:r,loc:{start:{line:141,column:3},end:{line:147,column:10}}}))!=null?t:"")+`		});
+	}
+
+`},26:function(e,n,o,i,r){return`	 * @deprecated
+`},28:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"summary"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:56,column:4},end:{line:56,column:31}}}))!=null?t:"")+`
+`},30:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:59,column:4},end:{line:59,column:35}}}))!=null?t:"")+`
+`},32:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"parameters"),{name:"if",hash:{},fn:e.program(33,r,0),inverse:e.noop,data:r,loc:{start:{line:62,column:1},end:{line:66,column:8}}}))!=null?t:""},33:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parameters"),{name:"each",hash:{},fn:e.program(34,r,0),inverse:e.noop,data:r,loc:{start:{line:63,column:1},end:{line:65,column:10}}}))!=null?t:""},34:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * @param "+((t=e.lambda(e.strict(n,"name",{start:{line:64,column:14},end:{line:64,column:18}}),n))!=null?t:"")+" "+((t=a(o,"if").call(n??(e.nullContext||{}),a(n,"description"),{name:"if",hash:{},fn:e.program(35,r,0),inverse:e.noop,data:r,loc:{start:{line:64,column:22},end:{line:64,column:79}}}))!=null?t:"")+`
+`},35:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:64,column:41},end:{line:64,column:72}}}))!=null?t:""},37:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * @returns "+((t=e.lambda(e.strict(n,"type",{start:{line:69,column:16},end:{line:69,column:20}}),n))!=null?t:"")+" "+((t=a(o,"if").call(n??(e.nullContext||{}),a(n,"description"),{name:"if",hash:{},fn:e.program(35,r,0),inverse:e.noop,data:r,loc:{start:{line:69,column:24},end:{line:69,column:81}}}))!=null?t:"")+`
+`},39:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(a(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(40,r,0),inverse:e.program(42,r,0),data:r,loc:{start:{line:74,column:1},end:{line:80,column:12}}}))!=null?t:""},40:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	public "+((t=e.lambda(e.strict(n,"name",{start:{line:75,column:11},end:{line:75,column:15}}),n))!=null?t:"")+"("+((t=e.invokePartial(a(i,"parameters"),n,{name:"parameters",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+"): Observable<"+((t=e.invokePartial(a(i,"result"),n,{name:"result",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`> {
+		return this.httpRequest.request({
+`},42:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	public "+((t=e.lambda(e.strict(n,"name",{start:{line:78,column:11},end:{line:78,column:15}}),n))!=null?t:"")+"("+((t=e.invokePartial(a(i,"parameters"),n,{name:"parameters",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+"): CancelablePromise<"+((t=e.invokePartial(a(i,"result"),n,{name:"result",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`> {
+		return this.httpRequest.request({
+`},44:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(a(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(45,r,0),inverse:e.program(47,r,0),data:r,loc:{start:{line:82,column:1},end:{line:88,column:12}}}))!=null?t:""},45:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	public "+((t=e.lambda(e.strict(n,"name",{start:{line:83,column:11},end:{line:83,column:15}}),n))!=null?t:"")+"("+((t=e.invokePartial(a(i,"parameters"),n,{name:"parameters",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+"): Observable<"+((t=e.invokePartial(a(i,"result"),n,{name:"result",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`> {
+		return __request(OpenAPI, this.http, {
+`},47:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	public static "+((t=e.lambda(e.strict(n,"name",{start:{line:86,column:18},end:{line:86,column:22}}),n))!=null?t:"")+"("+((t=e.invokePartial(a(i,"parameters"),n,{name:"parameters",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+"): CancelablePromise<"+((t=e.invokePartial(a(i,"result"),n,{name:"result",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`> {
+		return __request(OpenAPI, {
+`},49:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			path: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parametersPath"),{name:"each",hash:{},fn:e.program(50,r,0),inverse:e.noop,data:r,loc:{start:{line:94,column:4},end:{line:96,column:13}}}))!=null?t:"")+`			},
+`},50:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"				'"+((t=l(a(n,"prop",{start:{line:95,column:8},end:{line:95,column:12}}),n))!=null?t:"")+"': "+((t=l(a(n,"name",{start:{line:95,column:21},end:{line:95,column:25}}),n))!=null?t:"")+`,
+`},52:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			cookies: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parametersCookie"),{name:"each",hash:{},fn:e.program(50,r,0),inverse:e.noop,data:r,loc:{start:{line:101,column:4},end:{line:103,column:13}}}))!=null?t:"")+`			},
+`},54:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			headers: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parametersHeader"),{name:"each",hash:{},fn:e.program(50,r,0),inverse:e.noop,data:r,loc:{start:{line:108,column:4},end:{line:110,column:13}}}))!=null?t:"")+`			},
+`},56:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			query: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parametersQuery"),{name:"each",hash:{},fn:e.program(50,r,0),inverse:e.noop,data:r,loc:{start:{line:115,column:4},end:{line:117,column:13}}}))!=null?t:"")+`			},
+`},58:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			formData: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parametersForm"),{name:"each",hash:{},fn:e.program(50,r,0),inverse:e.noop,data:r,loc:{start:{line:122,column:4},end:{line:124,column:13}}}))!=null?t:"")+`			},
+`},60:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"equals").call(a,l(l(n,"parametersBody"),"in"),"formData",{name:"equals",hash:{},fn:e.program(61,r,0),inverse:e.noop,data:r,loc:{start:{line:128,column:3},end:{line:130,column:14}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(n,"parametersBody"),"in"),"body",{name:"equals",hash:{},fn:e.program(63,r,0),inverse:e.noop,data:r,loc:{start:{line:131,column:3},end:{line:133,column:14}}}))!=null?t:"")+((t=l(o,"if").call(a,l(l(n,"parametersBody"),"mediaType"),{name:"if",hash:{},fn:e.program(65,r,0),inverse:e.noop,data:r,loc:{start:{line:134,column:3},end:{line:136,column:10}}}))!=null?t:"")},61:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"			formData: "+((t=e.lambda(e.strict(a(n,"parametersBody"),"name",{start:{line:129,column:16},end:{line:129,column:35}}),n))!=null?t:"")+`,
+`},63:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"			body: "+((t=e.lambda(e.strict(a(n,"parametersBody"),"name",{start:{line:132,column:12},end:{line:132,column:31}}),n))!=null?t:"")+`,
+`},65:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"			mediaType: '"+((t=e.lambda(e.strict(a(n,"parametersBody"),"mediaType",{start:{line:135,column:18},end:{line:135,column:42}}),n))!=null?t:"")+`',
+`},67:function(e,n,o,i,r){var t;return"			responseHeader: '"+((t=e.lambda(e.strict(n,"responseHeader",{start:{line:139,column:23},end:{line:139,column:37}}),n))!=null?t:"")+`',
+`},69:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`			errors: {
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"errors"),{name:"each",hash:{},fn:e.program(70,r,0),inverse:e.noop,data:r,loc:{start:{line:143,column:4},end:{line:145,column:13}}}))!=null?t:"")+`			},
+`},70:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"				"+((t=e.lambda(e.strict(n,"code",{start:{line:144,column:7},end:{line:144,column:11}}),n))!=null?t:"")+": `"+((t=a(o,"escapeDescription").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeDescription",hash:{},data:r,loc:{start:{line:144,column:17},end:{line:144,column:52}}}))!=null?t:"")+"`,\n"},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.strict,s=e.lambda,u=e.lookupProperty||function(p,c){if(Object.prototype.hasOwnProperty.call(p,c))return p[c]};return((t=e.invokePartial(u(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=u(o,"equals").call(a,u(u(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:13,column:11}}}))!=null?t:"")+((t=u(o,"if").call(a,u(n,"imports"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:14,column:0},end:{line:19,column:7}}}))!=null?t:"")+((t=u(o,"notEquals").call(a,u(u(r,"root"),"httpClient"),"angular",{name:"notEquals",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:20,column:0},end:{line:22,column:14}}}))!=null?t:"")+((t=u(o,"if").call(a,u(u(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(11,r,0),inverse:e.program(16,r,0),data:r,loc:{start:{line:23,column:0},end:{line:32,column:7}}}))!=null?t:"")+`
+`+((t=u(o,"equals").call(a,u(u(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(18,r,0),inverse:e.noop,data:r,loc:{start:{line:34,column:0},end:{line:38,column:11}}}))!=null?t:"")+"export class "+((t=s(l(n,"name",{start:{line:39,column:16},end:{line:39,column:20}}),n))!=null?t:"")+((t=s(l(u(r,"root"),"postfix",{start:{line:39,column:26},end:{line:39,column:39}}),n))!=null?t:"")+` {
+`+((t=u(o,"if").call(a,u(u(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(20,r,0),inverse:e.program(22,r,0),data:r,loc:{start:{line:40,column:1},end:{line:48,column:8}}}))!=null?t:"")+`
+`+((t=u(o,"each").call(a,u(n,"operations"),{name:"each",hash:{},fn:e.program(25,r,0),inverse:e.noop,data:r,loc:{start:{line:50,column:1},end:{line:151,column:10}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},Z0={1:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"export { "+((t=l(a(n,"clientName",{start:{line:4,column:12},end:{line:4,column:22}}),n))!=null?t:"")+" } from './"+((t=l(a(n,"clientName",{start:{line:4,column:39},end:{line:4,column:49}}),n))!=null?t:"")+`';
+
+`},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`export { ApiError } from './core/ApiError';
+`+((t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:9,column:0},end:{line:11,column:7}}}))!=null?t:"")+`export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+`},4:function(e,n,o,i,r){return`export { BaseHttpRequest } from './core/BaseHttpRequest';
+`},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"models"),{name:"if",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:17,column:0},end:{line:30,column:7}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"models"),{name:"each",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:19,column:0},end:{line:29,column:9}}}))!=null?t:"")},8:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"useUnionTypes"),{name:"if",hash:{},fn:e.program(9,r,0),inverse:e.program(12,r,0),data:r,loc:{start:{line:20,column:0},end:{line:28,column:7}}}))!=null?t:""},9:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"export type { "+((t=l(a(n,"name",{start:{line:21,column:17},end:{line:21,column:21}}),n))!=null?t:"")+((t=s(o,"if").call(n??(e.nullContext||{}),s(s(r,"root"),"postfixModels"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:21,column:24},end:{line:21,column:97}}}))!=null?t:"")+" } from './models/"+((t=l(a(n,"name",{start:{line:21,column:118},end:{line:21,column:122}}),n))!=null?t:"")+`';
+`},10:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return" as "+((t=l(a(n,"name",{start:{line:21,column:58},end:{line:21,column:62}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfixModels",{start:{line:21,column:68},end:{line:21,column:87}}),n))!=null?t:"")},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"enum"),{name:"if",hash:{},fn:e.program(13,r,0),inverse:e.program(15,r,0),data:r,loc:{start:{line:22,column:0},end:{line:28,column:0}}}))!=null?t:""},13:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"export { "+((t=l(a(n,"name",{start:{line:23,column:12},end:{line:23,column:16}}),n))!=null?t:"")+((t=s(o,"if").call(n??(e.nullContext||{}),s(s(r,"root"),"postfixModels"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:23,column:19},end:{line:23,column:92}}}))!=null?t:"")+" } from './models/"+((t=l(a(n,"name",{start:{line:23,column:113},end:{line:23,column:117}}),n))!=null?t:"")+`';
+`},15:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"enums"),{name:"if",hash:{},fn:e.program(13,r,0),inverse:e.program(9,r,0),data:r,loc:{start:{line:24,column:0},end:{line:28,column:0}}}))!=null?t:""},17:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"models"),{name:"if",hash:{},fn:e.program(18,r,0),inverse:e.noop,data:r,loc:{start:{line:33,column:0},end:{line:38,column:7}}}))!=null?t:""},18:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"models"),{name:"each",hash:{},fn:e.program(19,r,0),inverse:e.noop,data:r,loc:{start:{line:35,column:0},end:{line:37,column:9}}}))!=null?t:"")},19:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"export { $"+((t=l(a(n,"name",{start:{line:36,column:13},end:{line:36,column:17}}),n))!=null?t:"")+" } from './schemas/$"+((t=l(a(n,"name",{start:{line:36,column:43},end:{line:36,column:47}}),n))!=null?t:"")+`';
+`},21:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"services"),{name:"if",hash:{},fn:e.program(22,r,0),inverse:e.noop,data:r,loc:{start:{line:41,column:0},end:{line:46,column:7}}}))!=null?t:""},22:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"services"),{name:"each",hash:{},fn:e.program(23,r,0),inverse:e.noop,data:r,loc:{start:{line:43,column:0},end:{line:45,column:9}}}))!=null?t:"")},23:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return"export { "+((t=l(a(n,"name",{start:{line:44,column:12},end:{line:44,column:16}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfixServices",{start:{line:44,column:22},end:{line:44,column:43}}),n))!=null?t:"")+" } from './services/"+((t=l(a(n,"name",{start:{line:44,column:69},end:{line:44,column:73}}),n))!=null?t:"")+((t=l(a(s(r,"root"),"postfixServices",{start:{line:44,column:79},end:{line:44,column:100}}),n))!=null?t:"")+`';
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=e.invokePartial(l(i,"header"),n,{name:"header",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`
+`+((t=l(o,"if").call(a,l(l(r,"root"),"exportClient"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:6,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(l(r,"root"),"exportCore"),{name:"if",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:7,column:0},end:{line:15,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(l(r,"root"),"exportModels"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:16,column:0},end:{line:31,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(l(r,"root"),"exportSchemas"),{name:"if",hash:{},fn:e.program(17,r,0),inverse:e.noop,data:r,loc:{start:{line:32,column:0},end:{line:39,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(l(r,"root"),"exportServices"),{name:"if",hash:{},fn:e.program(21,r,0),inverse:e.noop,data:r,loc:{start:{line:40,column:0},end:{line:47,column:7}}}))!=null?t:"")},usePartial:!0,useData:!0},ev={1:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"fetch",{name:"equals",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:0},end:{line:2,column:53}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"xhr",{name:"equals",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:3,column:51}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"axios",{name:"equals",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:4,column:0},end:{line:4,column:53}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"angular",{name:"equals",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:5,column:0},end:{line:5,column:55}}}))!=null?t:"")+((t=l(o,"equals").call(a,l(l(r,"root"),"httpClient"),"node",{name:"equals",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:6,column:52}}}))!=null?t:"")},2:function(e,n,o,i,r){return"Blob"},4:function(e,n,o,i,r){var t;return(t=e.lambda(e.strict(n,"base",{start:{line:8,column:3},end:{line:8,column:7}}),n))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"base"),"binary",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(4,r,0),data:r,loc:{start:{line:1,column:0},end:{line:9,column:13}}}))!=null?t:""},useData:!0},nv={1:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+` */
+`},2:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:4,column:3},end:{line:4,column:34}}}))!=null?t:"")+`
+`},4:function(e,n,o,i,r){return` * @deprecated
+`},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"unless").call(n??(e.nullContext||{}),a(a(r,"root"),"useUnionTypes"),{name:"unless",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:13,column:0},end:{line:37,column:11}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+export namespace `+((t=e.lambda(e.strict(n,"name",{start:{line:15,column:20},end:{line:15,column:24}}),n))!=null?t:"")+` {
+
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"enums"),{name:"each",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:17,column:1},end:{line:34,column:10}}}))!=null?t:"")+`
+}
+`},8:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"ifdef").call(a,l(n,"description"),l(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:18,column:1},end:{line:27,column:11}}}))!=null?t:"")+"	export enum "+((t=e.lambda(e.strict(n,"name",{start:{line:28,column:16},end:{line:28,column:20}}),n))!=null?t:"")+` {
+`+((t=l(o,"each").call(a,l(n,"enum"),{name:"each",hash:{},fn:e.program(14,r,0),inverse:e.noop,data:r,loc:{start:{line:29,column:2},end:{line:31,column:11}}}))!=null?t:"")+`	}
+
+`},9:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`	/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:20,column:1},end:{line:22,column:8}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(12,r,0),inverse:e.noop,data:r,loc:{start:{line:23,column:1},end:{line:25,column:8}}}))!=null?t:"")+`	 */
+`},10:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:21,column:4},end:{line:21,column:35}}}))!=null?t:"")+`
+`},12:function(e,n,o,i,r){return`	 * @deprecated
+`},14:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"		"+((t=l(a(n,"name",{start:{line:30,column:5},end:{line:30,column:9}}),n))!=null?t:"")+" = "+((t=l(a(n,"value",{start:{line:30,column:18},end:{line:30,column:23}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"ifdef").call(a,l(n,"description"),l(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:10,column:10}}}))!=null?t:"")+"export type "+((t=e.lambda(e.strict(n,"name",{start:{line:11,column:15},end:{line:11,column:19}}),n))!=null?t:"")+" = "+((t=e.invokePartial(l(i,"type"),n,{name:"type",hash:{parent:l(n,"name")},data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`;
+`+((t=l(o,"if").call(a,l(n,"enums"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:12,column:0},end:{line:38,column:7}}}))!=null?t:"")},usePartial:!0,useData:!0},tv={1:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+` */
+`},2:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:4,column:3},end:{line:4,column:34}}}))!=null?t:"")+`
+`},4:function(e,n,o,i,r){return` * @deprecated
+`},6:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:13,column:1},end:{line:17,column:8}}}))!=null?t:"")+((t=l(o,"containsSpaces").call(a,l(n,"name"),{name:"containsSpaces",hash:{},fn:e.program(9,r,0),inverse:e.program(11,r,0),data:r,loc:{start:{line:18,column:1},end:{line:22,column:20}}}))!=null?t:"")},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`	/**
+	 * `+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:15,column:4},end:{line:15,column:35}}}))!=null?t:"")+`
+	 */
+`},9:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"	'"+((t=l(a(n,"name",{start:{line:19,column:5},end:{line:19,column:9}}),n))!=null?t:"")+"' = "+((t=l(a(n,"value",{start:{line:19,column:19},end:{line:19,column:24}}),n))!=null?t:"")+`,
+`},11:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"	"+((t=l(a(n,"name",{start:{line:21,column:4},end:{line:21,column:8}}),n))!=null?t:"")+" = "+((t=l(a(n,"value",{start:{line:21,column:17},end:{line:21,column:22}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"ifdef").call(a,l(n,"description"),l(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:10,column:10}}}))!=null?t:"")+"export enum "+((t=e.lambda(e.strict(n,"name",{start:{line:11,column:15},end:{line:11,column:19}}),n))!=null?t:"")+` {
+`+((t=l(o,"each").call(a,l(n,"enum"),{name:"each",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:12,column:1},end:{line:23,column:10}}}))!=null?t:"")+"}"},useData:!0},rv={1:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+` */
+`},2:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:4,column:3},end:{line:4,column:34}}}))!=null?t:"")+`
+`},4:function(e,n,o,i,r){return` * @deprecated
+`},6:function(e,n,o,i,r,t,a){var l,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return((l=s(o,"ifdef").call(n??(e.nullContext||{}),s(n,"description"),s(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(7,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:13,column:1},end:{line:22,column:11}}}))!=null?l:"")+"	"+((l=e.invokePartial(s(i,"isReadOnly"),n,{name:"isReadOnly",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+((l=e.lambda(e.strict(n,"name",{start:{line:23,column:19},end:{line:23,column:23}}),n))!=null?l:"")+((l=e.invokePartial(s(i,"isRequired"),n,{name:"isRequired",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+": "+((l=e.invokePartial(s(i,"type"),n,{name:"type",hash:{parent:s(a[1],"name")},data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+`;
+`},7:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`	/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:15,column:1},end:{line:17,column:8}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:18,column:1},end:{line:20,column:8}}}))!=null?t:"")+`	 */
+`},8:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	 * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:16,column:4},end:{line:16,column:35}}}))!=null?t:"")+`
+`},10:function(e,n,o,i,r){return`	 * @deprecated
+`},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"unless").call(n??(e.nullContext||{}),a(a(r,"root"),"useUnionTypes"),{name:"unless",hash:{},fn:e.program(13,r,0),inverse:e.noop,data:r,loc:{start:{line:27,column:0},end:{line:46,column:11}}}))!=null?t:""},13:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+export namespace `+((t=e.lambda(e.strict(n,"name",{start:{line:29,column:20},end:{line:29,column:24}}),n))!=null?t:"")+` {
+
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"enums"),{name:"each",hash:{},fn:e.program(14,r,0),inverse:e.noop,data:r,loc:{start:{line:31,column:1},end:{line:43,column:10}}}))!=null?t:"")+`
+}
+`},14:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(15,r,0),inverse:e.noop,data:r,loc:{start:{line:32,column:1},end:{line:36,column:8}}}))!=null?t:"")+"	export enum "+((t=e.lambda(e.strict(n,"name",{start:{line:37,column:16},end:{line:37,column:20}}),n))!=null?t:"")+` {
+`+((t=l(o,"each").call(a,l(n,"enum"),{name:"each",hash:{},fn:e.program(17,r,0),inverse:e.noop,data:r,loc:{start:{line:38,column:2},end:{line:40,column:11}}}))!=null?t:"")+`	}
+
+`},15:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`	/**
+	 * `+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:34,column:4},end:{line:34,column:35}}}))!=null?t:"")+`
+	 */
+`},17:function(e,n,o,i,r){var t,a=e.strict,l=e.lambda;return"		"+((t=l(a(n,"name",{start:{line:39,column:5},end:{line:39,column:9}}),n))!=null?t:"")+" = "+((t=l(a(n,"value",{start:{line:39,column:18},end:{line:39,column:23}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r,t,a){var l,s=n??(e.nullContext||{}),u=e.lookupProperty||function(p,c){if(Object.prototype.hasOwnProperty.call(p,c))return p[c]};return((l=u(o,"ifdef").call(s,u(n,"description"),u(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(1,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:10,column:10}}}))!=null?l:"")+"export type "+((l=e.lambda(e.strict(n,"name",{start:{line:11,column:15},end:{line:11,column:19}}),n))!=null?l:"")+` = {
+`+((l=u(o,"each").call(s,u(n,"properties"),{name:"each",hash:{},fn:e.program(6,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:12,column:1},end:{line:24,column:10}}}))!=null?l:"")+`};
+`+((l=u(o,"if").call(s,u(n,"enums"),{name:"if",hash:{},fn:e.program(12,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:26,column:0},end:{line:47,column:7}}}))!=null?l:"")},usePartial:!0,useData:!0,useDepths:!0},ov={1:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+` */
+`},2:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:4,column:3},end:{line:4,column:34}}}))!=null?t:"")+`
+`},4:function(e,n,o,i,r){return` * @deprecated
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"ifdef").call(n??(e.nullContext||{}),a(n,"description"),a(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:10,column:10}}}))!=null?t:"")+"export type "+((t=e.lambda(e.strict(n,"name",{start:{line:11,column:15},end:{line:11,column:19}}),n))!=null?t:"")+" = "+((t=e.invokePartial(a(i,"type"),n,{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+";"},usePartial:!0,useData:!0},av={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){return`/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */`},useData:!0},iv={1:function(e,n,o,i,r){return" | null"},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"isNullable"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:32}}}))!=null?t:""},useData:!0},lv={1:function(e,n,o,i,r){return"readonly "},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:34}}}))!=null?t:""},useData:!0},sv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"unless").call(n??(e.nullContext||{}),a(n,"isRequired"),{name:"unless",hash:{},fn:e.program(2,r,0),inverse:e.program(4,r,0),data:r,loc:{start:{line:2,column:0},end:{line:2,column:54}}}))!=null?t:""},2:function(e,n,o,i,r){return"?"},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"default"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:23},end:{line:2,column:43}}}))!=null?t:""},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"unless").call(n??(e.nullContext||{}),a(n,"isRequired"),{name:"unless",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:4,column:0},end:{line:4,column:64}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"unless").call(n??(e.nullContext||{}),a(n,"default"),{name:"unless",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:4,column:22},end:{line:4,column:53}}}))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"useOptions"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(6,r,0),data:r,loc:{start:{line:1,column:0},end:{line:5,column:9}}}))!=null?t:""},useData:!0},uv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(a(r,"root"),"useOptions"),{name:"if",hash:{},fn:e.program(2,r,0),inverse:e.program(12,r,0),data:r,loc:{start:{line:2,column:0},end:{line:27,column:7}}}))!=null?t:""},2:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+`+((t=l(o,"each").call(a,l(n,"parameters"),{name:"each",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:4,column:0},end:{line:6,column:9}}}))!=null?t:"")+`}: {
+`+((t=l(o,"each").call(a,l(n,"parameters"),{name:"each",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:8,column:0},end:{line:20,column:9}}}))!=null?t:"")+"}"},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.lambda(e.strict(n,"name",{start:{line:5,column:3},end:{line:5,column:7}}),n))!=null?t:"")+((t=a(o,"if").call(n??(e.nullContext||{}),a(n,"default"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:5,column:10},end:{line:5,column:48}}}))!=null?t:"")+`,
+`},4:function(e,n,o,i,r){var t;return" = "+((t=e.lambda(e.strict(n,"default",{start:{line:5,column:31},end:{line:5,column:38}}),n))!=null?t:"")},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"ifdef").call(n??(e.nullContext||{}),a(n,"description"),a(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:9,column:0},end:{line:18,column:10}}}))!=null?t:"")+((t=e.lambda(e.strict(n,"name",{start:{line:19,column:3},end:{line:19,column:7}}),n))!=null?t:"")+((t=e.invokePartial(a(i,"isRequired"),n,{name:"isRequired",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+": "+((t=e.invokePartial(a(i,"type"),n,{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`,
+`},7:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:11,column:0},end:{line:13,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:14,column:0},end:{line:16,column:7}}}))!=null?t:"")+` */
+`},8:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:12,column:3},end:{line:12,column:34}}}))!=null?t:"")+`
+`},10:function(e,n,o,i,r){return` * @deprecated
+`},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return`
+`+((t=a(o,"each").call(n??(e.nullContext||{}),a(n,"parameters"),{name:"each",hash:{},fn:e.program(13,r,0),inverse:e.noop,data:r,loc:{start:{line:24,column:0},end:{line:26,column:9}}}))!=null?t:"")},13:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.lambda(e.strict(n,"name",{start:{line:25,column:3},end:{line:25,column:7}}),n))!=null?t:"")+((t=e.invokePartial(a(i,"isRequired"),n,{name:"isRequired",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+": "+((t=e.invokePartial(a(i,"type"),n,{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=a(o,"if").call(n??(e.nullContext||{}),a(n,"default"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:25,column:36},end:{line:25,column:74}}}))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"parameters"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:28,column:7}}}))!=null?t:""},usePartial:!0,useData:!0},cv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"each").call(n??(e.nullContext||{}),a(n,"results"),{name:"each",hash:{},fn:e.program(2,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:0},end:{line:2,column:66}}}))!=null?t:""},2:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"type"),n,{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=a(o,"unless").call(n??(e.nullContext||{}),a(r,"last"),{name:"unless",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:26},end:{line:2,column:57}}}))!=null?t:"")},3:function(e,n,o,i,r){return" | "},5:function(e,n,o,i,r){return"void"},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"results"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(5,r,0),data:r,loc:{start:{line:1,column:0},end:{line:5,column:9}}}))!=null?t:""},usePartial:!0,useData:!0},pv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaInterface"),n,{name:"schemaInterface",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"enum",{name:"equals",hash:{},fn:e.program(4,r,0),inverse:e.program(6,r,0),data:r,loc:{start:{line:3,column:0},end:{line:17,column:0}}}))!=null?t:""},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaEnum"),n,{name:"schemaEnum",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"array",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(9,r,0),data:r,loc:{start:{line:5,column:0},end:{line:17,column:0}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaArray"),n,{name:"schemaArray",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},9:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"dictionary",{name:"equals",hash:{},fn:e.program(10,r,0),inverse:e.program(12,r,0),data:r,loc:{start:{line:7,column:0},end:{line:17,column:0}}}))!=null?t:""},10:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaDictionary"),n,{name:"schemaDictionary",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"any-of",{name:"equals",hash:{},fn:e.program(13,r,0),inverse:e.program(15,r,0),data:r,loc:{start:{line:9,column:0},end:{line:17,column:0}}}))!=null?t:""},13:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaComposition"),n,{name:"schemaComposition",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},15:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"all-of",{name:"equals",hash:{},fn:e.program(13,r,0),inverse:e.program(16,r,0),data:r,loc:{start:{line:11,column:0},end:{line:17,column:0}}}))!=null?t:""},16:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"one-of",{name:"equals",hash:{},fn:e.program(13,r,0),inverse:e.program(17,r,0),data:r,loc:{start:{line:13,column:0},end:{line:17,column:0}}}))!=null?t:""},17:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"schemaGeneric"),n,{name:"schemaGeneric",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"interface",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:1,column:0},end:{line:17,column:11}}}))!=null?t:""},usePartial:!0,useData:!0},fv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	contains: "+((t=e.invokePartial(a(i,"schema"),a(n,"link"),{name:"schema",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`,
+`},3:function(e,n,o,i,r){var t;return`	contains: {
+		type: '`+((t=e.lambda(e.strict(n,"base",{start:{line:7,column:12},end:{line:7,column:16}}),n))!=null?t:"")+`',
+	},
+`},5:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:11,column:16},end:{line:11,column:26}}),n))!=null?t:"")+`,
+`},7:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:14,column:16},end:{line:14,column:26}}),n))!=null?t:"")+`,
+`},9:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:17,column:16},end:{line:17,column:26}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+	type: 'array',
+`+((t=l(o,"if").call(a,l(n,"link"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:3,column:0},end:{line:9,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:10,column:0},end:{line:12,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:13,column:0},end:{line:15,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:16,column:0},end:{line:18,column:7}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},mv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	description: `"+((t=a(o,"escapeDescription").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeDescription",hash:{},data:r,loc:{start:{line:4,column:15},end:{line:4,column:50}}}))!=null?t:"")+"`,\n"},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"schema"),n,{name:"schema",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=a(o,"unless").call(n??(e.nullContext||{}),a(r,"last"),{name:"unless",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:43},end:{line:6,column:73}}}))!=null?t:"")},4:function(e,n,o,i,r){return", "},6:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:8,column:16},end:{line:8,column:26}}),n))!=null?t:"")+`,
+`},8:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:11,column:16},end:{line:11,column:26}}),n))!=null?t:"")+`,
+`},10:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:14,column:16},end:{line:14,column:26}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+	type: '`+((t=e.lambda(e.strict(n,"export",{start:{line:2,column:10},end:{line:2,column:16}}),n))!=null?t:"")+`',
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+"	contains: ["+((t=l(o,"each").call(a,l(n,"properties"),{name:"each",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:12},end:{line:6,column:82}}}))!=null?t:"")+`],
+`+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:7,column:0},end:{line:9,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:10,column:0},end:{line:12,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:13,column:0},end:{line:15,column:7}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},dv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	contains: "+((t=e.invokePartial(a(i,"schema"),a(n,"link"),{name:"schema",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`,
+`},3:function(e,n,o,i,r){var t;return`	contains: {
+		type: '`+((t=e.lambda(e.strict(n,"base",{start:{line:7,column:12},end:{line:7,column:16}}),n))!=null?t:"")+`',
+	},
+`},5:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:11,column:16},end:{line:11,column:26}}),n))!=null?t:"")+`,
+`},7:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:14,column:16},end:{line:14,column:26}}),n))!=null?t:"")+`,
+`},9:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:17,column:16},end:{line:17,column:26}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+	type: 'dictionary',
+`+((t=l(o,"if").call(a,l(n,"link"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:3,column:0},end:{line:9,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:10,column:0},end:{line:12,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:13,column:0},end:{line:15,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:16,column:0},end:{line:18,column:7}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},hv={1:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:4,column:16},end:{line:4,column:26}}),n))!=null?t:"")+`,
+`},3:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:7,column:16},end:{line:7,column:26}}),n))!=null?t:"")+`,
+`},5:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:10,column:16},end:{line:10,column:26}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+	type: 'Enum',
+`+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:5,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:9,column:0},end:{line:11,column:7}}}))!=null?t:"")+"}"},useData:!0},yv={1:function(e,n,o,i,r){var t;return"	type: '"+((t=e.lambda(e.strict(n,"type",{start:{line:3,column:11},end:{line:3,column:15}}),n))!=null?t:"")+`',
+`},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	description: `"+((t=a(o,"escapeDescription").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeDescription",hash:{},data:r,loc:{start:{line:6,column:15},end:{line:6,column:50}}}))!=null?t:"")+"`,\n"},5:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:9,column:16},end:{line:9,column:26}}),n))!=null?t:"")+`,
+`},7:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:12,column:16},end:{line:12,column:26}}),n))!=null?t:"")+`,
+`},9:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:15,column:16},end:{line:15,column:26}}),n))!=null?t:"")+`,
+`},11:function(e,n,o,i,r){var t;return"	format: '"+((t=e.lambda(e.strict(n,"format",{start:{line:18,column:13},end:{line:18,column:19}}),n))!=null?t:"")+`',
+`},13:function(e,n,o,i,r){var t;return"	maximum: "+((t=e.lambda(e.strict(n,"maximum",{start:{line:21,column:13},end:{line:21,column:20}}),n))!=null?t:"")+`,
+`},15:function(e,n,o,i,r){var t;return"	exclusiveMaximum: "+((t=e.lambda(e.strict(n,"exclusiveMaximum",{start:{line:24,column:22},end:{line:24,column:38}}),n))!=null?t:"")+`,
+`},17:function(e,n,o,i,r){var t;return"	minimum: "+((t=e.lambda(e.strict(n,"minimum",{start:{line:27,column:13},end:{line:27,column:20}}),n))!=null?t:"")+`,
+`},19:function(e,n,o,i,r){var t;return"	exclusiveMinimum: "+((t=e.lambda(e.strict(n,"exclusiveMinimum",{start:{line:30,column:22},end:{line:30,column:38}}),n))!=null?t:"")+`,
+`},21:function(e,n,o,i,r){var t;return"	multipleOf: "+((t=e.lambda(e.strict(n,"multipleOf",{start:{line:33,column:16},end:{line:33,column:26}}),n))!=null?t:"")+`,
+`},23:function(e,n,o,i,r){var t;return"	maxLength: "+((t=e.lambda(e.strict(n,"maxLength",{start:{line:36,column:15},end:{line:36,column:24}}),n))!=null?t:"")+`,
+`},25:function(e,n,o,i,r){var t;return"	minLength: "+((t=e.lambda(e.strict(n,"minLength",{start:{line:39,column:15},end:{line:39,column:24}}),n))!=null?t:"")+`,
+`},27:function(e,n,o,i,r){var t;return"	pattern: '"+((t=e.lambda(e.strict(n,"pattern",{start:{line:42,column:14},end:{line:42,column:21}}),n))!=null?t:"")+`',
+`},29:function(e,n,o,i,r){var t;return"	maxItems: "+((t=e.lambda(e.strict(n,"maxItems",{start:{line:45,column:14},end:{line:45,column:22}}),n))!=null?t:"")+`,
+`},31:function(e,n,o,i,r){var t;return"	minItems: "+((t=e.lambda(e.strict(n,"minItems",{start:{line:48,column:14},end:{line:48,column:22}}),n))!=null?t:"")+`,
+`},33:function(e,n,o,i,r){var t;return"	uniqueItems: "+((t=e.lambda(e.strict(n,"uniqueItems",{start:{line:51,column:17},end:{line:51,column:28}}),n))!=null?t:"")+`,
+`},35:function(e,n,o,i,r){var t;return"	maxProperties: "+((t=e.lambda(e.strict(n,"maxProperties",{start:{line:54,column:19},end:{line:54,column:32}}),n))!=null?t:"")+`,
+`},37:function(e,n,o,i,r){var t;return"	minProperties: "+((t=e.lambda(e.strict(n,"minProperties",{start:{line:57,column:19},end:{line:57,column:32}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+`+((t=l(o,"if").call(a,l(n,"type"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:0},end:{line:4,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:5,column:0},end:{line:7,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(5,r,0),inverse:e.noop,data:r,loc:{start:{line:8,column:0},end:{line:10,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(7,r,0),inverse:e.noop,data:r,loc:{start:{line:11,column:0},end:{line:13,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(9,r,0),inverse:e.noop,data:r,loc:{start:{line:14,column:0},end:{line:16,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"format"),{name:"if",hash:{},fn:e.program(11,r,0),inverse:e.noop,data:r,loc:{start:{line:17,column:0},end:{line:19,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"maximum"),{name:"if",hash:{},fn:e.program(13,r,0),inverse:e.noop,data:r,loc:{start:{line:20,column:0},end:{line:22,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"exclusiveMaximum"),{name:"if",hash:{},fn:e.program(15,r,0),inverse:e.noop,data:r,loc:{start:{line:23,column:0},end:{line:25,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"minimum"),{name:"if",hash:{},fn:e.program(17,r,0),inverse:e.noop,data:r,loc:{start:{line:26,column:0},end:{line:28,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"exclusiveMinimum"),{name:"if",hash:{},fn:e.program(19,r,0),inverse:e.noop,data:r,loc:{start:{line:29,column:0},end:{line:31,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"multipleOf"),{name:"if",hash:{},fn:e.program(21,r,0),inverse:e.noop,data:r,loc:{start:{line:32,column:0},end:{line:34,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"maxLength"),{name:"if",hash:{},fn:e.program(23,r,0),inverse:e.noop,data:r,loc:{start:{line:35,column:0},end:{line:37,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"minLength"),{name:"if",hash:{},fn:e.program(25,r,0),inverse:e.noop,data:r,loc:{start:{line:38,column:0},end:{line:40,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"pattern"),{name:"if",hash:{},fn:e.program(27,r,0),inverse:e.noop,data:r,loc:{start:{line:41,column:0},end:{line:43,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"maxItems"),{name:"if",hash:{},fn:e.program(29,r,0),inverse:e.noop,data:r,loc:{start:{line:44,column:0},end:{line:46,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"minItems"),{name:"if",hash:{},fn:e.program(31,r,0),inverse:e.noop,data:r,loc:{start:{line:47,column:0},end:{line:49,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"uniqueItems"),{name:"if",hash:{},fn:e.program(33,r,0),inverse:e.noop,data:r,loc:{start:{line:50,column:0},end:{line:52,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"maxProperties"),{name:"if",hash:{},fn:e.program(35,r,0),inverse:e.noop,data:r,loc:{start:{line:53,column:0},end:{line:55,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"minProperties"),{name:"if",hash:{},fn:e.program(37,r,0),inverse:e.noop,data:r,loc:{start:{line:56,column:0},end:{line:58,column:7}}}))!=null?t:"")+"}"},useData:!0},vv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"	description: `"+((t=a(o,"escapeDescription").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeDescription",hash:{},data:r,loc:{start:{line:3,column:15},end:{line:3,column:50}}}))!=null?t:"")+"`,\n"},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"each").call(n??(e.nullContext||{}),a(n,"properties"),{name:"each",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:7,column:1},end:{line:9,column:10}}}))!=null?t:""},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"		"+((t=e.lambda(e.strict(n,"name",{start:{line:8,column:5},end:{line:8,column:9}}),n))!=null?t:"")+": "+((t=e.invokePartial(a(i,"schema"),n,{name:"schema",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`,
+`},6:function(e,n,o,i,r){var t;return"	isReadOnly: "+((t=e.lambda(e.strict(n,"isReadOnly",{start:{line:13,column:16},end:{line:13,column:26}}),n))!=null?t:"")+`,
+`},8:function(e,n,o,i,r){var t;return"	isRequired: "+((t=e.lambda(e.strict(n,"isRequired",{start:{line:16,column:16},end:{line:16,column:26}}),n))!=null?t:"")+`,
+`},10:function(e,n,o,i,r){var t;return"	isNullable: "+((t=e.lambda(e.strict(n,"isNullable",{start:{line:19,column:16},end:{line:19,column:26}}),n))!=null?t:"")+`,
+`},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`{
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:2,column:0},end:{line:4,column:7}}}))!=null?t:"")+`	properties: {
+`+((t=l(o,"if").call(a,l(n,"properties"),{name:"if",hash:{},fn:e.program(3,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:10,column:7}}}))!=null?t:"")+`	},
+`+((t=l(o,"if").call(a,l(n,"isReadOnly"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:12,column:0},end:{line:14,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isRequired"),{name:"if",hash:{},fn:e.program(8,r,0),inverse:e.noop,data:r,loc:{start:{line:15,column:0},end:{line:17,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"isNullable"),{name:"if",hash:{},fn:e.program(10,r,0),inverse:e.noop,data:r,loc:{start:{line:18,column:0},end:{line:20,column:7}}}))!=null?t:"")+"}"},usePartial:!0,useData:!0},gv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeInterface"),n,{name:"typeInterface",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"reference",{name:"equals",hash:{},fn:e.program(4,r,0),inverse:e.program(6,r,0),data:r,loc:{start:{line:3,column:0},end:{line:19,column:0}}}))!=null?t:""},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeReference"),n,{name:"typeReference",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},6:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"enum",{name:"equals",hash:{},fn:e.program(7,r,0),inverse:e.program(9,r,0),data:r,loc:{start:{line:5,column:0},end:{line:19,column:0}}}))!=null?t:""},7:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeEnum"),n,{name:"typeEnum",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},9:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"array",{name:"equals",hash:{},fn:e.program(10,r,0),inverse:e.program(12,r,0),data:r,loc:{start:{line:7,column:0},end:{line:19,column:0}}}))!=null?t:""},10:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeArray"),n,{name:"typeArray",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},12:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"dictionary",{name:"equals",hash:{},fn:e.program(13,r,0),inverse:e.program(15,r,0),data:r,loc:{start:{line:9,column:0},end:{line:19,column:0}}}))!=null?t:""},13:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeDictionary"),n,{name:"typeDictionary",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},15:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"one-of",{name:"equals",hash:{},fn:e.program(16,r,0),inverse:e.program(18,r,0),data:r,loc:{start:{line:11,column:0},end:{line:19,column:0}}}))!=null?t:""},16:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeUnion"),n,{name:"typeUnion",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},18:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"any-of",{name:"equals",hash:{},fn:e.program(16,r,0),inverse:e.program(19,r,0),data:r,loc:{start:{line:13,column:0},end:{line:19,column:0}}}))!=null?t:""},19:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"all-of",{name:"equals",hash:{},fn:e.program(20,r,0),inverse:e.program(22,r,0),data:r,loc:{start:{line:15,column:0},end:{line:19,column:0}}}))!=null?t:""},20:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeIntersection"),n,{name:"typeIntersection",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},22:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=e.invokePartial(a(i,"typeGeneric"),n,{name:"typeGeneric",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"equals").call(n??(e.nullContext||{}),a(n,"export"),"interface",{name:"equals",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:1,column:0},end:{line:19,column:11}}}))!=null?t:""},usePartial:!0,useData:!0},xv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"Array<"+((t=e.invokePartial(a(i,"type"),a(n,"link"),{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+">"+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"Array<"+((t=e.invokePartial(a(i,"base"),n,{name:"base",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+">"+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"link"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:1,column:0},end:{line:5,column:9}}}))!=null?t:""},usePartial:!0,useData:!0},Pv={1:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"Record<string, "+((t=e.invokePartial(a(i,"type"),a(n,"link"),{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+">"+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},3:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return"Record<string, "+((t=e.invokePartial(a(i,"base"),n,{name:"base",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+">"+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return(t=a(o,"if").call(n??(e.nullContext||{}),a(n,"link"),{name:"if",hash:{},fn:e.program(1,r,0),inverse:e.program(3,r,0),data:r,loc:{start:{line:1,column:0},end:{line:5,column:9}}}))!=null?t:""},usePartial:!0,useData:!0},bv={1:function(e,n,o,i,r){var t;return(t=e.lambda(n,n))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"enumerator").call(n??(e.nullContext||{}),a(n,"enum"),a(n,"parent"),a(n,"name"),{name:"enumerator",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:55}}}))!=null?t:"")+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},usePartial:!0,useData:!0},Ov={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"base"),n,{name:"base",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},usePartial:!0,useData:!0},wv={1:function(e,n,o,i,r,t,a){var l,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return`{
+`+((l=s(o,"each").call(n??(e.nullContext||{}),s(n,"properties"),{name:"each",hash:{},fn:e.program(2,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:3,column:0},end:{line:19,column:9}}}))!=null?l:"")+"}"+((l=e.invokePartial(s(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")},2:function(e,n,o,i,r,t,a){var l,s=n??(e.nullContext||{}),u=e.lookupProperty||function(p,c){if(Object.prototype.hasOwnProperty.call(p,c))return p[c]};return((l=u(o,"ifdef").call(s,u(n,"description"),u(n,"deprecated"),{name:"ifdef",hash:{},fn:e.program(3,r,0,t,a),inverse:e.noop,data:r,loc:{start:{line:4,column:0},end:{line:13,column:10}}}))!=null?l:"")+((l=u(o,"if").call(s,u(a[1],"parent"),{name:"if",hash:{},fn:e.program(8,r,0,t,a),inverse:e.program(10,r,0,t,a),data:r,loc:{start:{line:14,column:0},end:{line:18,column:7}}}))!=null?l:"")},3:function(e,n,o,i,r){var t,a=n??(e.nullContext||{}),l=e.lookupProperty||function(s,u){if(Object.prototype.hasOwnProperty.call(s,u))return s[u]};return`/**
+`+((t=l(o,"if").call(a,l(n,"description"),{name:"if",hash:{},fn:e.program(4,r,0),inverse:e.noop,data:r,loc:{start:{line:6,column:0},end:{line:8,column:7}}}))!=null?t:"")+((t=l(o,"if").call(a,l(n,"deprecated"),{name:"if",hash:{},fn:e.program(6,r,0),inverse:e.noop,data:r,loc:{start:{line:9,column:0},end:{line:11,column:7}}}))!=null?t:"")+` */
+`},4:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return" * "+((t=a(o,"escapeComment").call(n??(e.nullContext||{}),a(n,"description"),{name:"escapeComment",hash:{},data:r,loc:{start:{line:7,column:3},end:{line:7,column:34}}}))!=null?t:"")+`
+`},6:function(e,n,o,i,r){return` * @deprecated
+`},8:function(e,n,o,i,r,t,a){var l,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return((l=e.invokePartial(s(i,"isReadOnly"),n,{name:"isReadOnly",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+((l=e.lambda(e.strict(n,"name",{start:{line:15,column:18},end:{line:15,column:22}}),n))!=null?l:"")+((l=e.invokePartial(s(i,"isRequired"),n,{name:"isRequired",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+": "+((l=e.invokePartial(s(i,"type"),n,{name:"type",hash:{parent:s(a[1],"parent")},data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?l:"")+`;
+`},10:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"isReadOnly"),n,{name:"isReadOnly",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=e.lambda(e.strict(n,"name",{start:{line:17,column:18},end:{line:17,column:22}}),n))!=null?t:"")+((t=e.invokePartial(a(i,"isRequired"),n,{name:"isRequired",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+": "+((t=e.invokePartial(a(i,"type"),n,{name:"type",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+`;
+`},12:function(e,n,o,i,r){return"any"},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r,t,a){var l,s=e.lookupProperty||function(u,p){if(Object.prototype.hasOwnProperty.call(u,p))return u[p]};return(l=s(o,"if").call(n??(e.nullContext||{}),s(n,"properties"),{name:"if",hash:{},fn:e.program(1,r,0,t,a),inverse:e.program(12,r,0,t,a),data:r,loc:{start:{line:1,column:0},end:{line:23,column:9}}}))!=null?l:""},usePartial:!0,useData:!0,useDepths:!0},kv={1:function(e,n,o,i,r){var t;return(t=e.lambda(n,n))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"intersection").call(n??(e.nullContext||{}),a(n,"properties"),a(n,"parent"),{name:"intersection",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:60}}}))!=null?t:"")+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},usePartial:!0,useData:!0},Cv={compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=e.invokePartial(a(i,"base"),n,{name:"base",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},usePartial:!0,useData:!0},Sv={1:function(e,n,o,i,r){var t;return(t=e.lambda(n,n))!=null?t:""},compiler:[8,">= 4.3.0"],main:function(e,n,o,i,r){var t,a=e.lookupProperty||function(l,s){if(Object.prototype.hasOwnProperty.call(l,s))return l[s]};return((t=a(o,"union").call(n??(e.nullContext||{}),a(n,"properties"),a(n,"parent"),{name:"union",hash:{},fn:e.program(1,r,0),inverse:e.noop,data:r,loc:{start:{line:1,column:0},end:{line:1,column:46}}}))!=null?t:"")+((t=e.invokePartial(a(i,"isNullable"),n,{name:"isNullable",data:r,helpers:o,partials:i,decorators:e.decorators}))!=null?t:"")},usePartial:!0,useData:!0},Ev=e=>{h.registerHelper("ifdef",function(...n){let o=n.pop();return n.every(i=>!i)?o.inverse(this):o.fn(this)}),h.registerHelper("equals",function(n,o,i){return n===o?i.fn(this):i.inverse(this)}),h.registerHelper("notEquals",function(n,o,i){return n!==o?i.fn(this):i.inverse(this)}),h.registerHelper("containsSpaces",function(n,o){return/\s+/.test(n)?o.fn(this):o.inverse(this)}),h.registerHelper("union",function(n,o,i){let r=h.partials.type,t=n.map(l=>r({...e,...l,parent:o})).filter(nn),a=t.join(" | ");return t.length>1&&(a=`(${a})`),i.fn(a)}),h.registerHelper("intersection",function(n,o,i){let r=h.partials.type,t=n.map(l=>r({...e,...l,parent:o})).filter(nn),a=t.join(" & ");return t.length>1&&(a=`(${a})`),i.fn(a)}),h.registerHelper("enumerator",function(n,o,i,r){return!e.useUnionTypes&&o&&i?`${o}.${i}`:r.fn(n.map(t=>t.value).filter(nn).join(" | "))}),h.registerHelper("escapeComment",function(n){return n.replace(/\*\//g,"*").replace(/\/\*/g,"*").replace(/\r?\n(.*)/g,(o,i)=>`${Cn.EOL} * ${i.trim()}`)}),h.registerHelper("escapeDescription",function(n){return n.replace(/\\/g,"\\\\").replace(/`/g,"\\`").replace(/\${/g,"\\${")}),h.registerHelper("camelCase",function(n){return Ae(n)})},re=Zn.writeFile,Rv=Zn.copyFile,qv=Zn.pathExists,On=Zn.mkdirp,Tt=Zn.remove,It=e=>{let n=0,o=e.split(Cn.EOL);return o=o.map(i=>{i=i.trim().replace(/^\*/g," *");let r=n;(i.endsWith("(")||i.endsWith("{")||i.endsWith("["))&&n++,(i.startsWith(")")||i.startsWith("}")||i.startsWith("]"))&&r&&(n--,r--);let t=`${"	".repeat(r)}${i}`;return t.trim()===""?"":t}),o.join(Cn.EOL)},le=(e,n)=>{let o=e.split(Cn.EOL);return o=o.map(i=>{switch(n){case exports.Indent.SPACE_4:return i.replace(/\t/g,"    ");case exports.Indent.SPACE_2:return i.replace(/\t/g,"  ");case exports.Indent.TAB:return i}}),`${o.join(Cn.EOL)}${Cn.EOL}`},yu=e=>{switch(e){case exports.HttpClient.FETCH:return"FetchHttpRequest";case exports.HttpClient.XHR:return"XHRHttpRequest";case exports.HttpClient.NODE:return"NodeHttpRequest";case exports.HttpClient.AXIOS:return"AxiosHttpRequest";case exports.HttpClient.ANGULAR:return"AngularHttpRequest"}},vu=e=>e.sort((n,o)=>{let i=n.name.toLowerCase(),r=o.name.toLowerCase();return i.localeCompare(r,"en")}),gu=e=>e.sort((n,o)=>{let i=n.name.toLowerCase(),r=o.name.toLowerCase();return i.localeCompare(r,"en")}),xu=async(e,n,o,i,r,t,a,l,s,u,p,c,f,m,d)=>{let y=N.resolve(process.cwd(),o),g=N.resolve(y,"core"),P=N.resolve(y,"models"),x=N.resolve(y,"schemas"),S=N.resolve(y,"services");if(L=process.cwd(),ae=o,!N.relative(ae,L).startsWith(".."))throw new Error("Output folder is not a subdirectory of the current working directory");var L,ae;a&&(await Tt(g),await On(g),await(async(_,F,j,b,w,k,E)=>{let q=yu(b),C={httpClient:b,clientName:k,httpRequest:q,server:_.server,version:_.version};if(await re(N.resolve(j,"OpenAPI.ts"),le(F.core.settings(C),w)),await re(N.resolve(j,"ApiError.ts"),le(F.core.apiError(C),w)),await re(N.resolve(j,"ApiRequestOptions.ts"),le(F.core.apiRequestOptions(C),w)),await re(N.resolve(j,"ApiResult.ts"),le(F.core.apiResult(C),w)),await re(N.resolve(j,"CancelablePromise.ts"),le(F.core.cancelablePromise(C),w)),await re(N.resolve(j,"request.ts"),le(F.core.request(C),w)),en(k)&&(await re(N.resolve(j,"BaseHttpRequest.ts"),le(F.core.baseHttpRequest(C),w)),await re(N.resolve(j,`${q}.ts`),le(F.core.httpRequest(C),w))),E){let R=N.resolve(process.cwd(),E);if(!await qv(R))throw new Error(`Custom request file "${R}" does not exists`);await Rv(R,N.resolve(j,"request.ts"))}})(e,n,g,i,p,m,d)),l&&(await Tt(S),await On(S),await(async(_,F,j,b,w,k,E,q,C)=>{for(let R of _){let T=N.resolve(j,`${R.name}${q}.ts`),A=F.exports.service({...R,httpClient:b,useUnionTypes:w,useOptions:k,postfix:q,exportClient:en(C)});await re(T,le(It(A),E))}})(e.services,n,S,i,t,r,p,c,m)),u&&(await Tt(x),await On(x),await(async(_,F,j,b,w,k)=>{for(let E of _){let q=N.resolve(j,`$${E.name}.ts`),C=F.exports.schema({...E,httpClient:b,useUnionTypes:w});await re(q,le(It(C),k))}})(e.models,n,x,i,t,p)),s&&(await Tt(P),await On(P),await(async(_,F,j,b,w,k)=>{for(let E of _){let q=N.resolve(j,`${E.name}.ts`),C=F.exports.model({...E,httpClient:b,useUnionTypes:w});await re(q,le(It(C),k))}})(e.models,n,P,i,t,p)),en(m)&&(await On(y),await(async(_,F,j,b,w,k,E)=>{let q=F.client({clientName:w,httpClient:b,postfix:E,server:_.server,version:_.version,models:vu(_.models),services:gu(_.services),httpRequest:yu(b)});await re(N.resolve(j,`${w}.ts`),le(It(q),k))})(e,n,y,i,m,p,c)),(a||l||u||s)&&(await On(y),await(async(_,F,j,b,w,k,E,q,C,R,T)=>{let A=F.index({exportCore:w,exportServices:k,exportModels:E,exportSchemas:q,useUnionTypes:b,postfixServices:C,postfixModels:R,clientName:T,server:_.server,version:_.version,models:vu(_.models),services:gu(_.services),exportClient:en(T)});await re(N.resolve(j,"index.ts"),A)})(e,n,y,t,a,l,s,u,c,f,m))},ju=async({input:e,output:n,httpClient:o=exports.HttpClient.FETCH,clientName:i,useOptions:r=!1,useUnionTypes:t=!1,exportCore:a=!0,exportServices:l=!0,exportModels:s=!0,exportSchemas:u=!1,indent:p=exports.Indent.SPACE_4,postfixServices:c="Service",postfixModels:f="",request:m,write:d=!0})=>{let y=Qn(e)?await(async x=>await Gh.bundle(x,x,{}))(e):e,g=(x=>{let S=x.swagger||x.openapi;if(typeof S=="string"){let L=S.charAt(0),ae=Number.parseInt(L);if(ae===wn.V2||ae===wn.V3)return ae}throw new Error(`Unsupported Open API version: "${String(S)}"`)})(y),P=(x=>{Ev(x);let S={index:h.template(Z0),client:h.template(Zy),exports:{model:h.template(z0),schema:h.template(Q0),service:h.template(X0)},core:{settings:h.template(B0),apiError:h.template(i0),apiRequestOptions:h.template(l0),apiResult:h.template(s0),cancelablePromise:h.template(y0),request:h.template(U0),baseHttpRequest:h.template(h0),httpRequest:h.template(D0)}};return h.registerPartial("exportEnum",h.template(tv)),h.registerPartial("exportInterface",h.template(rv)),h.registerPartial("exportComposition",h.template(nv)),h.registerPartial("exportType",h.template(ov)),h.registerPartial("header",h.template(av)),h.registerPartial("isNullable",h.template(iv)),h.registerPartial("isReadOnly",h.template(lv)),h.registerPartial("isRequired",h.template(sv)),h.registerPartial("parameters",h.template(uv)),h.registerPartial("result",h.template(cv)),h.registerPartial("schema",h.template(pv)),h.registerPartial("schemaArray",h.template(fv)),h.registerPartial("schemaDictionary",h.template(dv)),h.registerPartial("schemaEnum",h.template(hv)),h.registerPartial("schemaGeneric",h.template(yv)),h.registerPartial("schemaInterface",h.template(vv)),h.registerPartial("schemaComposition",h.template(mv)),h.registerPartial("type",h.template(gv)),h.registerPartial("typeArray",h.template(xv)),h.registerPartial("typeDictionary",h.template(Pv)),h.registerPartial("typeEnum",h.template(bv)),h.registerPartial("typeGeneric",h.template(Ov)),h.registerPartial("typeInterface",h.template(wv)),h.registerPartial("typeReference",h.template(Cv)),h.registerPartial("typeUnion",h.template(Sv)),h.registerPartial("typeIntersection",h.template(kv)),h.registerPartial("base",h.template(ev)),h.registerPartial("functions/catchErrorCodes",h.template(k0)),h.registerPartial("functions/getFormData",h.template(C0)),h.registerPartial("functions/getQueryString",h.template(S0)),h.registerPartial("functions/getUrl",h.template(E0)),h.registerPartial("functions/isBlob",h.template(R0)),h.registerPartial("functions/isDefined",h.template(q0)),h.registerPartial("functions/isFormData",h.template(A0)),h.registerPartial("functions/isString",h.template(T0)),h.registerPartial("functions/isStringWithValue",h.template(I0)),h.registerPartial("functions/isSuccess",h.template(_0)),h.registerPartial("functions/base64",h.template(w0)),h.registerPartial("functions/resolve",h.template(j0)),h.registerPartial("fetch/getHeaders",h.template(v0)),h.registerPartial("fetch/getRequestBody",h.template(g0)),h.registerPartial("fetch/getResponseBody",h.template(x0)),h.registerPartial("fetch/getResponseHeader",h.template(P0)),h.registerPartial("fetch/sendRequest",h.template(O0)),h.registerPartial("fetch/request",h.template(b0)),h.registerPartial("xhr/getHeaders",h.template(W0)),h.registerPartial("xhr/getRequestBody",h.template(V0)),h.registerPartial("xhr/getResponseBody",h.template(Y0)),h.registerPartial("xhr/getResponseHeader",h.template(J0)),h.registerPartial("xhr/sendRequest",h.template(K0)),h.registerPartial("xhr/request",h.template(G0)),h.registerPartial("node/getHeaders",h.template(N0)),h.registerPartial("node/getRequestBody",h.template(H0)),h.registerPartial("node/getResponseBody",h.template(F0)),h.registerPartial("node/getResponseHeader",h.template($0)),h.registerPartial("node/sendRequest",h.template(M0)),h.registerPartial("node/request",h.template(L0)),h.registerPartial("axios/getHeaders",h.template(u0)),h.registerPartial("axios/getRequestBody",h.template(c0)),h.registerPartial("axios/getResponseBody",h.template(p0)),h.registerPartial("axios/getResponseHeader",h.template(f0)),h.registerPartial("axios/sendRequest",h.template(d0)),h.registerPartial("axios/request",h.template(m0)),h.registerPartial("angular/getHeaders",h.template(e0)),h.registerPartial("angular/getRequestBody",h.template(n0)),h.registerPartial("angular/getResponseBody",h.template(t0)),h.registerPartial("angular/getResponseHeader",h.template(r0)),h.registerPartial("angular/sendRequest",h.template(a0)),h.registerPartial("angular/request",h.template(o0)),S})({httpClient:o,useUnionTypes:t,useOptions:r});switch(g){case wn.V2:{let x=oy(y),S=cu(x);if(!d)break;await xu(S,P,n,o,r,t,a,l,s,u,p,c,f,i,m);break}case wn.V3:{let x=yy(y),S=cu(x);if(!d)break;await xu(S,P,n,o,r,t,a,l,s,u,p,c,f,i,m);break}}},Av={HttpClient:exports.HttpClient,generate:ju};exports.default=Av,exports.generate=ju;

--- a/packages/openapi-fetch/vitest.config.ts
+++ b/packages/openapi-fetch/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
       enabled: true,
       tsconfig: "./tsconfig.json",
     },
+    restoreMocks: true,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       openapi-typescript-helpers:
         specifier: workspace:^
         version: link:../openapi-typescript-helpers
-      vitest-fetch-mock:
-        specifier: ^0.3.0
-        version: 0.3.0(vitest@2.0.5(@types/node@22.5.2)(jsdom@20.0.3))
     devDependencies:
       axios:
         specifier: ^1.7.7
@@ -1947,9 +1944,6 @@ packages:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
 
-  cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
-
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
@@ -3527,12 +3521,6 @@ packages:
         optional: true
       postcss:
         optional: true
-
-  vitest-fetch-mock@0.3.0:
-    resolution: {integrity: sha512-g6upWcL8/32fXL43/5f4VHcocuwQIi9Fj5othcK9gPO8XqSEGtnIZdenr2IaipDr61ReRFt+vaOEgo8jiUUX5w==}
-    engines: {node: '>=14.14.0'}
-    peerDependencies:
-      vitest: '>=2.0.0'
 
   vitest@2.0.5:
     resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}
@@ -5326,12 +5314,6 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  cross-fetch@4.0.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   cross-spawn@5.1.0:
     dependencies:
       lru-cache: 4.1.5
@@ -5378,6 +5360,10 @@ snapshots:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 9.4.0
+
+  debug@4.3.6:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.3.6(supports-color@9.4.0):
     dependencies:
@@ -6634,7 +6620,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.6(supports-color@9.4.0)
+      debug: 4.3.6
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 3.5.1
@@ -6896,13 +6882,6 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
-
-  vitest-fetch-mock@0.3.0(vitest@2.0.5(@types/node@22.5.2)(jsdom@20.0.3)):
-    dependencies:
-      cross-fetch: 4.0.0
-      vitest: 2.0.5(@types/node@22.5.2)(jsdom@20.0.3)
-    transitivePeerDependencies:
-      - encoding
 
   vitest@2.0.5(@types/node@22.5.2)(jsdom@20.0.3):
     dependencies:


### PR DESCRIPTION
## Changes

Part of #1365. #1895 removed MSW from benchmarks, but didn’t get the benchmarks working.

But it seems **removing MSW has greatly improved consistency**. I’m seeing really consistent runs for openapi-fetch, openapi-fetch (path-based), and openapi-typescript-fetch.

There’s still a missing mock needed for libraries that don’t use `globalThis.fetch` directly (axios, superagent, openapi-typescript-codegen), but that can be handled in a followup.

## How to Review

- `pnpm run bench:js` works in openapi-fetch

## Checklist

N/A
