### PR TITLE
feat(openapi-fetch): allow usage of custom Request class

### DIFF
--- a/.changeset/brave-days-invent.md
+++ b/.changeset/brave-days-invent.md
@@ -1,5 +1,5 @@
 ---
-"openapi-fetch": minor
+"openapi-fetch": patch
 ---
 
 allow usage of custom Request class

--- a/.changeset/brave-days-invent.md
+++ b/.changeset/brave-days-invent.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": minor
+---
+
+allow usage of custom Request class

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -17,6 +17,8 @@ export interface ClientOptions extends Omit<RequestInit, "headers"> {
   baseUrl?: string;
   /** custom fetch (defaults to globalThis.fetch) */
   fetch?: (input: Request) => Promise<Response>;
+  /** custom Request (defaults to globalThis.Request) */
+  Request?: typeof Request;
   /** global querySerializer */
   querySerializer?: QuerySerializer<unknown> | QuerySerializerOptions;
   /** global bodySerializer */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -1,20 +1,6 @@
 // settings & const
 const PATH_PARAM_RE = /\{[^{}]+\}/g;
 
-/** Add custom parameters to Request object */
-class CustomRequest extends Request {
-  constructor(input, init) {
-    super(input, init);
-
-    // add custom parameters
-    for (const key in init) {
-      if (!(key in this)) {
-        this[key] = init[key];
-      }
-    }
-  }
-}
-
 /**
  * Returns a cheap, non-cryptographically-secure random ID
  * Courtesy of @imranbarbhuiya (https://github.com/imranbarbhuiya)
@@ -30,6 +16,7 @@ export function randomID() {
 export default function createClient(clientOptions) {
   let {
     baseUrl = "",
+    Request: CustomRequest = globalThis.Request,
     fetch: baseFetch = globalThis.fetch,
     querySerializer: globalQuerySerializer,
     bodySerializer: globalBodySerializer,
@@ -48,6 +35,7 @@ export default function createClient(clientOptions) {
     const {
       baseUrl: localBaseUrl,
       fetch = baseFetch,
+      Request = CustomRequest,
       headers,
       params = {},
       parseAs = "json",
@@ -98,6 +86,13 @@ export default function createClient(clientOptions) {
     let options;
     let request = new CustomRequest(createFinalURL(schemaPath, { baseUrl, params, querySerializer }), requestInit);
 
+    /** Add custom parameters to Request object */
+    for (const key in init) {
+      if (!(key in request)) {
+        request[key] = init[key];
+      }
+    }
+
     if (middlewares.length) {
       id = randomID();
 
@@ -119,7 +114,7 @@ export default function createClient(clientOptions) {
             id,
           });
           if (result) {
-            if (!(result instanceof Request)) {
+            if (!(result instanceof CustomRequest)) {
               throw new Error("onRequest: must return new Request() when modifying the request");
             }
             request = result;

--- a/packages/openapi-fetch/test/common/request.test.ts
+++ b/packages/openapi-fetch/test/common/request.test.ts
@@ -286,9 +286,7 @@ describe("request", () => {
     // santity check to make sure the profided fetch function is actually called
     expect.assertions(1);
 
-    class SpecialRequestImplementation extends Request {
-      static special = "special";
-    }
+    class SpecialRequestImplementation extends Request {}
 
     const specialFetch = async (input: Request) => {
       // make sure that the request is actually an instance of the custom request we provided

--- a/packages/openapi-fetch/test/common/request.test.ts
+++ b/packages/openapi-fetch/test/common/request.test.ts
@@ -282,6 +282,29 @@ describe("request", () => {
     expect(headers.get("cookie")).toEqual("session=1234");
   });
 
+  test("uses provided Request class", async () => {
+    // santity check to make sure the profided fetch function is actually called
+    expect.assertions(1);
+
+    class SpecialRequestImplementation extends Request {
+      static special = "special";
+    }
+
+    const specialFetch = async (input: Request) => {
+      // make sure that the request is actually an instance of the custom request we provided
+      expect(input).instanceOf(SpecialRequestImplementation);
+      return Promise.resolve(Response.json({ hello: "world" }));
+    };
+
+    const client = createClient<paths>({
+      baseUrl: "https://fakeurl.example",
+      fetch: specialFetch,
+      Request: SpecialRequestImplementation,
+    });
+
+    await client.GET("/resources");
+  });
+
   test("can attach custom properties to request", async () => {
     function createCustomFetch(data: any) {
       const response = {


### PR DESCRIPTION
## Changes

- allows to specify a custom `Request` class
  - for more information around the motivation see #1563 
  - build on the foundation of #1593 

## How to Review

- I removed the pre-existing `CustomRequest` class and inlined the business logic from the constructor
- added a unit test

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
