### PR TITLE
Improve middleware type definition

### DIFF
--- a/.changeset/short-lizards-rescue.md
+++ b/.changeset/short-lizards-rescue.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Improve `Middleware` type definition to require either onRequest or onResponse

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -144,12 +144,22 @@ export interface MiddlewareCallbackParams {
   readonly options: MergedOptions;
 }
 
-export interface Middleware {
-  onRequest?: (options: MiddlewareCallbackParams) => void | Request | undefined | Promise<Request | undefined | void>;
-  onResponse?: (
-    options: MiddlewareCallbackParams & { response: Response },
-  ) => void | Response | undefined | Promise<Response | undefined | void>;
-}
+type MiddlewareOnRequest = (
+  options: MiddlewareCallbackParams,
+) => void | Request | undefined | Promise<Request | undefined | void>;
+type MiddlewareOnResponse = (
+  options: MiddlewareCallbackParams & { response: Response },
+) => void | Response | undefined | Promise<Response | undefined | void>;
+
+export type Middleware =
+  | {
+      onRequest: MiddlewareOnRequest;
+      onResponse?: MiddlewareOnResponse;
+    }
+  | {
+      onRequest?: MiddlewareOnRequest;
+      onResponse: MiddlewareOnResponse;
+    };
 
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */
 export type MaybeOptionalInit<Params, Location extends keyof Params> = RequiredKeysOf<

--- a/packages/openapi-fetch/test/middleware/middleware.test.ts
+++ b/packages/openapi-fetch/test/middleware/middleware.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, expectTypeOf, assertType } from "vitest";
 import { createObservedClient } from "../helpers.js";
 import type { Middleware, MiddlewareCallbackParams } from "../../src/index.js";
 import type { paths } from "./schemas/middleware.js";
@@ -353,4 +353,13 @@ test("auth header", async () => {
     params: { path: { id: 123 } },
   });
   expect(headers.get("authorization")).toBe(`Bearer ${accessToken}`);
+});
+
+test("type error occurs only when neither onRequest nor onResponse is specified", async () => {
+  expectTypeOf<Middleware>().not.toEqualTypeOf({});
+  const onRequest = async ({ request }: MiddlewareCallbackParams) => request;
+  const onResponse = async ({ response }: MiddlewareCallbackParams & { response: Response }) => response;
+  assertType<Middleware>({ onRequest });
+  assertType<Middleware>({ onResponse });
+  assertType<Middleware>({ onRequest, onResponse });
 });


### PR DESCRIPTION
## Changes

This PR updates the Middleware type definition to ensure that either `onRequest` or `onResponse` must be provided, as reflected in the error:

> "Middleware must be an object with one of onRequest() or onResponse()"

(see https://github.com/openapi-ts/openapi-typescript/issues/1916)

The new type definition introduces a union that enforces this behavior, allowing the absence of both methods to be detected at compile time.

## How to Review

Please review the changes to ensure that the new type definition accurately reflects the expected behavior. The key point is that a type error should occur only if neither onRequest nor onResponse is provided. Additionally, please check that existing middleware implementations are unaffected by this change.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)

Closes #1916