### PR TITLE
fix(openapi-fetch): Prevent orphan ampersands in query from empty arrays

### DIFF
--- a/.changeset/strong-boats-drive.md
+++ b/.changeset/strong-boats-drive.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix multiple empty arrays in query params appending extra ampersands

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -436,6 +436,9 @@ export function createQuerySerializer(options) {
           continue;
         }
         if (Array.isArray(value)) {
+          if (value.length === 0) {
+            continue;
+          }
           search.push(
             serializeArrayParam(name, value, {
               style: "form",

--- a/packages/openapi-fetch/test/common/params.test.ts
+++ b/packages/openapi-fetch/test/common/params.test.ts
@@ -264,6 +264,23 @@ describe("params", () => {
         expect(actualURL.search).toBe("");
       });
 
+      test("array params (empty, multiple)", async () => {
+        let actualURL = new URL("https://fakeurl.example");
+        const client = createObservedClient<paths>({}, async (req) => {
+          actualURL = new URL(req.url);
+          return Response.json({});
+        });
+
+        await client.GET("/query-params", {
+          params: {
+            query: { array: [], second_array: [], third_array: [] },
+          },
+        });
+
+        expect(actualURL.pathname).toBe("/query-params");
+        expect(actualURL.search).toBe("");
+      });
+
       test("empty/null params", async () => {
         let actualURL = new URL("https://fakeurl.example");
         const client = createObservedClient<paths>({}, async (req) => {


### PR DESCRIPTION
## Changes

Fixes a case where multiple empty arrays are passed as query params will create multiple orphaned ampersands in the resultant request URL

Closes https://github.com/openapi-ts/openapi-typescript/issues/1935

## How to Review

I decided to effectively ignore empty arrays in the querySerializer, the issue was they were returning `""` from `seralizeArrayParam` which was then caught up in the `.join("&")`. However, we could just as easily `.filter` out the empty strings and catch for the general case.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
