### PR TITLE
docs: fix the name of cli argument

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ In previous versions globbing was supported, but that has been **deprecated** in
 
 ## Redocly config
 
-A `redocly.yaml` file isn’t required to use openapi-typescript. By default it extends the `"minimal"` built-in config. But it is recommended if you want to have custom validation rules (or build types for [multiple schemas](#multiple-schemas)). The CLI will try to automatically find a `redocly.yaml` in the root of your project, but you can also provide its location with the `--redoc` flag:
+A `redocly.yaml` file isn’t required to use openapi-typescript. By default it extends the `"minimal"` built-in config. But it is recommended if you want to have custom validation rules (or build types for [multiple schemas](#multiple-schemas)). The CLI will try to automatically find a `redocly.yaml` in the root of your project, but you can also provide its location with the `--redocly` flag:
 
 ```bash
 npx openapi-typescript --redocly ./path/to/redocly.yaml

--- a/docs/ja/cli.md
+++ b/docs/ja/cli.md
@@ -65,7 +65,7 @@ npx openapi-typescript
 
 ## Redocly config
 
-openapi-typescript を使用するには `redocly.yaml` ファイルは必須ではありません。デフォルトでは、組み込みの `"minimal"` 設定を拡張します。ただし、カスタム検証ルールや[複数のスキーマ](#複数のスキーマ)の型を構築したい場合には使用をお勧めします。CLI はプロジェクトのルートディレクトリで `redocly.yaml` を自動的に見つけようとしますが、`--redoc` フラグを使用してその場所を指定することもできます：
+openapi-typescript を使用するには `redocly.yaml` ファイルは必須ではありません。デフォルトでは、組み込みの `"minimal"` 設定を拡張します。ただし、カスタム検証ルールや[複数のスキーマ](#複数のスキーマ)の型を構築したい場合には使用をお勧めします。CLI はプロジェクトのルートディレクトリで `redocly.yaml` を自動的に見つけようとしますが、`--redocly` フラグを使用してその場所を指定することもできます：
 
 ```bash
 npx openapi-typescript --redocly ./path/to/redocly.yaml

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -65,7 +65,7 @@ npx openapi-typescript
 
 ## Redoc 配置
 
-使用 openapi-typescript 不需要 `redocly.yaml` 文件。默认情况下，它扩展了内置配置中的 `"minimal"`。但如果您想要自定义验证规则（或构建[多个模式](#multiple-schemas)的类型），建议使用它。CLI 将尝试在项目根目录自动找到 `redocly.yaml`，但您也可以使用 `--redoc` 标志提供其位置：
+使用 openapi-typescript 不需要 `redocly.yaml` 文件。默认情况下，它扩展了内置配置中的 `"minimal"`。但如果您想要自定义验证规则（或构建[多个模式](#multiple-schemas)的类型），建议使用它。CLI 将尝试在项目根目录自动找到 `redocly.yaml`，但您也可以使用 `--redocly` 标志提供其位置：
 
 ```bash
 npx openapi-typescript --redocly ./path/to/redocly.yaml


### PR DESCRIPTION
## Changes

Replaced `redoc` to `redocly` following to the changes of https://github.com/openapi-ts/openapi-typescript/pull/1645 .


## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
