### PR TITLE
add MethodResponse for openapi-react-query

### DIFF
--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -11,7 +11,7 @@ import {
   useQuery,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient } from "openapi-fetch";
+import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient, ClientPathsWithMethod } from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 
 type InitWithUnknowns<Init> = Init & { [key: string]: unknown };
@@ -93,6 +93,16 @@ export interface OpenapiQueryClient<Paths extends {}, Media extends MediaType = 
   useMutation: UseMutationMethod<Paths, Media>;
 }
 
+export type MethodResponse<
+  CreatedClient extends OpenapiQueryClient<any, any>,
+  Method extends HttpMethod,
+  Path extends ClientPathsWithMethod<FetchClient<any, any>, Method>,
+  Options = {}
+> =
+  CreatedClient extends OpenapiQueryClient<infer Paths extends { [key: string]: any }, infer Media extends MediaType>
+    ? NonNullable<FetchResponse<Paths[Path][Method], Options, Media>["data"]>
+    : never
+
 // TODO: Add the ability to bring queryClient as argument
 export default function createClient<Paths extends {}, Media extends MediaType = MediaType>(
   client: FetchClient<Paths, Media>,
@@ -141,3 +151,4 @@ export default function createClient<Paths extends {}, Media extends MediaType =
       ),
   };
 }
+

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -11,7 +11,7 @@ import {
   useQuery,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient, ClientPathsWithMethod } from "openapi-fetch";
+import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient } from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 
 type InitWithUnknowns<Init> = Init & { [key: string]: unknown };
@@ -96,12 +96,13 @@ export interface OpenapiQueryClient<Paths extends {}, Media extends MediaType = 
 export type MethodResponse<
   CreatedClient extends OpenapiQueryClient<any, any>,
   Method extends HttpMethod,
-  Path extends ClientPathsWithMethod<FetchClient<any, any>, Method>,
-  Options = {}
-> =
-  CreatedClient extends OpenapiQueryClient<infer Paths extends { [key: string]: any }, infer Media extends MediaType>
-    ? NonNullable<FetchResponse<Paths[Path][Method], Options, Media>["data"]>
-    : never
+  Path extends CreatedClient extends OpenapiQueryClient<infer Paths, infer _Media>
+    ? PathsWithMethod<Paths, Method>
+    : never,
+  Options = object,
+> = CreatedClient extends OpenapiQueryClient<infer Paths extends { [key: string]: any }, infer Media extends MediaType>
+  ? NonNullable<FetchResponse<Paths[Path][Method], Options, Media>["data"]>
+  : never;
 
 // TODO: Add the ability to bring queryClient as argument
 export default function createClient<Paths extends {}, Media extends MediaType = MediaType>(
@@ -151,4 +152,3 @@ export default function createClient<Paths extends {}, Media extends MediaType =
       ),
   };
 }
-

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { server, baseUrl, useMockRequestHandler } from "./fixtures/mock-server.js";
 import type { paths } from "./fixtures/api.js";
-import createClient from "../src/index.js";
+import createClient, { type MethodResponse } from "../src/index.js";
 import createFetchClient from "openapi-fetch";
 import { fireEvent, render, renderHook, screen, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider, useQueries } from "@tanstack/react-query";
@@ -212,6 +212,7 @@ describe("client", () => {
 
       const { data, error } = result.current;
 
+      expectTypeOf(data).toEqualTypeOf<MethodResponse<typeof client, "get", "/string-array"> | undefined>();      
       expectTypeOf(data).toEqualTypeOf<string[] | undefined>();
       expectTypeOf(error).toEqualTypeOf<{ code: number; message: string } | null>();
     });

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -212,7 +212,7 @@ describe("client", () => {
 
       const { data, error } = result.current;
 
-      expectTypeOf(data).toEqualTypeOf<MethodResponse<typeof client, "get", "/string-array"> | undefined>();      
+      expectTypeOf(data).toEqualTypeOf<MethodResponse<typeof client, "get", "/string-array"> | undefined>();
       expectTypeOf(data).toEqualTypeOf<string[] | undefined>();
       expectTypeOf(error).toEqualTypeOf<{ code: number; message: string } | null>();
     });


### PR DESCRIPTION
## Changes

Following suit from https://github.com/openapi-ts/openapi-typescript/pull/1831, this PR adds the ability to get the return type of an endpoint from a `OpenapiQueryClient` client.

## How to Review

The rationale implements the same behaviours as the referenced PR, only changing expected type for the incoming client to be compliant with the `OpenapiQueryClient` interface (which doesn't extend `Client`).

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
