### PR TITLE
fix(openapi-typescript-helpers): fix SuccessResponseJSON, ErrorResponseJSON and RequestBodyJSON

### DIFF
--- a/.changeset/odd-seahorses-juggle.md
+++ b/.changeset/odd-seahorses-juggle.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+fix SuccessResponseJSON, ErrorResponseJSON and RequestBodyJSON helpers

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -131,13 +131,13 @@ export type ErrorResponse<T, Media extends MediaType = MediaType> = FilterKeys<
 >;
 
 /** Return first JSON-like 2XX response from a path + HTTP method */
-export type SuccessResponseJSON<PathMethod> = SuccessResponse<ResponseObjectMap<PathMethod>>;
+export type SuccessResponseJSON<PathMethod> = SuccessResponse<ResponseObjectMap<PathMethod>, `${string}/json`>;
 
 /** Return first JSON-like 5XX or 4XX response from a path + HTTP method */
-export type ErrorResponseJSON<PathMethod> = ErrorResponse<ResponseObjectMap<PathMethod>>;
+export type ErrorResponseJSON<PathMethod> = ErrorResponse<ResponseObjectMap<PathMethod>, `${string}/json`>;
 
 /** Return JSON-like request body from a path + HTTP method */
-export type RequestBodyJSON<PathMethod> = FilterKeys<OperationRequestBody<PathMethod>, "content">;
+export type RequestBodyJSON<PathMethod> = JSONLike<FilterKeys<OperationRequestBody<PathMethod>, "content">>;
 
 // Generic TS utils
 


### PR DESCRIPTION
## Changes

Since #1871,
1. SuccessResponseJSON and ErrorResponseJSON no longer return `never`, but may return a non-application/json response.
2. RequestBodyJSON returns `{ "application/json": T }` instead of `T`.

This fixes these issues.

## How to Review

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
