### PR TITLE
feat(openapi-react-query): use `queryOptions` helper

### DIFF
--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -11,14 +11,24 @@ import {
   useQuery,
   useSuspenseQuery,
   queryOptions,
-  type DataTag,
-  type DefinedInitialDataOptions,
-  type UndefinedInitialDataOptions,
 } from "@tanstack/react-query";
 import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient } from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 
 type InitWithUnknowns<Init> = Init & { [key: string]: unknown };
+
+// biome-ignore lint/suspicious/noRedeclare: <https://stackoverflow.com/questions/52760509/typescript-returntype-of-overloaded-function>
+type OverloadedReturnType<T> = T extends { (...args: any[]): infer R; (...args: any[]): infer R }
+  ? R
+  : T extends (...args: any[]) => infer R
+    ? R
+    : any;
+
+type OverloadedParameters<T> = T extends { (...args: infer P1): any; (...args: infer P2): any }
+  ? P1
+  : T extends (...args: infer P) => any
+    ? P
+    : never;
 
 export type QueryKey<
   Paths extends Record<string, Record<HttpMethod, {}>>,
@@ -26,14 +36,14 @@ export type QueryKey<
   Path extends PathsWithMethod<Paths, Method>,
 > = readonly [Method, Path, MaybeOptionalInit<Paths[Path], Method>];
 
-export type QueryOptionsObject<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
+export type QueryOptionsFunction<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
   Path extends PathsWithMethod<Paths, Method>,
   Init extends MaybeOptionalInit<Paths[Path], Method>,
   Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>, // note: Required is used to avoid repeating NonNullable in UseQuery types
   Options extends Omit<
     UseQueryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>,
-    "queryKey" | "queryFn" | "initialData"
+    "queryKey" | "queryFn"
   >,
 >(
   method: Method,
@@ -41,12 +51,28 @@ export type QueryOptionsObject<Paths extends Record<string, Record<HttpMethod, {
   ...[init, options]: RequiredKeysOf<Init> extends never
     ? [InitWithUnknowns<Init>?, Options?]
     : [InitWithUnknowns<Init>, Options?]
-) => (
-  | DefinedInitialDataOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
-  | UndefinedInitialDataOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
-) & {
-  queryKey: DataTag<QueryKey<Paths, Method, Path>, Response["data"]>;
-};
+) => UseQueryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>;
+
+export type QueryOptionsObject<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
+  Method extends HttpMethod,
+  Path extends PathsWithMethod<Paths, Method>,
+  Init extends MaybeOptionalInit<Paths[Path], Method>,
+  Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>, // note: Required is used to avoid repeating NonNullable in UseQuery types
+  Options extends Omit<
+    OverloadedParameters<
+      typeof queryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
+    >[0],
+    "queryKey" | "queryFn"
+  >,
+>(
+  method: Method,
+  path: Path,
+  ...[init, options]: RequiredKeysOf<Init> extends never
+    ? [InitWithUnknowns<Init>?, Options?]
+    : [InitWithUnknowns<Init>, Options?]
+) => OverloadedReturnType<
+  typeof queryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
+>;
 
 export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
@@ -119,19 +145,24 @@ export default function createClient<Paths extends {}, Media extends MediaType =
     return data;
   };
 
-  const queryOptionsObject: QueryOptionsObject<Paths, Media> = (method, path, ...[init, options]) =>
-    queryOptions({
-      queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
-      queryFn,
-      ...options,
-    });
+  const queryOptionsParams: QueryOptionsFunction<Paths, Media> = (method, path, ...[init, options]) => ({
+    queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
+    queryFn,
+    ...options,
+  });
 
   return {
-    queryOptions: queryOptionsObject,
+    queryOptions: (method, path, ...[init, options]) =>
+      queryOptions({
+        queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
+        queryFn,
+        // TODO: find a way to avoid as any
+        ...(options as any),
+      }),
     useQuery: (method, path, ...[init, options, queryClient]) =>
-      useQuery(queryOptionsObject(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
+      useQuery(queryOptionsParams(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
     useSuspenseQuery: (method, path, ...[init, options, queryClient]) =>
-      useSuspenseQuery(queryOptionsObject(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
+      useSuspenseQuery(queryOptionsParams(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
     useMutation: (method, path, options, queryClient) =>
       useMutation(
         {

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -10,6 +10,10 @@ import {
   useMutation,
   useQuery,
   useSuspenseQuery,
+  queryOptions,
+  type DataTag,
+  type DefinedInitialDataOptions,
+  type UndefinedInitialDataOptions,
 } from "@tanstack/react-query";
 import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient } from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
@@ -22,14 +26,14 @@ export type QueryKey<
   Path extends PathsWithMethod<Paths, Method>,
 > = readonly [Method, Path, MaybeOptionalInit<Paths[Path], Method>];
 
-export type QueryOptionsFunction<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
+export type QueryOptionsObject<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
   Path extends PathsWithMethod<Paths, Method>,
   Init extends MaybeOptionalInit<Paths[Path], Method>,
   Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>, // note: Required is used to avoid repeating NonNullable in UseQuery types
   Options extends Omit<
     UseQueryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>,
-    "queryKey" | "queryFn"
+    "queryKey" | "queryFn" | "initialData"
   >,
 >(
   method: Method,
@@ -37,7 +41,12 @@ export type QueryOptionsFunction<Paths extends Record<string, Record<HttpMethod,
   ...[init, options]: RequiredKeysOf<Init> extends never
     ? [InitWithUnknowns<Init>?, Options?]
     : [InitWithUnknowns<Init>, Options?]
-) => UseQueryOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>;
+) => (
+  | DefinedInitialDataOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
+  | UndefinedInitialDataOptions<Response["data"], Response["error"], Response["data"], QueryKey<Paths, Method, Path>>
+) & {
+  queryKey: DataTag<QueryKey<Paths, Method, Path>, Response["data"]>;
+};
 
 export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
@@ -87,7 +96,7 @@ export type UseMutationMethod<Paths extends Record<string, Record<HttpMethod, {}
 ) => UseMutationResult<Response["data"], Response["error"], Init>;
 
 export interface OpenapiQueryClient<Paths extends {}, Media extends MediaType = MediaType> {
-  queryOptions: QueryOptionsFunction<Paths, Media>;
+  queryOptions: QueryOptionsObject<Paths, Media>;
   useQuery: UseQueryMethod<Paths, Media>;
   useSuspenseQuery: UseSuspenseQueryMethod<Paths, Media>;
   useMutation: UseMutationMethod<Paths, Media>;
@@ -110,18 +119,19 @@ export default function createClient<Paths extends {}, Media extends MediaType =
     return data;
   };
 
-  const queryOptions: QueryOptionsFunction<Paths, Media> = (method, path, ...[init, options]) => ({
-    queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
-    queryFn,
-    ...options,
-  });
+  const queryOptionsObject: QueryOptionsObject<Paths, Media> = (method, path, ...[init, options]) =>
+    queryOptions({
+      queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
+      queryFn,
+      ...options,
+    });
 
   return {
-    queryOptions,
+    queryOptions: queryOptionsObject,
     useQuery: (method, path, ...[init, options, queryClient]) =>
-      useQuery(queryOptions(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
+      useQuery(queryOptionsObject(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
     useSuspenseQuery: (method, path, ...[init, options, queryClient]) =>
-      useSuspenseQuery(queryOptions(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
+      useSuspenseQuery(queryOptionsObject(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
     useMutation: (method, path, options, queryClient) =>
       useMutation(
         {

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -70,26 +70,34 @@ describe("client", () => {
 
       const initialData = { title: "Initial data", body: "Initial data" };
 
-      const options = client.queryOptions("get", "/blogposts/{post_id}", {
-        params: {
-          path: {
-            post_id: "1",
+      const options = client.queryOptions(
+        "get",
+        "/blogposts/{post_id}",
+        {
+          params: {
+            path: {
+              post_id: "1",
+            },
           },
         },
-      },{
-        initialData: () => initialData
-      })
+        {
+          initialData: () => initialData,
+        },
+      );
 
-      const data = queryClient.getQueryData( options.queryKey );
-      
-      expectTypeOf(data).toEqualTypeOf<{
-        title: string;
-        body: string;
-        publish_date?: number;
-      } | undefined>();
+      const data = queryClient.getQueryData(options.queryKey);
+
+      expectTypeOf(data).toEqualTypeOf<
+        | {
+            title: string;
+            body: string;
+            publish_date?: number;
+          }
+        | undefined
+      >();
       expect(data).toEqual(undefined);
 
-      const { result } = renderHook(() => useQuery({...options, enabled: false}), {
+      const { result } = renderHook(() => useQuery({ ...options, enabled: false }), {
         wrapper,
       });
 
@@ -97,9 +105,6 @@ describe("client", () => {
 
       expect(result.current.data).toEqual(initialData);
       expect(result.current.error).toBeNull();
-
-
-      
     });
 
     it("returns query options that can resolve data correctly with fetchQuery", async () => {

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -4,7 +4,7 @@ import type { paths } from "./fixtures/api.js";
 import createClient from "../src/index.js";
 import createFetchClient from "openapi-fetch";
 import { fireEvent, render, renderHook, screen, waitFor, act } from "@testing-library/react";
-import { QueryClient, QueryClientProvider, useQueries } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQueries, useQuery } from "@tanstack/react-query";
 import { Suspense, type ReactNode } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -68,21 +68,36 @@ describe("client", () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);
 
-      const data = queryClient.getQueryData(
-        client.queryOptions("get", "/blogposts/{post_id}", {
-          params: {
-            path: {
-              post_id: "1",
-            },
-          },
-        }).queryKey
-      );
+      const initialData = { title: "Initial data", body: "Initial data" };
 
+      const options = client.queryOptions("get", "/blogposts/{post_id}", {
+        params: {
+          path: {
+            post_id: "1",
+          },
+        },
+      },{
+        initialData: () => initialData
+      })
+
+      const data = queryClient.getQueryData( options.queryKey );
+      
       expectTypeOf(data).toEqualTypeOf<{
         title: string;
         body: string;
         publish_date?: number;
       } | undefined>();
+      expect(data).toEqual(undefined);
+
+      const { result } = renderHook(() => useQuery({...options, enabled: false}), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      expect(result.current.data).toEqual(initialData);
+      expect(result.current.error).toBeNull();
+
 
       
     });

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -64,6 +64,29 @@ describe("client", () => {
       client.queryOptions("get", "/blogposts/{post_id}", {});
     });
 
+    it("correctly infers return type from query key", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      const data = queryClient.getQueryData(
+        client.queryOptions("get", "/blogposts/{post_id}", {
+          params: {
+            path: {
+              post_id: "1",
+            },
+          },
+        }).queryKey
+      );
+
+      expectTypeOf(data).toEqualTypeOf<{
+        title: string;
+        body: string;
+        publish_date?: number;
+      } | undefined>();
+
+      
+    });
+
     it("returns query options that can resolve data correctly with fetchQuery", async () => {
       const response = { title: "title", body: "body" };
       const fetchClient = createFetchClient<paths>({ baseUrl });


### PR DESCRIPTION
## Changes

The current state of queryOptions doesn't take advantage of the `queryOptions` helper, which has the ability of linking the returned data shape to the queryKey.
This is useful when using `queryClient.getQueryData` and especially handy for optimistic updates managed via `queryClient.setQueryData`.

The proposed implementation only consumes the helper to build the queryOptions property, and doesn't touch the way options are passed to `useQuery/useSuspenseQuery` to avoid narrowing the allowed options to the ones provided by the helper.

## How to Review
When consuming `queryClient.getQueryData` by passing a queryKey coming from a queryOptions object, see that the returned type isn't `unknown` anymore, but `TData | undefined`.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
