### PR TITLE
fix(openapi-react-query): Fix typing of queryOptions

### DIFF
--- a/.changeset/query-options-infer.md
+++ b/.changeset/query-options-infer.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+Fix return type inference for `queryOptions()` when used inside `useQuery` or `useSuspenseQuery`.

--- a/.changeset/query-options-queryfn.md
+++ b/.changeset/query-options-queryfn.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+Narrow `queryFn` returned by `queryOptions()` to be a function.

--- a/packages/openapi-react-query/package.json
+++ b/packages/openapi-react-query/package.json
@@ -79,7 +79,7 @@
     "react-error-boundary": "^4.1.2"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-query": "^5.25.0",
     "openapi-fetch": "workspace:^"
   }
 }


### PR DESCRIPTION
## Changes

Fixes #1929, #1946. And also fixes an issue with `SkipToken` and `useSuspenseQuery`.

## How to Review

Added tests that reproduce the bug so if they are correct and green, the linked issues should be fixed.

## Checklist

- [x] Unit tests updated