### PR TITLE
Add a flag to skip Schema prefix when rendering root types

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,6 +120,7 @@ The following flags are supported in the CLI:
 | `--immutable`                      |       | `false`  | Generates immutable types (readonly properties and readonly array)                                                  |
 | `--path-params-as-types`           |       | `false`  | Allow dynamic string lookups on the `paths` object                                                                  |
 | `--root-types`                     |       | `false`  | Exports types from `components` as root level type aliases                                                          |
+| `--root-types-no-schema-prefix`    |       | `false`  | Do not add "Schema" prefix to types at the root level (should only be used with --root-types)                       |
 
 ### pathParamsAsTypes
 

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -11,26 +11,27 @@ const HELP = `Usage
   $ openapi-typescript [input] [options]
 
 Options
-  --help                     Display this
-  --version                  Display the version
-  --redocly [path], -c       Specify path to Redocly config (default: redocly.yaml)
-  --output, -o               Specify output file (if not specified in redocly.yaml)
-  --enum                     Export true TS enums instead of unions
-  --enum-values              Export enum values as arrays
-  --dedupe-enums             Dedupe enum types when \`--enum=true\` is set
-  --check                    Check that the generated types are up-to-date. (default: false)
-  --export-type, -t          Export top-level \`type\` instead of \`interface\`
-  --immutable                Generate readonly types
-  --additional-properties    Treat schema objects as if \`additionalProperties: true\` is set
-  --empty-objects-unknown    Generate \`unknown\` instead of \`Record<string, never>\` for empty objects
-  --default-non-nullable     Set to \`false\` to ignore default values when generating non-nullable types
+  --help                                      Display this
+  --version                                   Display the version
+  --redocly [path], -c                        Specify path to Redocly config (default: redocly.yaml)
+  --output, -o                                Specify output file (if not specified in redocly.yaml)
+  --enum                                      Export true TS enums instead of unions
+  --enum-values                               Export enum values as arrays
+  --dedupe-enums                              Dedupe enum types when \`--enum=true\` is set
+  --check                                     Check that the generated types are up-to-date. (default: false)
+  --export-type, -t                           Export top-level \`type\` instead of \`interface\`
+  --immutable                                 Generate readonly types
+  --additional-properties                     Treat schema objects as if \`additionalProperties: true\` is set
+  --empty-objects-unknown                     Generate \`unknown\` instead of \`Record<string, never>\` for empty objects
+  --default-non-nullable                      Set to \`false\` to ignore default values when generating non-nullable types
   --properties-required-by-default
-                             Treat schema objects as if \`required\` is set to all properties by default
-  --array-length             Generate tuples using array minItems / maxItems
-  --path-params-as-types     Convert paths to template literal types
-  --alphabetize              Sort object keys alphabetically
-  --exclude-deprecated       Exclude deprecated types
-  --root-types (optional)    Export schemas types at root level
+                                              Treat schema objects as if \`required\` is set to all properties by default
+  --array-length                              Generate tuples using array minItems / maxItems
+  --path-params-as-types                      Convert paths to template literal types
+  --alphabetize                               Sort object keys alphabetically
+  --exclude-deprecated                        Exclude deprecated types
+  --root-types (optional)                     Export schemas types at root level
+  --root-types-no-schema-prefix (optional)    Do not add "Schema" prefix to types at the root level (should be used with --root-types)
 `;
 
 const OUTPUT_FILE = "FILE";
@@ -56,6 +57,9 @@ if (args.includes("-it")) {
 if (args.includes("--redoc")) {
   errorAndExit(`The --redoc config flag has been renamed to "--redocly" (or -c as shorthand).`);
 }
+if (args.includes("--root-types-no-schema-prefix") && !args.includes("--root-types")) {
+  console.warn("--root-types-no-schema-prefix has no effect without --root-types flag");
+}
 
 const flags = parser(args, {
   boolean: [
@@ -76,6 +80,7 @@ const flags = parser(args, {
     "immutable",
     "pathParamsAsTypes",
     "rootTypes",
+    "rootTypesNoSchemaPrefix",
   ],
   string: ["output", "redocly"],
   alias: {
@@ -136,6 +141,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       immutable: flags.immutable,
       pathParamsAsTypes: flags.pathParamsAsTypes,
       rootTypes: flags.rootTypes,
+      rootTypesNoSchemaPrefix: flags.rootTypesNoSchemaPrefix,
       redocly,
       silent,
     }),

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -32,7 +32,7 @@ Options
   --exclude-deprecated       Exclude deprecated types
   --root-types (optional)    Export schemas types at root level
   --root-types-no-schema-prefix (optional)
-                             Do not add "Schema" prefix to types at the root level (should be used with --root-types)
+                             Do not add "Schema" prefix to types at the root level (should only be used with --root-types)
 `;
 
 const OUTPUT_FILE = "FILE";

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -11,27 +11,28 @@ const HELP = `Usage
   $ openapi-typescript [input] [options]
 
 Options
-  --help                                      Display this
-  --version                                   Display the version
-  --redocly [path], -c                        Specify path to Redocly config (default: redocly.yaml)
-  --output, -o                                Specify output file (if not specified in redocly.yaml)
-  --enum                                      Export true TS enums instead of unions
-  --enum-values                               Export enum values as arrays
-  --dedupe-enums                              Dedupe enum types when \`--enum=true\` is set
-  --check                                     Check that the generated types are up-to-date. (default: false)
-  --export-type, -t                           Export top-level \`type\` instead of \`interface\`
-  --immutable                                 Generate readonly types
-  --additional-properties                     Treat schema objects as if \`additionalProperties: true\` is set
-  --empty-objects-unknown                     Generate \`unknown\` instead of \`Record<string, never>\` for empty objects
-  --default-non-nullable                      Set to \`false\` to ignore default values when generating non-nullable types
+  --help                     Display this
+  --version                  Display the version
+  --redocly [path], -c       Specify path to Redocly config (default: redocly.yaml)
+  --output, -o               Specify output file (if not specified in redocly.yaml)
+  --enum                     Export true TS enums instead of unions
+  --enum-values              Export enum values as arrays
+  --dedupe-enums             Dedupe enum types when \`--enum=true\` is set
+  --check                    Check that the generated types are up-to-date. (default: false)
+  --export-type, -t          Export top-level \`type\` instead of \`interface\`
+  --immutable                Generate readonly types
+  --additional-properties    Treat schema objects as if \`additionalProperties: true\` is set
+  --empty-objects-unknown    Generate \`unknown\` instead of \`Record<string, never>\` for empty objects
+  --default-non-nullable     Set to \`false\` to ignore default values when generating non-nullable types
   --properties-required-by-default
-                                              Treat schema objects as if \`required\` is set to all properties by default
-  --array-length                              Generate tuples using array minItems / maxItems
-  --path-params-as-types                      Convert paths to template literal types
-  --alphabetize                               Sort object keys alphabetically
-  --exclude-deprecated                        Exclude deprecated types
-  --root-types (optional)                     Export schemas types at root level
-  --root-types-no-schema-prefix (optional)    Do not add "Schema" prefix to types at the root level (should be used with --root-types)
+                             Treat schema objects as if \`required\` is set to all properties by default
+  --array-length             Generate tuples using array minItems / maxItems
+  --path-params-as-types     Convert paths to template literal types
+  --alphabetize              Sort object keys alphabetically
+  --exclude-deprecated       Exclude deprecated types
+  --root-types (optional)    Export schemas types at root level
+  --root-types-no-schema-prefix (optional)
+                             Do not add "Schema" prefix to types at the root level (should be used with --root-types)
 `;
 
 const OUTPUT_FILE = "FILE";

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -701,9 +701,11 @@ export interface paths {
          *     `/v2/cdn/endpoints/$ENDPOINT_ID/cache`. The body of the request should include
          *     a `files` attribute containing a list of cached file paths to be purged. A
          *     path may be for a single file or may contain a wildcard (`*`) to recursively
-         *     purge all files under a directory. When only a wildcard is provided, all
-         *     cached files will be purged. There is a rate limit of 50 files per 20 seconds
-         *     that can be purged.
+         *     purge all files under a directory. When only a wildcard is provided, all cached
+         *     files will be purged. There is a rate limit of 50 files per 20 seconds that can
+         *     be purged. CDN endpoints have a rate limit of 5 requests per 10 seconds.
+         *     Purging files using a wildcard path counts as a single request against the API's
+         *     rate limit. Two identical purge requests cannot be sent at the same time.
          *
          */
         delete: operations["cdn_purge_cache"];
@@ -1165,7 +1167,7 @@ export interface paths {
         get: operations["databases_list_firewall_rules"];
         /**
          * Update Firewall Rules (Trusted Sources) for a Database
-         * @description To update a database cluster's firewall rules (known as "trusted sources" in the control panel), send a PUT request to `/v2/databases/$DATABASE_ID/firewall` specifying which resources should be able to open connections to the database. You may limit connections to specific Droplets, Kubernetes clusters, or IP addresses. When a tag is provided, any Droplet or Kubernetes node with that tag applied to it will have access. The firewall is limited to 100 rules (or trusted sources). When possible, we recommend [placing your databases into a VPC network](https://www.digitalocean.com/docs/networking/vpc/) to limit access to them instead of using a firewall.
+         * @description To update a database cluster's firewall rules (known as "trusted sources" in the control panel), send a PUT request to `/v2/databases/$DATABASE_ID/firewall` specifying which resources should be able to open connections to the database. You may limit connections to specific Droplets, Kubernetes clusters, or IP addresses. When a tag is provided, any Droplet or Kubernetes node with that tag applied to it will have access. The firewall is limited to 100 rules (or trusted sources). When possible, we recommend [placing your databases into a VPC network](https://docs.digitalocean.com/products/networking/vpc/) to limit access to them instead of using a firewall.
          *     A successful
          */
         put: operations["databases_update_firewall_rules"];
@@ -1578,7 +1580,7 @@ export interface paths {
          * Add a New Connection Pool (PostgreSQL)
          * @description For PostgreSQL database clusters, connection pools can be used to allow a
          *     database to share its idle connections. The popular PostgreSQL connection
-         *     pooling utility PgBouncer is used to provide this service. [See here for more information](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools/)
+         *     pooling utility PgBouncer is used to provide this service. [See here for more information](https://docs.digitalocean.com/products/databases/postgresql/how-to/manage-connection-pools/)
          *     about how and why to use PgBouncer connection pooling including
          *     details about the available transaction modes.
          *
@@ -2072,6 +2074,11 @@ export interface paths {
          *     To only list Droplets assigned to a specific tag, include the `tag_name` query
          *     parameter set to the name of the tag in your GET request. For example,
          *     `/v2/droplets?tag_name=$TAG_NAME`.
+         *
+         *     ### GPU Droplets
+         *
+         *     By default, only non-GPU Droplets are returned. To list only GPU Droplets, set
+         *     the `type` query parameter to `gpus`. For example, `/v2/droplets?type=gpus`.
          *
          */
         get: operations["droplets_list"];
@@ -3164,7 +3171,7 @@ export interface paths {
          *     The request may contain a maintenance window policy describing a time period
          *     when disruptive maintenance tasks may be carried out. Omitting the policy
          *     implies that a window will be chosen automatically. See
-         *     [here](https://www.digitalocean.com/docs/kubernetes/how-to/upgrade-cluster/)
+         *     [here](https://docs.digitalocean.com/products/kubernetes/how-to/upgrade-cluster/)
          *     for details.
          *
          */
@@ -3302,7 +3309,7 @@ export interface paths {
          *     The resulting kubeconfig file uses token-based authentication for clusters
          *     supporting it, and certificate-based authentication otherwise. For a list of
          *     supported versions and more information, see "[How to Connect to a DigitalOcean
-         *     Kubernetes Cluster with kubectl](https://www.digitalocean.com/docs/kubernetes/how-to/connect-with-kubectl/)".
+         *     Kubernetes Cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/)".
          *
          *     To retrieve a kubeconfig file for use with a Kubernetes cluster, send a GET
          *     request to `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/kubeconfig`.
@@ -3338,7 +3345,7 @@ export interface paths {
          *     The resulting JSON object contains token-based authentication for clusters
          *     supporting it, and certificate-based authentication otherwise. For a list of
          *     supported versions and more information, see "[How to Connect to a DigitalOcean
-         *     Kubernetes Cluster with kubectl](https://www.digitalocean.com/docs/kubernetes/how-to/connect-with-kubectl/)".
+         *     Kubernetes Cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/)".
          *
          *     To retrieve credentials for accessing a Kubernetes cluster, send a GET
          *     request to `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/credentials`.
@@ -4672,6 +4679,108 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/monitoring/sinks/destinations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Logging Destinations
+         * @description To list all logging destinations, send a GET request to `/v2/monitoring/sinks/destinations`.
+         */
+        get: operations["monitoring_list_destinations"];
+        put?: never;
+        /**
+         * Create Logging Destination
+         * @description To create a new destination, send a POST request to `/v2/monitoring/sinks/destinations`.
+         */
+        post: operations["monitoring_create_destination"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/monitoring/sinks/destinations/{destination_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Logging Destination
+         * @description To get the details of a destination, send a GET request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+         */
+        get: operations["monitoring_get_destination"];
+        put?: never;
+        /**
+         * Update Logging Destination
+         * @description To update the details of a destination, send a PATCH request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+         */
+        post: operations["monitoring_update_destination"];
+        /**
+         * Delete Logging Destination
+         * @description To delete a destination and all associated sinks, send a DELETE request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+         */
+        delete: operations["monitoring_delete_destination"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/monitoring/sinks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Lists all sinks
+         * @description To list all sinks, send a GET request to `/v2/monitoring/sinks`.
+         */
+        get: operations["monitoring_list_sinks"];
+        put?: never;
+        /**
+         * Create Sink
+         * @description To create a new sink, send a POST request to `/v2/monitoring/sinks`. Forwards logs from the
+         *     resources identified in `resources` to the specified pre-existing destination.
+         *
+         */
+        post: operations["monitoring_create_sink"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/monitoring/sinks/{sink_uuid}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sink
+         * @description To get the details of a sink (resources and destination), send a GET request to `/v2/monitoring/sinks/${sink_uuid}`.
+         */
+        get: operations["monitoring_get_sink"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Sink
+         * @description To delete a sink, send a DELETE request to `/v2/monitoring/sinks/${sink_uuid}`.
+         */
+        delete: operations["monitoring_delete_sink"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/projects": {
         parameters: {
             query?: never;
@@ -5134,7 +5243,7 @@ export interface paths {
          *     manifest data) after deleting one or more manifests from a repository. If
          *     there are no unreferenced blobs resulting from the deletion of one or more
          *     manifests, garbage collection is effectively a noop.
-         *     [See here for more information](https://www.digitalocean.com/docs/container-registry/how-to/clean-up-container-registry/)
+         *     [See here for more information](https://docs.digitalocean.com/products/container-registry/how-to/clean-up-container-registry/)
          *     about how and why you should clean up your container registry periodically.
          *
          *     To request a garbage collection run on your registry, send a POST request to
@@ -5603,7 +5712,7 @@ export interface paths {
          *     volumes may be attached to a Droplet at a time. Pre-formatted volumes will be
          *     automatically mounted to Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS
          *     Droplets created on or after April 26, 2018 when attached. On older Droplets,
-         *     [additional configuration](https://www.digitalocean.com/community/tutorials/how-to-partition-and-format-digitalocean-block-storage-volumes-in-linux#mounting-the-filesystems)
+         *     [additional configuration](https://docs.digitalocean.com/products/volumes/how-to/mount/)
          *     is required.
          *
          *     ## Remove a Block Storage Volume from a Droplet
@@ -5716,7 +5825,7 @@ export interface paths {
          *     volumes may be attached to a Droplet at a time. Pre-formatted volumes will be
          *     automatically mounted to Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS
          *     Droplets created on or after April 26, 2018 when attached. On older Droplets,
-         *     [additional configuration](https://www.digitalocean.com/community/tutorials/how-to-partition-and-format-digitalocean-block-storage-volumes-in-linux#mounting-the-filesystems)
+         *     [additional configuration](https://docs.digitalocean.com/products/volumes/how-to/mount/)
          *     is required.
          *
          *     ## Remove a Block Storage Volume from a Droplet
@@ -5889,6 +5998,116 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/v2/vpcs/{vpc_id}/peerings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the Peerings of a VPC
+         * @description To list all of a VPC's peerings, send a GET request to
+         *     `/v2/vpcs/$VPC_ID/peerings`.
+         *
+         */
+        get: operations["vpcs_list_peerings"];
+        put?: never;
+        /**
+         * Create a Peering with a VPC
+         * @description To create a new VPC peering for a given VPC, send a POST request to
+         *     `/v2/vpcs/$VPC_ID/peerings`.
+         *
+         */
+        post: operations["vpcs_create_peerings"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/vpcs/{vpc_id}/peerings/{vpc_peering_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update a VPC Peering
+         * @description To update the name of a VPC peering in a particular VPC, send a PATCH request
+         *     to `/v2/vpcs/$VPC_ID/peerings/$VPC_PEERING_ID` with the new `name` in the
+         *     request body.
+         *
+         */
+        patch: operations["vpcs_patch_peerings"];
+        trace?: never;
+    };
+    "/v2/vpc_peerings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List All VPC Peerings
+         * @description To list all of the VPC peerings on your account, send a GET request to `/v2/vpc_peerings`.
+         */
+        get: operations["vpcPeerings_list"];
+        put?: never;
+        /**
+         * Create a New VPC Peering
+         * @description To create a new VPC Peering, send a POST request to `/v2/vpc_peerings`
+         *     specifying a name and a list of two VPC IDs to peer. The response code, 202
+         *     Accepted, does not indicate the success or failure of the operation, just
+         *     that the request has been accepted for processing.
+         *
+         */
+        post: operations["vpcPeerings_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/vpc_peerings/{vpc_peering_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve an Existing VPC Peering
+         * @description To show information about an existing VPC Peering, send a GET request to `/v2/vpc_peerings/$VPC_PEERING_ID`.
+         *
+         */
+        get: operations["vpcPeerings_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a VPC peering
+         * @description To delete a VPC peering, send a DELETE request to `/v2/vpc_peerings/$VPC_PEERING_ID`.
+         *
+         */
+        delete: operations["vpcPeerings_delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a VPC peering
+         * @description To update the name of a VPC peering, send a PATCH request to `/v2/vpc_peerings/$VPC_PEERING_ID` with the new `name` in the request body.
+         *
+         */
+        patch: operations["vpcPeerings_patch"];
         trace?: never;
     };
     "/v2/uptime/checks": {
@@ -6267,11 +6486,6 @@ export interface components {
              */
             sizes: unknown;
         };
-        /**
-         * @description A human-readable string that is used as a unique identifier for each region.
-         * @example nyc3
-         */
-        slug: string;
         action: {
             /**
              * @description A unique numeric ID that can be used to identify and reference an action.
@@ -6313,7 +6527,11 @@ export interface components {
              */
             resource_type?: string;
             region?: components["schemas"]["region"];
-            region_slug?: components["schemas"]["slug"] & (string | null);
+            /**
+             * @description A human-readable string that is used as a unique identifier for each region.
+             * @example nyc3
+             */
+            region_slug?: string | null;
         };
         apps_deployment_job: {
             /**
@@ -6719,7 +6937,7 @@ export interface components {
             /** @description A list of environment variables made available to the component. */
             envs?: components["schemas"]["app_variable_definition"][];
             /**
-             * @description An environment slug describing the type of this app. For a full list, please refer to [the product documentation](https://www.digitalocean.com/docs/app-platform/).
+             * @description An environment slug describing the type of this app. For a full list, please refer to [the product documentation](https://docs.digitalocean.com/products/app-platform/).
              * @example node-js
              */
             environment_slug?: string;
@@ -6736,11 +6954,9 @@ export interface components {
             instance_count: number;
             /**
              * @description The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`
-             * @default apps-s-1vcpu-0.5gb
              * @example apps-s-1vcpu-0.5gb
-             * @enum {string}
              */
-            instance_size_slug: "apps-s-1vcpu-0.5gb" | "apps-s-1vcpu-1gb-fixed" | "apps-s-1vcpu-1gb" | "apps-s-1vcpu-2gb" | "apps-s-2vcpu-4gb" | "apps-d-1vcpu-0.5gb" | "apps-d-1vcpu-1gb" | "apps-d-1vcpu-2gb" | "apps-d-1vcpu-4gb" | "apps-d-2vcpu-4gb" | "apps-d-2vcpu-8gb" | "apps-d-4vcpu-8gb" | "apps-d-4vcpu-16gb" | "apps-d-8vcpu-32gb";
+            instance_size_slug?: ("apps-s-1vcpu-0.5gb" | "apps-s-1vcpu-1gb-fixed" | "apps-s-1vcpu-1gb" | "apps-s-1vcpu-2gb" | "apps-s-2vcpu-4gb" | "apps-d-1vcpu-0.5gb" | "apps-d-1vcpu-1gb" | "apps-d-1vcpu-2gb" | "apps-d-1vcpu-4gb" | "apps-d-2vcpu-4gb" | "apps-d-2vcpu-8gb" | "apps-d-4vcpu-8gb" | "apps-d-4vcpu-16gb" | "apps-d-8vcpu-32gb") | ("basic-xxs" | "basic-xs" | "basic-s" | "basic-m" | "professional-xs" | "professional-s" | "professional-m" | "professional-1l" | "professional-l" | "professional-xl");
             /** @description Configuration for automatically scaling this component based on metrics. */
             autoscaling?: {
                 /**
@@ -6913,6 +7129,16 @@ export interface components {
         app_service_spec: components["schemas"]["app_component_base"] & components["schemas"]["app_component_instance_base"] & {
             cors?: components["schemas"]["apps_cors_policy"] & unknown & unknown;
             health_check?: components["schemas"]["app_service_spec_health_check"];
+            /**
+             * @description The protocol which the service uses to serve traffic on the http_port.
+             *
+             *     - `HTTP`: The app is serving the HTTP protocol. Default.
+             *     - `HTTP2`: The app is serving the HTTP/2 protocol. Currently, this needs to be implemented in the service by serving HTTP/2 cleartext (h2c).
+             *
+             * @example HTTP
+             * @enum {string}
+             */
+            protocol?: "HTTP" | "HTTP2";
             /**
              * Format: int64
              * @description The internal port on which this service's run command will listen. Default: 8080
@@ -7183,6 +7409,19 @@ export interface components {
         app_egress_spec: {
             type?: components["schemas"]["app_egress_type_spec"];
         };
+        /** @description Specification to configure maintenance settings for the app, such as maintenance mode and archiving the app. */
+        app_maintenance_spec: {
+            /**
+             * @description Indicates whether maintenance mode should be enabled for the app.
+             * @example true
+             */
+            enabled?: boolean;
+            /**
+             * @description Indicates whether the app should be archived. Setting this to true implies that enabled is set to true. Note that this feature is currently in closed beta.
+             * @example true
+             */
+            archive?: boolean;
+        };
         /**
          * AppSpec
          * @description The desired configuration of an application.
@@ -7216,6 +7455,7 @@ export interface components {
             databases?: components["schemas"]["app_database_spec"][];
             ingress?: components["schemas"]["app_ingress_spec"];
             egress?: components["schemas"]["app_egress_spec"];
+            maintenance?: components["schemas"]["app_maintenance_spec"];
         };
         apps_deployment_static_site: {
             /**
@@ -9383,6 +9623,11 @@ export interface components {
              * @example false
              */
             stat_monitor_enable?: boolean;
+            /**
+             * @description Number of seconds of master unavailability before triggering database failover to standby. The default value is 60.
+             * @example 50
+             */
+            max_failover_replication_time_lag?: number;
         };
         /**
          * @description A string specifying the desired eviction policy for the Redis cluster.
@@ -9427,7 +9672,10 @@ export interface components {
              */
             redis_lfu_decay_time: number;
             /**
-             * @description Require SSL to access Redis
+             * @description Require SSL to access Redis.
+             *     - When enabled, Redis accepts only SSL connections on port `25061`.
+             *     - When disabled, port `25060` is opened for non-SSL connections, while port `25061` remains available for SSL connections.
+             *
              * @default true
              * @example true
              */
@@ -9882,6 +10130,12 @@ export interface components {
              *     ]
              */
             reindex_remote_whitelist?: string[];
+            /**
+             * @description Enable or disable filtering of alerting by backend roles.
+             * @default false
+             * @example false
+             */
+            plugins_alerting_filter_by_backend_roles_enabled: boolean;
         };
         mongo_advanced_config: {
             /**
@@ -10708,12 +10962,32 @@ export interface components {
         domain_record_soa: components["schemas"]["domain_record"] & unknown;
         domain_record_srv: components["schemas"]["domain_record"] & unknown;
         domain_record_txt: components["schemas"]["domain_record"] & unknown;
+        disk_info: {
+            /**
+             * @description The type of disk. All Droplets contain a `local` disk. Additionally, GPU Droplets can also have a `scratch` disk for non-persistent data.
+             * @example local
+             * @enum {string}
+             */
+            type?: "local" | "scratch";
+            size?: {
+                /**
+                 * @description The amount of space allocated to the disk.
+                 * @example 25
+                 */
+                amount?: number;
+                /**
+                 * @description The unit of measure for the disk size.
+                 * @example gib
+                 */
+                unit?: string;
+            };
+        };
         /**
          * @deprecated
          * @description **Note**: All Droplets created after March 2017 use internal kernels by default.
          *     These Droplets will have this attribute set to `null`.
          *
-         *     The current [kernel](https://www.digitalocean.com/docs/droplets/how-to/kernel/)
+         *     The current [kernel](https://docs.digitalocean.com/products/droplets/how-to/kernel/)
          *     for Droplets with externally managed kernels. This will initially be set to
          *     the kernel of the base image when the Droplet is created.
          *
@@ -10765,7 +11039,7 @@ export interface components {
          * @example nyc3
          * @enum {string}
          */
-        region_slug: "ams1" | "ams2" | "ams3" | "blr1" | "fra1" | "lon1" | "nyc1" | "nyc2" | "nyc3" | "sfo1" | "sfo2" | "sfo3" | "sgp1" | "tor1";
+        region_slug: "ams1" | "ams2" | "ams3" | "blr1" | "fra1" | "lon1" | "nyc1" | "nyc2" | "nyc3" | "sfo1" | "sfo2" | "sfo3" | "sgp1" | "tor1" | "syd1";
         /**
          * @description This attribute is an array of the regions that the image is available in. The regions are represented by their identifying slug values.
          * @example [
@@ -10845,6 +11119,31 @@ export interface components {
              */
             error_message?: string;
         };
+        /** @description An object containing information about the GPU capabilities of Droplets created with this size. */
+        gpu_info: {
+            /**
+             * @description The number of GPUs allocated to the Droplet.
+             * @example 1
+             */
+            count?: number;
+            /**
+             * @description The model of the GPU.
+             * @example nvidia_h100
+             */
+            model?: string;
+            vram?: {
+                /**
+                 * @description The amount of VRAM allocated to the GPU.
+                 * @example 25
+                 */
+                amount?: number;
+                /**
+                 * @description The unit of measure for the VRAM.
+                 * @example gib
+                 */
+                unit?: string;
+            };
+        };
         size: {
             /**
              * @description A human-readable string that is used to uniquely identify each size.
@@ -10857,7 +11156,7 @@ export interface components {
              */
             memory: number;
             /**
-             * @description The integer of number CPUs allocated to Droplets of this size.
+             * @description The number of CPUs allocated to Droplets of this size.
              * @example 1
              */
             vcpus: number;
@@ -10914,6 +11213,9 @@ export interface components {
              * @example Basic
              */
             description: string;
+            /** @description An array of objects containing information about the disks available to Droplets created with this size. */
+            disk_info?: components["schemas"]["disk_info"][];
+            gpu_info?: components["schemas"]["gpu_info"];
         };
         network_v4: {
             /**
@@ -10998,6 +11300,8 @@ export interface components {
              * @example 25
              */
             disk: number;
+            /** @description An array of objects containing information about the disks available to the Droplet. */
+            disk_info?: components["schemas"]["disk_info"][];
             /**
              * @description A boolean value indicating whether the Droplet has been locked, preventing actions by users.
              * @example false
@@ -11073,6 +11377,7 @@ export interface components {
              * @example 760e09ef-dc84-11e8-981e-3cfdfeaae000
              */
             vpc_uuid?: string;
+            gpu_info?: components["schemas"]["gpu_info"];
         };
         droplet_backup_policy: {
             /**
@@ -12056,15 +12361,16 @@ export interface components {
             version: string;
             /**
              * Format: cidr
-             * @description The range of IP addresses in the overlay network of the Kubernetes cluster in CIDR notation.
-             * @example 10.244.0.0/16
+             * @description The range of IP addresses for the overlay network of the Kubernetes cluster in CIDR notation.
+             * @example 192.168.0.0/20
              */
-            readonly cluster_subnet?: string;
+            cluster_subnet?: string;
             /**
+             * Format: cidr
              * @description The range of assignable IP addresses for services running in the Kubernetes cluster in CIDR notation.
-             * @example 10.245.0.0/16
+             * @example 192.168.16.0/24
              */
-            readonly service_subnet?: string;
+            service_subnet?: string;
             /**
              * Format: uuid
              * @description A string specifying the UUID of the VPC to which the Kubernetes cluster is assigned.
@@ -12273,7 +12579,7 @@ export interface components {
              *
              *     Newly created Kubernetes clusters do not return credentials using
              *     certificate-based authentication. For additional information,
-             *     [see here](https://www.digitalocean.com/docs/kubernetes/how-to/connect-to-cluster/#authenticate).
+             *     [see here](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/#authenticate).
              *
              * @example null
              */
@@ -12287,7 +12593,7 @@ export interface components {
              *
              *     Newly created Kubernetes clusters do not return credentials using
              *     certificate-based authentication. For additional information,
-             *     [see here](https://www.digitalocean.com/docs/kubernetes/how-to/connect-to-cluster/#authenticate).
+             *     [see here](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/#authenticate).
              *
              * @example null
              */
@@ -12698,6 +13004,13 @@ export interface components {
              */
             disable_lets_encrypt_dns_records: boolean;
             firewall?: components["schemas"]["lb_firewall"];
+            /**
+             * @description A string indicating whether the load balancer should be external or internal. Internal load balancers have no public IPs and are only accessible to resources on the same VPC network. This property cannot be updated after creating the load balancer.
+             * @default EXTERNAL
+             * @example EXTERNAL
+             * @enum {string}
+             */
+            network: "EXTERNAL" | "INTERNAL";
         };
         load_balancer: components["schemas"]["load_balancer_base"] & {
             region?: unknown & components["schemas"]["region"];
@@ -12877,6 +13190,193 @@ export interface components {
              */
             status: "success" | "error";
         };
+        /** @description OpenSearch destination configuration with `credentials` omitted. */
+        opensearch_config_omit_credentials: {
+            /**
+             * @description A unique identifier for a configuration.
+             * @example 41078d41-165c-4cff-9f0a-19536e3e3d49
+             */
+            id?: string;
+            /**
+             * @description host of the OpenSearch cluster
+             * @example example.com
+             */
+            endpoint?: string;
+            /**
+             * @description A unique identifier for a managed OpenSearch cluster.
+             * @example 85148069-7e35-4999-80bd-6fa1637ca385
+             */
+            cluster_uuid?: string;
+            /**
+             * @description Name of a managed OpenSearch cluster.
+             * @example managed_dbaas_cluster
+             */
+            cluster_name?: string;
+            /**
+             * @description OpenSearch index to send logs to.
+             * @example logs
+             */
+            index_name?: string;
+            /**
+             * @description Number of days to retain logs in OpenSearch.
+             * @default 14
+             * @example 14
+             */
+            retention_days: number;
+        };
+        destination_omit_credentials: {
+            /**
+             * @description A unique identifier for a destination.
+             * @example 01f30bfa-319a-4769-ba95-9d43971fb514
+             */
+            id?: string;
+            /**
+             * @description destination name
+             * @example managed_opensearch_cluster
+             */
+            name?: string;
+            /**
+             * @description The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+             *     cluster or `opensearch_ext` for an externally managed one.
+             *
+             * @example opensearch_dbaas
+             * @enum {unknown}
+             */
+            type?: "opensearch_dbaas" | "opensearch_ext";
+            config?: components["schemas"]["opensearch_config_omit_credentials"];
+        };
+        opensearch_config_request: {
+            /** @description Credentials for an OpenSearch cluster user. Optional if `cluster_uuid` is passed. */
+            credentials?: {
+                /** @example username */
+                username?: string;
+                /** @example password */
+                password?: string;
+            };
+            /**
+             * @description host of the OpenSearch cluster
+             * @example example.com
+             */
+            endpoint: string;
+            /**
+             * @description A unique identifier for a managed OpenSearch cluster.
+             * @example 85148069-7e35-4999-80bd-6fa1637ca385
+             */
+            cluster_uuid?: string;
+            /**
+             * @description Name of a managed OpenSearch cluster.
+             * @example managed_dbaas_cluster
+             */
+            cluster_name?: string;
+            /**
+             * @description OpenSearch index to send logs to.
+             * @example logs
+             */
+            index_name?: string;
+            /**
+             * @description Number of days to retain logs in an OpenSearch cluster.
+             * @default 14
+             * @example 14
+             */
+            retention_days: number;
+        };
+        destination_request: {
+            /**
+             * @description destination name
+             * @example managed_opensearch_cluster
+             */
+            name?: string;
+            /**
+             * @description The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+             *     cluster or `opensearch_ext` for an externally managed one.
+             *
+             * @enum {unknown}
+             */
+            type: "opensearch_dbaas" | "opensearch_ext";
+            config: components["schemas"]["opensearch_config_request"];
+        };
+        /**
+         * @description The uniform resource name (URN) for the resource in the format do:resource_type:resource_id.
+         * @example do:droplet:13457723
+         */
+        urn: string;
+        opensearch_config: {
+            /**
+             * @description A unique identifier for a configuration.
+             * @example 41078d41-165c-4cff-9f0a-19536e3e3d49
+             */
+            id?: string;
+            /** @description Credentials for an OpenSearch cluster user. Optional if `cluster_uuid` is passed. */
+            credentials?: {
+                /** @example username */
+                username?: string;
+                /** @example password */
+                password?: string;
+            };
+            /**
+             * @description host of the OpenSearch cluster
+             * @example example.com
+             */
+            endpoint: string;
+            /**
+             * @description A unique identifier for a managed OpenSearch cluster.
+             * @example 85148069-7e35-4999-80bd-6fa1637ca385
+             */
+            cluster_uuid?: string;
+            /**
+             * @description Name of a managed OpenSearch cluster.
+             * @example managed_dbaas_cluster
+             */
+            cluster_name?: string;
+            /**
+             * @description OpenSearch index to send logs to.
+             * @example logs
+             */
+            index_name?: string;
+            /**
+             * @description Number of days to retain logs in OpenSearch (default: 14)
+             * @example 14
+             */
+            retention_days?: number;
+        };
+        destination: {
+            /**
+             * @description A unique identifier for a destination.
+             * @example 01f30bfa-319a-4769-ba95-9d43971fb514
+             */
+            id?: string;
+            /**
+             * @description destination name
+             * @example managed_opensearch_cluster
+             */
+            name?: string;
+            /**
+             * @description The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+             *     cluster or `opensearch_ext` for an externally managed one.
+             *
+             * @example opensearch_dbaas
+             * @enum {unknown}
+             */
+            type?: "opensearch_dbaas" | "opensearch_ext";
+            config: components["schemas"]["opensearch_config"];
+        };
+        sink_resource: {
+            /**
+             * @description The uniform resource name (URN) for the resource in the format do:resource_type:resource_id.
+             * @example do:kubernetes:f453aa14-646e-4cf8-8c62-75a19fb24ec2
+             */
+            urn: string;
+            /**
+             * @description resource name
+             * @example managed_kubernetes_cluster
+             */
+            name?: string;
+        };
+        sinks_response: {
+            destination?: components["schemas"]["destination"];
+            /** @description List of resources identified by their URNs. */
+            resources?: components["schemas"]["sink_resource"][];
+        };
         project_base: {
             /**
              * Format: uuid
@@ -12950,11 +13450,6 @@ export interface components {
              */
             is_default?: boolean;
         };
-        /**
-         * @description The uniform resource name (URN) for the resource in the format do:resource_type:resource_id.
-         * @example do:droplet:13457723
-         */
-        urn: string;
         resource: {
             urn?: components["schemas"]["urn"];
             /**
@@ -13730,6 +14225,44 @@ export interface components {
              */
             created_at?: string;
         };
+        vpc_peering_base: {
+            /**
+             * Format: uuid
+             * @description A unique ID that can be used to identify and reference the VPC peering.
+             * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+             */
+            readonly id?: string;
+            /**
+             * Format: date-time
+             * @description A time value given in ISO8601 combined date and time format.
+             * @example 2020-03-13T19:20:47.442049222Z
+             */
+            readonly created_at?: string;
+            /**
+             * @description The current status of the VPC peering.
+             * @example ACTIVE
+             * @enum {string}
+             */
+            readonly status?: "PROVISIONING" | "ACTIVE" | "DELETING";
+        };
+        vpc_peering_create: {
+            /**
+             * @description An array of the two peered VPCs IDs.
+             * @example [
+             *       "c140286f-e6ce-4131-8b7b-df4590ce8d6a",
+             *       "994a2735-dc84-11e8-80bc-3cfdfea9fba1"
+             *     ]
+             */
+            vpc_ids?: string[];
+        };
+        vpc_peering_updatable: {
+            /**
+             * @description The name of the VPC peering. Must be unique within the team and may only contain alphanumeric characters and dashes.
+             * @example nyc1-blr1-peering
+             */
+            name?: string;
+        };
+        vpc_peering: components["schemas"]["vpc_peering_base"] & components["schemas"]["vpc_peering_create"] & components["schemas"]["vpc_peering_updatable"];
         check_base: {
             /**
              * Format: uuid
@@ -15953,6 +16486,63 @@ export interface components {
                 "application/json": components["schemas"]["metrics"];
             };
         };
+        /** @description The response is a JSON object with a `destinations` key. */
+        monitoring_list_destinations: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    destinations?: components["schemas"]["destination_omit_credentials"][];
+                };
+            };
+        };
+        /** @description The response is a JSON object with a `destination` key. */
+        destination: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    destination?: components["schemas"]["destination_omit_credentials"];
+                };
+            };
+        };
+        /** @description The response is a JSON object with a `sinks` key. */
+        list_sinks: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    /** @description List of sinks identified by their URNs. */
+                    sinks?: components["schemas"]["sinks_response"][];
+                };
+            };
+        };
+        /** @description The response is a JSON object with a `sink` key. */
+        sinks: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    sink?: components["schemas"]["sinks_response"];
+                };
+            };
+        };
         /** @description The response will be a JSON object with a key called `projects`. The value of this will be an object with the standard project attributes */
         projects_list: {
             headers: {
@@ -16524,6 +17114,90 @@ export interface components {
                 } & components["schemas"]["pagination"] & components["schemas"]["meta"];
             };
         };
+        /** @description The response will be a JSON object with a key called `peerings`. This  will be set to an array of objects, each of which will contain the standard  attributes associated with a VPC peering. */
+        vpc_peerings: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    peerings?: components["schemas"]["vpc_peering"][];
+                } & components["schemas"]["pagination"] & components["schemas"]["meta"];
+            };
+        };
+        /** @description The response will be a JSON object with a key called `peering`, containing  the standard attributes associated with a VPC peering. */
+        vpc_peering: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    peering?: components["schemas"]["vpc_peering"];
+                };
+            };
+        };
+        /** @description The response will be a JSON object with a key called `vpc_peerings`. This  will be set to an array of objects, each of which will contain the standard  attributes associated with a VPC peering. */
+        all_vpc_peerings: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    vpc_peerings?: components["schemas"]["vpc_peering"][];
+                } & components["schemas"]["pagination"] & components["schemas"]["meta"];
+            };
+        };
+        /** @description The response will be a JSON object with a key called `vpc_peering`. The value of this will be an object that contains the standard attributes associated with a VPC peering. */
+        provisioning_vpc_peering: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    vpc_peering?: components["schemas"]["vpc_peering"];
+                };
+            };
+        };
+        /** @description The response will be a JSON object with a key called `vpc_peering`. The value of this will be an object that contains the standard attributes associated with a VPC peering. */
+        active_vpc_peering: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    vpc_peering?: components["schemas"]["vpc_peering"];
+                };
+            };
+        };
+        /** @description The response will be a JSON object with a key called `vpc_peering`. The value of this will be an object that contains the standard attributes associated with a VPC peering. */
+        deleting_vpc_peering: {
+            headers: {
+                "ratelimit-limit": components["headers"]["ratelimit-limit"];
+                "ratelimit-remaining": components["headers"]["ratelimit-remaining"];
+                "ratelimit-reset": components["headers"]["ratelimit-reset"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    vpc_peering?: components["schemas"]["vpc_peering"];
+                };
+            };
+        };
         /** @description The response will be a JSON object with a key called `checks`. This will be set to an array of objects, each of which will contain the standard attributes associated with an uptime check */
         all_checks: {
             headers: {
@@ -16781,7 +17455,7 @@ export interface components {
          */
         domain_record_id: number;
         /**
-         * @description Used to filter Droplets by a specific tag. Can not be combined with `name`.
+         * @description Used to filter Droplets by a specific tag. Can not be combined with `name` or `type`.
          * @example env:prod
          */
         droplet_tag_name: string;
@@ -16790,6 +17464,11 @@ export interface components {
          * @example web-01
          */
         droplet_name: string;
+        /**
+         * @description When `type` is set to `gpus`, only GPU Droplets will be returned. By default, only non-GPU Droplets are returned. Can not be combined with `tag_name`.
+         * @example droplets
+         */
+        droplet_type: "droplets" | "gpus";
         /**
          * @description Specifies Droplets to be deleted by tag.
          * @example env:test
@@ -16931,6 +17610,21 @@ export interface components {
          */
         parameters_load_balancer_id: string;
         /**
+         * @description A unique identifier for a destination.
+         * @example 1a64809f-1708-48ee-a742-dec8d481b8d1
+         */
+        destination_uuid: string;
+        /**
+         * @description A unique URN for a resource.
+         * @example do:kubernetes:5ba4518b-b9e2-4978-aa92-2d4c727e8824
+         */
+        resource_id: components["schemas"]["urn"];
+        /**
+         * @description A unique identifier for a sink.
+         * @example 78b172b6-52c3-4a4b-96d5-78d3f1a0b18c
+         */
+        sink_uuid: string;
+        /**
          * @description A unique identifier for a project.
          * @example 4de7ac8b-495b-4884-9a69-1050c6793cd6
          */
@@ -17030,6 +17724,11 @@ export interface components {
          * @example droplet
          */
         vpc_resource_type: string;
+        /**
+         * @description A unique identifier for a VPC peering.
+         * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+         */
+        vpc_peering_id: string;
         /**
          * @description A unique identifier for a check.
          * @example 4de7ac8b-495b-4884-9a69-1050c6793cd6
@@ -18409,7 +19108,18 @@ export interface operations {
     };
     invoices_get_byUUID: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description Number of items returned per page
+                 * @example 2
+                 */
+                per_page?: components["parameters"]["per_page"];
+                /**
+                 * @description Which 'page' of paginated results to return.
+                 * @example 1
+                 */
+                page?: components["parameters"]["page"];
+            };
             header?: never;
             path: {
                 /**
@@ -20456,7 +21166,7 @@ export interface operations {
                  */
                 page?: components["parameters"]["page"];
                 /**
-                 * @description Used to filter Droplets by a specific tag. Can not be combined with `name`.
+                 * @description Used to filter Droplets by a specific tag. Can not be combined with `name` or `type`.
                  * @example env:prod
                  */
                 tag_name?: components["parameters"]["droplet_tag_name"];
@@ -20465,6 +21175,11 @@ export interface operations {
                  * @example web-01
                  */
                 name?: components["parameters"]["droplet_name"];
+                /**
+                 * @description When `type` is set to `gpus`, only GPU Droplets will be returned. By default, only non-GPU Droplets are returned. Can not be combined with `tag_name`.
+                 * @example droplets
+                 */
+                type?: components["parameters"]["droplet_type"];
             };
             header?: never;
             path?: never;
@@ -20773,7 +21488,7 @@ export interface operations {
         parameters: {
             query?: {
                 /**
-                 * @description Used to filter Droplets by a specific tag. Can not be combined with `name`.
+                 * @description Used to filter Droplets by a specific tag. Can not be combined with `name` or `type`.
                  * @example env:prod
                  */
                 tag_name?: components["parameters"]["droplet_tag_name"];
@@ -23099,7 +23814,7 @@ export interface operations {
          *     `v1/insights/lbaas/avg_cpu_utilization_percent`|alert on the percent of CPU utilization|load balancer ID
          *     `v1/insights/lbaas/connection_utilization_percent`|alert on the percent of connection utilization|load balancer ID
          *     `v1/insights/lbaas/droplet_health`|alert on Droplet health status changes|load balancer ID
-         *     `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization|load balancer ID
+         *     `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization (requires at least one HTTPS forwarding rule)|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_percentage_5xx`|alert on the percent increase of 5xx level http errors over 5m|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_percentage_4xx`|alert on the percent increase of 4xx level http errors over 5m|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_count_5xx`|alert on the count of 5xx level http errors over 5m|load balancer ID
@@ -23181,7 +23896,7 @@ export interface operations {
          *     `v1/insights/lbaas/avg_cpu_utilization_percent`|alert on the percent of CPU utilization|load balancer ID
          *     `v1/insights/lbaas/connection_utilization_percent`|alert on the percent of connection utilization|load balancer ID
          *     `v1/insights/lbaas/droplet_health`|alert on Droplet health status changes|load balancer ID
-         *     `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization|load balancer ID
+         *     `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization (requires at least one HTTPS forwarding rule)|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_percentage_5xx`|alert on the percent increase of 5xx level http errors over 5m|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_percentage_4xx`|alert on the percent increase of 4xx level http errors over 5m|load balancer ID
          *     `v1/insights/lbaas/increase_in_http_error_rate_count_5xx`|alert on the count of 5xx level http errors over 5m|load balancer ID
@@ -24564,6 +25279,215 @@ export interface operations {
         responses: {
             200: components["responses"]["metric_response"];
             401: components["responses"]["unauthorized"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_list_destinations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["monitoring_list_destinations"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_create_destination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["destination_request"];
+            };
+        };
+        responses: {
+            200: components["responses"]["destination"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_get_destination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a destination.
+                 * @example 1a64809f-1708-48ee-a742-dec8d481b8d1
+                 */
+                destination_uuid: components["parameters"]["destination_uuid"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["destination"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_update_destination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a destination.
+                 * @example 1a64809f-1708-48ee-a742-dec8d481b8d1
+                 */
+                destination_uuid: components["parameters"]["destination_uuid"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["destination_request"];
+            };
+        };
+        responses: {
+            204: components["responses"]["no_content"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_delete_destination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a destination.
+                 * @example 1a64809f-1708-48ee-a742-dec8d481b8d1
+                 */
+                destination_uuid: components["parameters"]["destination_uuid"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["no_content"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_list_sinks: {
+        parameters: {
+            query?: {
+                /**
+                 * @description A unique URN for a resource.
+                 * @example do:kubernetes:5ba4518b-b9e2-4978-aa92-2d4c727e8824
+                 */
+                resource_id?: components["parameters"]["resource_id"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["list_sinks"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_create_sink: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description A unique identifier for an already-existing destination.
+                     * @example 9df2b7e9-3fb2-4577-b60a-e9c0d53f9a99
+                     */
+                    destination_uuid?: string;
+                    /** @description List of resources identified by their URNs. */
+                    resources?: components["schemas"]["sink_resource"][];
+                };
+            };
+        };
+        responses: {
+            202: components["responses"]["accepted"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_get_sink: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a sink.
+                 * @example 78b172b6-52c3-4a4b-96d5-78d3f1a0b18c
+                 */
+                sink_uuid: components["parameters"]["sink_uuid"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["sinks"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    monitoring_delete_sink: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a sink.
+                 * @example 78b172b6-52c3-4a4b-96d5-78d3f1a0b18c
+                 */
+                sink_uuid: components["parameters"]["sink_uuid"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["no_content"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
             429: components["responses"]["too_many_requests"];
             500: components["responses"]["server_error"];
             default: components["responses"]["unexpected_error"];
@@ -26418,6 +27342,237 @@ export interface operations {
         requestBody?: never;
         responses: {
             200: components["responses"]["vpc_members"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcs_list_peerings: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Number of items returned per page
+                 * @example 2
+                 */
+                per_page?: components["parameters"]["per_page"];
+                /**
+                 * @description Which 'page' of paginated results to return.
+                 * @example 1
+                 */
+                page?: components["parameters"]["page"];
+            };
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC.
+                 * @example 4de7ac8b-495b-4884-9a69-1050c6793cd6
+                 */
+                vpc_id: components["parameters"]["vpc_id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["vpc_peerings"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcs_create_peerings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC.
+                 * @example 4de7ac8b-495b-4884-9a69-1050c6793cd6
+                 */
+                vpc_id: components["parameters"]["vpc_id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description The name of the VPC peering. Must be unique and may only contain alphanumeric characters, dashes, and periods.
+                     * @example nyc1-blr1-peering
+                     */
+                    name: string;
+                    /**
+                     * Format: uuid
+                     * @description The ID of the VPC to peer with.
+                     * @example c140286f-e6ce-4131-8b7b-df4590ce8d6a
+                     */
+                    vpc_id: string;
+                };
+            };
+        };
+        responses: {
+            202: components["responses"]["vpc_peering"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcs_patch_peerings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC.
+                 * @example 4de7ac8b-495b-4884-9a69-1050c6793cd6
+                 */
+                vpc_id: components["parameters"]["vpc_id"];
+                /**
+                 * @description A unique identifier for a VPC peering.
+                 * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+                 */
+                vpc_peering_id: components["parameters"]["vpc_peering_id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": WithRequired<components["schemas"]["vpc_peering_updatable"], "name">;
+            };
+        };
+        responses: {
+            200: components["responses"]["vpc_peering"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcPeerings_list: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Number of items returned per page
+                 * @example 2
+                 */
+                per_page?: components["parameters"]["per_page"];
+                /**
+                 * @description Which 'page' of paginated results to return.
+                 * @example 1
+                 */
+                page?: components["parameters"]["page"];
+                /**
+                 * @description The slug identifier for the region where the resource is available.
+                 * @example nyc3
+                 */
+                region?: components["parameters"]["region"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["all_vpc_peerings"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcPeerings_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": WithRequired<components["schemas"]["vpc_peering_updatable"], "name"> & WithRequired<components["schemas"]["vpc_peering_create"], "vpc_ids">;
+            };
+        };
+        responses: {
+            202: components["responses"]["provisioning_vpc_peering"];
+            401: components["responses"]["unauthorized"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcPeerings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC peering.
+                 * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+                 */
+                vpc_peering_id: components["parameters"]["vpc_peering_id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["active_vpc_peering"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcPeerings_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC peering.
+                 * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+                 */
+                vpc_peering_id: components["parameters"]["vpc_peering_id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            202: components["responses"]["deleting_vpc_peering"];
+            401: components["responses"]["unauthorized"];
+            404: components["responses"]["not_found"];
+            429: components["responses"]["too_many_requests"];
+            500: components["responses"]["server_error"];
+            default: components["responses"]["unexpected_error"];
+        };
+    };
+    vpcPeerings_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description A unique identifier for a VPC peering.
+                 * @example 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+                 */
+                vpc_peering_id: components["parameters"]["vpc_peering_id"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": WithRequired<components["schemas"]["vpc_peering_updatable"], "name">;
+            };
+        };
+        responses: {
+            200: components["responses"]["active_vpc_peering"];
             401: components["responses"]["unauthorized"];
             404: components["responses"]["not_found"];
             429: components["responses"]["too_many_requests"];

--- a/packages/openapi-typescript/examples/digital-ocean-api/DigitalOcean-public.v2.yaml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/DigitalOcean-public.v2.yaml
@@ -23,7 +23,7 @@ tags:
     description: |-
       1-Click applications are pre-built Droplet images or Kubernetes apps with software,
       features, and configuration details already set up for you. They can be found in the
-      [DigitalOcean Marketplace](https://www.digitalocean.com/docs/marketplace).
+      [DigitalOcean Marketplace](https://marketplace.digitalocean.com/).
 
   - name: Account
     description: Provides information about your current account.
@@ -66,7 +66,7 @@ tags:
       **Balance:** By sending requests to the `/v2/customers/my/balance` endpoint, you can
       retrieve the balance information for the requested customer account.
 
-      **Invoices:** [Invoices](https://www.digitalocean.com/docs/accounts/billing/invoices/)
+      **Invoices:** [Invoices](https://docs.digitalocean.com/platform/billing/invoices/)
       are generated on the first of each month for every DigitalOcean
       customer. An invoice preview is generated daily, which can be accessed
       with the `preview` keyword in place of `$INVOICE_UUID`. To interact with
@@ -81,7 +81,7 @@ tags:
 
   - name: Block Storage
     description: |-
-      [DigitalOcean Block Storage Volumes](https://www.digitalocean.com/docs/volumes/)
+      [DigitalOcean Block Storage Volumes](https://docs.digitalocean.com/products/volumes/)
       provide expanded storage capacity for your Droplets and can be moved
       between Droplets within a specific region.
 
@@ -106,18 +106,20 @@ tags:
   - name: CDN Endpoints
     description: |-
       Content hosted in DigitalOcean's object storage solution,
-      [Spaces](https://www.digitalocean.com/docs/spaces/overview/),
+      [Spaces](https://docs.digitalocean.com/products/spaces/),
       can optionally be served by our globally distributed Content Delivery
       Network (CDN). By sending requests to `/v2/cdn/endpoints`, you can list,
       create, or delete CDN Endpoints as well as purge cached content. To use a
       custom subdomain to access the CDN Endpoint, provide the ID of a
       DigitalOcean managed TLS certificate and the fully qualified domain name
-      for the custom subdomain.
+      for the custom subdomain. 
+
+      CDN endpoints have a rate limit of five requests per 10 seconds.
 
   - name: Certificates
     description: |-
       In order to perform SSL termination on load balancers, DigitalOcean offers
-      two types of [SSL certificate management](https://www.digitalocean.com/docs/accounts/security/#certificates):
+      two types of [SSL certificate management](https://docs.digitalocean.com/platform/teams/manage-certificates):
 
       * **Custom**: User-generated certificates may be uploaded to DigitalOcean
       where they will be placed in a fully encrypted and isolated storage system.
@@ -130,7 +132,7 @@ tags:
   - name: Container Registry
     description: |-
       DigitalOcean offers the ability for you to create a
-      [private container registry](https://www.digitalocean.com/docs/images/container-registry/quickstart/)
+      [private container registry](https://docs.digitalocean.com/products/container-registry/)
       to store your Docker images for use with your Kubernetes clusters. This
       container registry runs inside the same datacenters as your cluster,
       ensuring reliable and performant rollout of image deployments.
@@ -140,12 +142,12 @@ tags:
 
   - name: Databases
     description: |-
-      DigitalOcean's [managed database service](https://www.digitalocean.com/docs/databases)
+      DigitalOcean's [managed database service](https://docs.digitalocean.com/products/databases)
       simplifies the creation and management of highly available database clusters. Currently, it
-      offers support for [PostgreSQL](http://www.digitalocean.com/docs/databases/postgresql/),
-      [Redis](https://www.digitalocean.com/docs/databases/redis/),
-      [MySQL](https://www.digitalocean.com/docs/databases/mysql/), 
-      [MongoDB](https://www.digitalocean.com/docs/databases/mongodb/), and
+      offers support for [PostgreSQL](http://docs.digitalocean.com/products/databases/postgresql/),
+      [Redis](https://docs.digitalocean.com/products/databases/redis/),
+      [MySQL](https://docs.digitalocean.com/products/databases/mysql/), 
+      [MongoDB](https://docs.digitalocean.com/products/databases/mongodb/), and
       [OpenSearch](https://docs.digitalocean.com/products/databases/opensearch/).
 
       By sending requests to the `/v2/databases` endpoint, you can list, create, or delete
@@ -170,7 +172,7 @@ tags:
       and manage DNS zone files by adding and modifying individual records for a
       domain.
 
-      The [DigitalOcean DNS management interface](https://www.digitalocean.com/docs/networking/dns/)
+      The [DigitalOcean DNS management interface](https://docs.digitalocean.com/products/networking/dns/)
       allows you to configure the following DNS records:
 
       Name  | Description                                                                                                                                        |
@@ -189,7 +191,7 @@ tags:
     description: |-
       Domain resources are domain names that you have purchased from a domain
       name registrar that you are managing through the
-      [DigitalOcean DNS interface](https://www.digitalocean.com/docs/networking/dns/).
+      [DigitalOcean DNS interface](https://docs.digitalocean.com/products/networking/dns/).
 
       This resource establishes top-level control over each domain. Actions that
       affect individual domain records should be taken on the
@@ -217,7 +219,7 @@ tags:
 
   - name: Droplets
     description: |-
-      A [Droplet](https://www.digitalocean.com/docs/droplets/) is a DigitalOcean
+      A [Droplet](https://docs.digitalocean.com/products/droplets/) is a DigitalOcean
       virtual machine. By sending requests to the Droplet endpoint, you can
       list, create, or delete Droplets.
 
@@ -228,7 +230,7 @@ tags:
 
   - name: Firewalls
     description: |-
-      [DigitalOcean Cloud Firewalls](https://www.digitalocean.com/docs/networking/firewalls/)
+      [DigitalOcean Cloud Firewalls](https://docs.digitalocean.com/products/networking/firewalls/)
       provide the ability to restrict network access to and from a Droplet
       allowing you to define which ports will accept inbound or outbound
       connections. By sending requests to the `/v2/firewalls` endpoint, you can
@@ -271,7 +273,7 @@ tags:
       will contain the field `reserved_ips` in addition to the `floating_ips` field.
       Floating IPs retrieved using the Projects API will retain the original name.
 
-      [DigitalOcean Floating IPs](https://www.digitalocean.com/docs/networking/floating-ips/)
+      [DigitalOcean Floating IPs](https://docs.digitalocean.com/products/networking/reserved-ips/)
       are publicly-accessible static IP addresses that can be mapped to one of
       your Droplets. They can be used to create highly available setups or other
       configurations requiring movable addresses.
@@ -296,26 +298,26 @@ tags:
 
   - name: Images
     description: |-
-      A DigitalOcean [image](https://www.digitalocean.com/docs/images/) can be
+      A DigitalOcean [image](https://docs.digitalocean.com/products/images/) can be
       used to create a Droplet and may come in a number of flavors. Currently,
       there are five types of images: snapshots, backups, applications,
       distributions, and custom images.
 
-      * [Snapshots](https://www.digitalocean.com/docs/images/snapshots/) provide
+      * [Snapshots](https://docs.digitalocean.com/products/snapshots/) provide
       a full copy of an existing Droplet instance taken on demand.
 
-      * [Backups](https://www.digitalocean.com/docs/images/backups/) are similar
+      * [Backups](https://docs.digitalocean.com/products/backups/) are similar
       to snapshots but are created automatically at regular intervals when
       enabled for a Droplet.
 
-      * [Custom images](https://www.digitalocean.com/docs/images/custom-images/)
+      * [Custom images](https://docs.digitalocean.com/products/custom-images/)
       are Linux-based virtual machine images (raw, qcow2, vhdx, vdi, and vmdk
       formats are supported) that you may upload for use on DigitalOcean.
 
       * Distributions are the public Linux distributions that are available to
       be used as a base to create Droplets.
 
-      * Applications, or [1-Click Apps](https://www.digitalocean.com/docs/one-clicks/),
+      * Applications, or [1-Click Apps](https://docs.digitalocean.com/products/marketplace/),
       are distributions pre-configured with additional software.
 
       To interact with images, you will generally send requests to the images
@@ -323,7 +325,7 @@ tags:
 
   - name: Kubernetes
     description: |-
-      [DigitalOcean Kubernetes](https://www.digitalocean.com/docs/kubernetes/)
+      [DigitalOcean Kubernetes](https://docs.digitalocean.com/products/kubernetes/)
       allows you to quickly deploy scalable and secure Kubernetes clusters. By
       sending requests to the `/v2/kubernetes/clusters` endpoint, you can list,
       create, or delete clusters as well as scale node pools up and down,
@@ -332,7 +334,7 @@ tags:
 
   - name: Load Balancers
     description: |-
-      [DigitalOcean Load Balancers](https://www.digitalocean.com/docs/networking/load-balancers/)
+      [DigitalOcean Load Balancers](https://docs.digitalocean.com/products/networking/load-balancers/)
       provide a way to distribute traffic across multiple Droplets. By sending
       requests to the `/v2/load_balancers` endpoint, you can list, create, or
       delete load balancers as well as add or remove Droplets, forwarding rules,
@@ -449,7 +451,7 @@ tags:
 
   - name: Snapshots
     description: |-
-      [Snapshots](https://www.digitalocean.com/docs/images/snapshots/) are saved
+      [Snapshots](https://docs.digitalocean.com/products/snapshots/) are saved
       instances of a Droplet or a block storage volume, which is reflected in
       the `resource_type` attribute. In order to avoid problems with compressing
       filesystems, each defines a `min_disk_size` attribute which is the minimum
@@ -478,9 +480,16 @@ tags:
 
         To interact with Uptime, you will generally send requests to the Uptime endpoint at `/v2/uptime/`.
 
+  - name: VPC Peerings
+    description: |-
+      [VPC Peerings](https://docs.digitalocean.com/products/networking/vpc/how-to/create-peering/) 
+      join two VPC networks with a secure, private connection. This allows 
+      resources in those networks to connect to each other's private IP addresses 
+      as if they were in the same network.
+
   - name: VPCs
     description: |-
-      [VPCs (virtual private clouds)](https://www.digitalocean.com/docs/networking/vpc/)
+      [VPCs (virtual private clouds)](https://docs.digitalocean.com/products/networking/vpc/)
       allow you to create virtual networks containing resources that can
       communicate with each other in full isolation using private IP addresses.
 
@@ -1393,6 +1402,32 @@ paths:
     get:
       $ref: 'resources/monitoring/monitoring_get_lb_droplets_downtime.yml'
 
+  /v2/monitoring/sinks/destinations:
+    post:
+      $ref: 'resources/monitoring/monitoring_create_destination.yml'
+    get:
+      $ref: 'resources/monitoring/monitoring_list_destinations.yml'
+
+  /v2/monitoring/sinks/destinations/{destination_uuid}:
+    get:
+      $ref: 'resources/monitoring/monitoring_get_destination.yml'
+    post:
+      $ref: 'resources/monitoring/monitoring_update_destination.yml'
+    delete:
+      $ref: 'resources/monitoring/monitoring_delete_destination.yml'
+
+  /v2/monitoring/sinks:
+    post:
+      $ref: 'resources/monitoring/monitoring_create_sink.yml'
+    get:
+      $ref: 'resources/monitoring/monitoring_list_sinks.yml'
+
+  /v2/monitoring/sinks/{sink_uuid}:
+    get:
+      $ref: 'resources/monitoring/monitoring_get_sink.yml'
+    delete:
+      $ref: 'resources/monitoring/monitoring_delete_sink.yml'
+
   /v2/projects:
     get:
       $ref: 'resources/projects/projects_list.yml'
@@ -1635,6 +1670,33 @@ paths:
     get:
       $ref: 'resources/vpcs/vpcs_list_members.yml'
 
+  /v2/vpcs/{vpc_id}/peerings:
+    get:
+      $ref: 'resources/vpcs/vpcs_list_peerings.yml'
+
+    post:
+      $ref: 'resources/vpcs/vpcs_create_peerings.yml'
+
+  /v2/vpcs/{vpc_id}/peerings/{vpc_peering_id}:
+    patch:
+      $ref: 'resources/vpcs/vpcs_update_peerings.yml'
+
+  /v2/vpc_peerings:
+    get:
+      $ref: 'resources/vpc_peerings/vpc_peerings_list.yml'
+
+    post:
+      $ref: 'resources/vpc_peerings/vpc_peerings_create.yml'
+
+  /v2/vpc_peerings/{vpc_peering_id}:
+    get:
+      $ref: 'resources/vpc_peerings/vpc_peerings_get.yml'
+
+    patch:
+      $ref: 'resources/vpc_peerings/vpc_peerings_update.yml'
+
+    delete:
+      $ref: 'resources/vpc_peerings/vpc_peerings_delete.yml'
 
   /v2/uptime/checks:
     get:

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/actions/models/action.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/actions/models/action.yml
@@ -49,7 +49,8 @@ properties:
       $ref: '../../regions/models/region.yml'
 
   region_slug:
-    allOf:
-      - $ref: '../../regions/models/region.yml#/properties/slug'
-      - type: string
-        nullable: true
+    type: string
+    nullable: true
+    description: A human-readable string that is used as a unique identifier
+      for each region.
+    example: nyc3

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_component_base.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_component_base.yml
@@ -55,7 +55,7 @@ properties:
   environment_slug:
     type: string
     description: An environment slug describing the type of this app. For a full list,
-      please refer to [the product documentation](https://www.digitalocean.com/docs/app-platform/).
+      please refer to [the product documentation](https://docs.digitalocean.com/products/app-platform/).
     example: node-js
 
   log_destinations:

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_component_instance_base.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_component_instance_base.yml
@@ -5,31 +5,52 @@ properties:
     type: integer
     format: int64
     minimum: 1
-    description: 'The amount of instances that this component should be scaled to. Default: 1. Must not be set if autoscaling is used.'
+    description: "The amount of instances that this component should be scaled to. Default: 1. Must not be set if autoscaling is used."
     default: 1
     example: 2
 
   instance_size_slug:
-    description: 'The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`'
-    type: string
-    enum:
-    - apps-s-1vcpu-0.5gb
-    - apps-s-1vcpu-1gb-fixed
-    - apps-s-1vcpu-1gb
-    - apps-s-1vcpu-2gb
-    - apps-s-2vcpu-4gb
-    - apps-d-1vcpu-0.5gb
-    - apps-d-1vcpu-1gb
-    - apps-d-1vcpu-2gb
-    - apps-d-1vcpu-4gb
-    - apps-d-2vcpu-4gb
-    - apps-d-2vcpu-8gb
-    - apps-d-4vcpu-8gb
-    - apps-d-4vcpu-16gb
-    - apps-d-8vcpu-32gb
-    default: apps-s-1vcpu-0.5gb
+    description: "The instance size to use for this component. Default: `apps-s-1vcpu-0.5gb`"
+    oneOf:
+      - title: "Size slug"
+        type: string
+        enum:
+          - apps-s-1vcpu-0.5gb
+          - apps-s-1vcpu-1gb-fixed
+          - apps-s-1vcpu-1gb
+          - apps-s-1vcpu-2gb
+          - apps-s-2vcpu-4gb
+          - apps-d-1vcpu-0.5gb
+          - apps-d-1vcpu-1gb
+          - apps-d-1vcpu-2gb
+          - apps-d-1vcpu-4gb
+          - apps-d-2vcpu-4gb
+          - apps-d-2vcpu-8gb
+          - apps-d-4vcpu-8gb
+          - apps-d-4vcpu-16gb
+          - apps-d-8vcpu-32gb
+        default: apps-s-1vcpu-0.5gb
+        example: apps-s-1vcpu-0.5gb
+      - title: "Deprecated"
+        description: | 
+          Deprecated size slugs for legacy plans. We strongly encourage customers
+          to use the new plans when creating or upgrading apps.
+        type: string
+        enum:
+          - basic-xxs
+          - basic-xs
+          - basic-s
+          - basic-m
+          - professional-xs
+          - professional-s
+          - professional-m
+          - professional-1l
+          - professional-l
+          - professional-xl
+        example: basic-xxs
+        deprecated: true
     example: apps-s-1vcpu-0.5gb
-  
+
   autoscaling:
     description: Configuration for automatically scaling this component based on metrics.
     type: object

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_maintenance_spec.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_maintenance_spec.yml
@@ -1,0 +1,11 @@
+type: object
+description: Specification to configure maintenance settings for the app, such as maintenance mode and archiving the app.
+properties:
+  enabled:
+    type: boolean
+    description: Indicates whether maintenance mode should be enabled for the app.
+    example: true
+  archive:
+    type: boolean
+    description: Indicates whether the app should be archived. Setting this to true implies that enabled is set to true. Note that this feature is currently in closed beta.
+    example: true

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_service_spec.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_service_spec.yml
@@ -13,6 +13,18 @@ allOf:
     health_check:
       $ref: app_service_spec_health_check.yml
 
+    protocol:
+      type: string
+      description: |
+        The protocol which the service uses to serve traffic on the http_port.
+
+        - `HTTP`: The app is serving the HTTP protocol. Default.
+        - `HTTP2`: The app is serving the HTTP/2 protocol. Currently, this needs to be implemented in the service by serving HTTP/2 cleartext (h2c).
+      enum:
+      - HTTP
+      - HTTP2
+      example: HTTP
+
     http_port:
       type: integer
       description: |-

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_spec.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/apps/models/app_spec.yml
@@ -77,5 +77,8 @@ properties:
   egress:
     $ref: app_egress_spec.yml
 
+  maintenance:
+    $ref: app_maintenance_spec.yml
+
 required:
 - name

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/billing/invoices_get_byUUID.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/billing/invoices_get_byUUID.yml
@@ -11,6 +11,8 @@ tags:
 
 parameters:
   - $ref: 'parameters.yml#/invoice_uuid'
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
 
 responses:
   '200':

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/cdn/cdn_purge_cache.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/cdn/cdn_purge_cache.yml
@@ -7,9 +7,11 @@ description: |
   `/v2/cdn/endpoints/$ENDPOINT_ID/cache`. The body of the request should include
   a `files` attribute containing a list of cached file paths to be purged. A
   path may be for a single file or may contain a wildcard (`*`) to recursively
-  purge all files under a directory. When only a wildcard is provided, all
-  cached files will be purged. There is a rate limit of 50 files per 20 seconds 
-  that can be purged.
+  purge all files under a directory. When only a wildcard is provided, all cached 
+  files will be purged. There is a rate limit of 50 files per 20 seconds that can 
+  be purged. CDN endpoints have a rate limit of 5 requests per 10 seconds. 
+  Purging files using a wildcard path counts as a single request against the API's 
+  rate limit. Two identical purge requests cannot be sent at the same time.
 
 tags:
   - CDN Endpoints

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/certificates/certificates_get.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/certificates/certificates_get.yml
@@ -39,5 +39,5 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'cdn:read'
+    - 'certificate:read'
 

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/certificates/certificates_list.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/certificates/certificates_list.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'cdn:read'
+    - 'certificate:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/databases_add_connectionPool.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/databases_add_connectionPool.yml
@@ -5,7 +5,7 @@ summary: Add a New Connection Pool (PostgreSQL)
 description: |
   For PostgreSQL database clusters, connection pools can be used to allow a
   database to share its idle connections. The popular PostgreSQL connection
-  pooling utility PgBouncer is used to provide this service. [See here for more information](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools/)
+  pooling utility PgBouncer is used to provide this service. [See here for more information](https://docs.digitalocean.com/products/databases/postgresql/how-to/manage-connection-pools/)
   about how and why to use PgBouncer connection pooling including
   details about the available transaction modes.
 

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/databases_update_firewall_rules.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/databases_update_firewall_rules.yml
@@ -11,7 +11,7 @@ description: >-
   provided, any Droplet or Kubernetes node with that tag applied to it will
   have access. The firewall is limited to 100 rules (or trusted sources). When
   possible, we recommend
-  [placing your databases into a VPC network](https://www.digitalocean.com/docs/networking/vpc/)
+  [placing your databases into a VPC network](https://docs.digitalocean.com/products/networking/vpc/)
   to limit access to them instead of using a firewall.
 
   A successful

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/opensearch_advanced_config.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/opensearch_advanced_config.yml
@@ -205,7 +205,7 @@ properties:
     type: integer
     example: 2500000
     minimum: 1
-    maximum: 9223372036854776000
+    maximum: 9223372036854775807
     default: 2500000
   ism_history_rollover_check_period_hours:
     description: >-
@@ -269,7 +269,7 @@ properties:
     default: use-context
   cluster_routing_allocation_node_concurrent_recoveries:
     description: >-
-      Maximum concurrent incoming/outgoing shard recoveries (normally replicas) are allowed to happen per node . 
+      Maximum concurrent incoming/outgoing shard recoveries (normally replicas) are allowed to happen per node .
     type: integer
     example: 2
     minimum: 2
@@ -279,6 +279,12 @@ properties:
     description: >-
       Allowlist of remote IP addresses for reindexing. Changing this value will cause all OpenSearch instances to restart.
     type: array
-    items: 
+    items:
       type: string
     example: ["255.255.223.233:9200", "222.33.222.222:6300"]
+  plugins_alerting_filter_by_backend_roles_enabled:
+    description: >-
+      Enable or disable filtering of alerting by backend roles.
+    type: boolean
+    example: false
+    default: false

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/postgres_advanced_config.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/postgres_advanced_config.yml
@@ -407,3 +407,10 @@ properties:
       Enable the pg_stat_monitor extension. <b>Enabling this extension will cause the cluster to be restarted.</b> When this extension is enabled, pg_stat_statements results for utility commands are unreliable.
     type: boolean
     example: false
+  max_failover_replication_time_lag:
+    description: >-
+      Number of seconds of master unavailability before triggering database failover to standby. The default value is 60.
+    type: integer
+    minimum: 10
+    maximum: 9223372036854776000
+    example: 50

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/redis_advanced_config.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/databases/models/advanced_config/redis_advanced_config.yml
@@ -2,7 +2,7 @@ type: object
 
 properties:
   redis_maxmemory_policy:
-    $ref: '../eviction_policy_model.yml'
+    $ref: "../eviction_policy_model.yml"
   redis_pubsub_client_output_buffer_limit:
     description: >-
       Set output buffer limit for pub / sub clients in MB. The value is the hard
@@ -43,7 +43,10 @@ properties:
     default: 1
     example: 1
   redis_ssl:
-    description: Require SSL to access Redis
+    description: |
+      Require SSL to access Redis.
+      - When enabled, Redis accepts only SSL connections on port `25061`.
+      - When disabled, port `25060` is opened for non-SSL connections, while port `25061` remains available for SSL connections.
     type: boolean
     default: true
     example: true
@@ -74,13 +77,13 @@ properties:
       - `A` &mdash; Alias for `"g$lshztxed"`
     type: string
     pattern: ^[KEg\$lshzxeA]*$
-    default: ''
+    default: ""
     maxLength: 32
     example: K
   redis_persistence:
     type: string
     enum:
-      - 'off'
+      - "off"
       - rdb
     description: >-
       When persistence is 'rdb', Redis does RDB dumps each 10 minutes if any key

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_get_destroyAssociatedResourcesStatus.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_get_destroyAssociatedResourcesStatus.yml
@@ -38,4 +38,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+    - 'droplet:delete'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_list.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_list.yml
@@ -16,6 +16,11 @@ description: |
   parameter set to the name of the tag in your GET request. For example,
   `/v2/droplets?tag_name=$TAG_NAME`.
 
+  ### GPU Droplets
+
+  By default, only non-GPU Droplets are returned. To list only GPU Droplets, set
+  the `type` query parameter to `gpus`. For example, `/v2/droplets?type=gpus`.
+
 tags:
   - Droplets
 
@@ -24,6 +29,7 @@ parameters:
   - $ref: '../../shared/parameters.yml#/page'
   - $ref: 'parameters.yml#/droplet_tag_name'
   - $ref: 'parameters.yml#/droplet_name'
+  - $ref: 'parameters.yml#/droplet_type'
 
 responses:
   '200':

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_list_associatedResources.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/droplets_list_associatedResources.yml
@@ -42,4 +42,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'droplet:read'
+    - 'droplet:delete'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet.yml
@@ -28,6 +28,13 @@ properties:
     example: 25
     description: The size of the Droplet's disk in gigabytes.
 
+  disk_info:
+    type: array
+    description: An array of objects containing information about the disks
+      available to the Droplet.
+    items:
+      $ref: '../../sizes/models/disk_info.yml'
+
   locked:
     type: boolean
     example: false
@@ -146,6 +153,9 @@ properties:
     example: '760e09ef-dc84-11e8-981e-3cfdfeaae000'
     description: A string specifying the UUID of the VPC to which the Droplet
       is assigned.
+
+  gpu_info:
+    $ref: '../../sizes/models/gpu_info.yml'
 
 required:
   - id

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet_actions.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet_actions.yml
@@ -34,7 +34,7 @@ droplet_action_enable_backups:
         allOf:
         - $ref: 'droplet_backup_policy.yml'
         - description: An object specifying the backup policy for the Droplet. If
-            omitted, the default backup policy will be used.
+            omitted, the backup plan will default to daily.
 
   example:
     type: enable_backups

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet_create.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/droplet_create.yml
@@ -49,7 +49,7 @@ properties:
     allOf:
       - $ref: 'droplet_backup_policy.yml'
       - description: An object specifying the backup policy for the Droplet. If
-          omitted and `backups` is `true`, the default backup policy will be used.
+          omitted and `backups` is `true`, the backup plan will default to daily.
 
   ipv6:
     type: boolean

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/kernel.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/models/kernel.yml
@@ -4,7 +4,7 @@ description: |
   **Note**: All Droplets created after March 2017 use internal kernels by default.
   These Droplets will have this attribute set to `null`.
 
-  The current [kernel](https://www.digitalocean.com/docs/droplets/how-to/kernel/)
+  The current [kernel](https://docs.digitalocean.com/products/droplets/how-to/kernel/)
   for Droplets with externally managed kernels. This will initially be set to
   the kernel of the base image when the Droplet is created.
 

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/parameters.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/parameters.yml
@@ -12,11 +12,25 @@ droplet_tag_name:
   in: query
   name: tag_name
   description: Used to filter Droplets by a specific tag. Can not be combined
-    with `name`.
+    with `name` or `type`.
   required: false
   schema:
     type: string
   example: env:prod
+
+droplet_type:
+  in: query
+  name: type
+  description: When `type` is set to `gpus`, only GPU Droplets will be returned.
+    By default, only non-GPU Droplets are returned. Can not be combined with
+    `tag_name`.
+  required: false
+  schema:
+    type: string
+    enum:
+    - droplets
+    - gpus
+  example: droplets
 
 droplet_delete_tag_name:
   in: query

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/responses/all_droplets.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/responses/all_droplets.yml
@@ -25,3 +25,5 @@ content:
         $ref: 'examples.yml#/droplets_all'
       Droplets Filtered By Tag:
         $ref: 'examples.yml#/droplets_tagged'
+      GPU Droplets:
+        $ref: 'examples.yml#/gpu_droplets'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/responses/examples.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/droplets/responses/examples.yml
@@ -6,6 +6,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -126,6 +131,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -239,6 +249,11 @@ droplets_all:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -360,6 +375,11 @@ droplets_tagged:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -480,6 +500,11 @@ droplets_tagged:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -594,6 +619,143 @@ droplets_tagged:
       total:
         2
 
+gpu_droplets:
+  value:
+    droplets:
+    - id: 448543583
+      name: ml-ai-ubuntu-gpu-h100x1-80gb-tor1
+      memory: 245760
+      vcpus: 20
+      disk: 720
+      disk_info:
+      - type: local
+        size:
+          amount: 720
+          unit: gib
+      - type: scratch
+        size:
+          amount: 5120
+          unit: gib
+      locked: false
+      status: active
+      kernel: null
+      created_at: 2024-09-30T15:23:36Z
+      features:
+        - droplet_agent
+        - private_networking
+      backup_ids: []
+      next_backup_window: null
+      snapshot_ids: []
+      image:
+        id: 166407044
+        name: AI/ML Ready H100x1
+        distribution: Ubuntu
+        slug: gpu-h100x1-base
+        public: true
+        regions:
+          - nyc3
+          - nyc1
+          - sfo1
+          - nyc2
+          - ams2
+          - sgp1
+          - lon1
+          - ams3
+          - fra1
+          - tor1
+          - sfo2
+          - blr1
+          - sfo3
+          - syd1
+        created_at: 2024-09-27T15:35:19Z
+        min_disk_size: 25
+        type: base
+        size_gigabytes: 18.47
+        description: GPU H100 1x Base Image
+        tags: []
+        status: available
+      volume_ids: []
+      size:
+        slug: gpu-h100x1-80gb
+        memory: 245760
+        vcpus: 20
+        disk: 720
+        transfer: 15
+        price_monthly: 4529.3
+        price_hourly: 6.74
+        regions:
+          - tor1
+        available: true
+        description: H100 GPU - 1X
+        gpu_info:
+          count: 1
+          vram:
+            amount: 80
+            unit: gib
+          model: nvidia_h100
+        disk_info:
+          - type: local
+            size:
+              amount: 720
+              unit: gib
+          - type: scratch
+            size:
+              amount: 5120
+              unit: gib
+      size_slug: gpu-h100x1-80gb
+      networks:
+        v4:
+        - ip_address: '10.128.192.124'
+          netmask: '255.255.0.0'
+          gateway: nil
+          type: private
+        - ip_address: '192.241.165.154'
+          netmask: '255.255.255.0'
+          gateway: '192.241.165.1'
+          type: public
+        v6: []
+      region:
+        name: Toronto 1
+        slug: tor1
+        features:
+          - backups
+          - ipv6
+          - metadata
+          - install_agent
+          - storage
+          - image_transfer
+          - server_id
+          - management_networking
+        available: true
+        sizes:
+        - s-1vcpu-1gb
+        - s-1vcpu-2gb
+        - s-1vcpu-3gb
+        - s-2vcpu-2gb
+        - s-3vcpu-1gb
+        - s-2vcpu-4gb
+        - s-4vcpu-8gb
+        - s-6vcpu-16gb
+        - s-8vcpu-32gb
+        - s-12vcpu-48gb
+        - s-16vcpu-64gb
+        - s-20vcpu-96gb
+        - s-24vcpu-128gb
+        - s-32vcpu-192g
+        - gpu-h100x1-80gb
+        - gpu-h100x8-640gb
+      tags: []
+      vpc_uuid: e2fdd15c-6ae6-4c11-8c5d-72dae2ba1ad1
+      gpu_info:
+        count: 1
+        vram:
+          amount: 80
+          unit: gib
+        model: nvidia_h100
+    links: {}
+    meta:
+      total: 1
+
 droplet_single:
   value:
     droplet:
@@ -602,6 +764,11 @@ droplet_single:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: active
       kernel: null
@@ -726,6 +893,11 @@ droplet_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null
@@ -839,6 +1011,11 @@ droplet_multi_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null
@@ -943,6 +1120,11 @@ droplet_multi_create_response:
       memory: 1024
       vcpus: 1
       disk: 25
+      disk_info:
+      - type: "local"
+        size:
+          amount: 25
+          unit: "gib"
       locked: false
       status: new
       kernel: null

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_add_rules.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_add_rules.yml
@@ -76,4 +76,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:create'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_add_tags.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_add_tags.yml
@@ -66,4 +66,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:create'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_assign_droplets.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_assign_droplets.yml
@@ -69,4 +69,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:create'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_droplets.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_droplets.yml
@@ -69,4 +69,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:delete'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_rules.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_rules.yml
@@ -76,4 +76,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:delete'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_tags.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/firewalls/firewalls_delete_tags.yml
@@ -66,4 +66,4 @@ x-codeSamples:
 
 security:
   - bearer_auth:
-    - 'firewall:delete'
+    - 'firewall:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_create_cluster.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_create_cluster.yml
@@ -10,7 +10,7 @@ description: |
   The request may contain a maintenance window policy describing a time period
   when disruptive maintenance tasks may be carried out. Omitting the policy
   implies that a window will be chosen automatically. See
-  [here](https://www.digitalocean.com/docs/kubernetes/how-to/upgrade-cluster/)
+  [here](https://docs.digitalocean.com/products/kubernetes/how-to/upgrade-cluster/)
   for details.
 
 tags:

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_get_credentials.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_get_credentials.yml
@@ -9,7 +9,7 @@ description: |
   The resulting JSON object contains token-based authentication for clusters
   supporting it, and certificate-based authentication otherwise. For a list of
   supported versions and more information, see "[How to Connect to a DigitalOcean
-  Kubernetes Cluster with kubectl](https://www.digitalocean.com/docs/kubernetes/how-to/connect-with-kubectl/)".
+  Kubernetes Cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/)".
 
   To retrieve credentials for accessing a Kubernetes cluster, send a GET
   request to `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/credentials`.

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_get_kubeconfig.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/kubernetes_get_kubeconfig.yml
@@ -10,7 +10,7 @@ description: |
   The resulting kubeconfig file uses token-based authentication for clusters
   supporting it, and certificate-based authentication otherwise. For a list of
   supported versions and more information, see "[How to Connect to a DigitalOcean
-  Kubernetes Cluster with kubectl](https://www.digitalocean.com/docs/kubernetes/how-to/connect-with-kubectl/)".
+  Kubernetes Cluster](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/)".
 
   To retrieve a kubeconfig file for use with a Kubernetes cluster, send a GET
   request to `/v2/kubernetes/clusters/$K8S_CLUSTER_ID/kubeconfig`.

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/models/cluster.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/models/cluster.yml
@@ -32,15 +32,14 @@ properties:
   cluster_subnet:
     type: string
     format: cidr
-    readOnly: true
-    example: 10.244.0.0/16
-    description: The range of IP addresses in the overlay network of the
+    example: 192.168.0.0/20
+    description: The range of IP addresses for the overlay network of the
       Kubernetes cluster in CIDR notation.
 
   service_subnet:
     type: string
-    readOnly: true
-    example: 10.245.0.0/16
+    format: cidr
+    example: 192.168.16.0/24
     description: The range of assignable IP addresses for services running in
       the Kubernetes cluster in CIDR notation.
 

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/models/credentials.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/kubernetes/models/credentials.yml
@@ -27,7 +27,7 @@ properties:
 
       Newly created Kubernetes clusters do not return credentials using
       certificate-based authentication. For additional information,
-      [see here](https://www.digitalocean.com/docs/kubernetes/how-to/connect-to-cluster/#authenticate).
+      [see here](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/#authenticate).
 
   client_key_data:
     type: string
@@ -42,7 +42,7 @@ properties:
 
       Newly created Kubernetes clusters do not return credentials using
       certificate-based authentication. For additional information,
-      [see here](https://www.digitalocean.com/docs/kubernetes/how-to/connect-to-cluster/#authenticate).
+      [see here](https://docs.digitalocean.com/products/kubernetes/how-to/connect-to-cluster/#authenticate).
 
   token:
     type: string

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/load_balancers/models/load_balancer_base.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/load_balancers/models/load_balancer_base.yml
@@ -157,5 +157,17 @@ properties:
   firewall:
     $ref: 'lb_firewall.yml'
 
+  network:
+    type: string
+    example: EXTERNAL
+    enum:
+      - EXTERNAL
+      - INTERNAL
+    default: EXTERNAL
+    description: A string indicating whether the load balancer should be external 
+      or internal. Internal load balancers have no public IPs and are only accessible 
+      to resources on the same VPC network. This property cannot be updated after
+      creating the load balancer.
+
 required:
   - forwarding_rules

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_create_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_create_destination.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/destinations" \
+    --data '{"name":"cluster", "type":"opensearch_dbaas", "config": {"endpoint": "example.com", "credentials": {"username": "username", "password": "password"}}}'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_create_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_create_sink.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks" \
+    --data '{"destination_uuid": "f2fcd5d9-f410-4f3a-8015-130ada94b1fe",  "resources": [{"name": "fra_kubernetes_cluster", "urn":"do:kubernetes:8463c9db-150c-4b44-830c-fca7f68d005b"}]}'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_delete_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_delete_destination.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/destinations/01f30bfa-319a-4769-ba95-9d43971fb514"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_delete_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_delete_sink.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/aef7ff4a-f1be-4d9e-b886-650fcb5bdfe3"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_get_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_get_destination.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/destinations/01f30bfa-319a-4769-ba95-9d43971fb514"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_get_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_get_sink.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/f945d774-86e8-4dc8-8f60-cfc76dd3d098"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_list_destinations.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_list_destinations.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/destinations"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_list_sinks.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_list_sinks.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks?resource_id=do:kubernetes:f2fcd5d9-f410-4f3a-8015-130ada94b1fe"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_update_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/examples/curl/monitoring_update_destination.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PATCH \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/monitoring/sinks/destinations/01f30bfa-319a-4769-ba95-9d43971fb514" \
+    --data '{"index_name": "logs", "retention_days": 30}'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination.yml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - config
+properties:
+  id:
+    type: string
+    description: "A unique identifier for a destination."
+    example: "01f30bfa-319a-4769-ba95-9d43971fb514"
+  name:
+    type: string
+    description: "destination name"
+    example: "managed_opensearch_cluster"    
+  type:
+    enum:
+      - opensearch_dbaas
+      - opensearch_ext
+    description: |
+      The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+      cluster or `opensearch_ext` for an externally managed one.
+    example: "opensearch_dbaas"
+  config:
+    $ref: 'opensearch_config.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination_omit_credentials.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination_omit_credentials.yml
@@ -1,0 +1,20 @@
+type: object
+properties:
+  id:
+    type: string
+    description: "A unique identifier for a destination."
+    example: "01f30bfa-319a-4769-ba95-9d43971fb514"
+  name:
+    type: string
+    description: "destination name"
+    example: "managed_opensearch_cluster"    
+  type:
+    enum:
+      - opensearch_dbaas
+      - opensearch_ext
+    description: |
+      The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+      cluster or `opensearch_ext` for an externally managed one.
+    example: opensearch_dbaas
+  config:
+    $ref: 'opensearch_config_omit_credentials.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination_request.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/destination_request.yml
@@ -1,0 +1,18 @@
+type: object
+required:
+  - config
+  - type
+properties:
+  name:
+    type: string
+    description: "destination name"
+    example: "managed_opensearch_cluster"
+  type:
+    enum:
+      - opensearch_dbaas
+      - opensearch_ext
+    description: |
+      The destination type. `opensearch_dbaas` for a DigitalOcean managed OpenSearch
+      cluster or `opensearch_ext` for an externally managed one.
+  config:
+    $ref: 'opensearch_config_request.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config.yml
@@ -1,0 +1,38 @@
+type: object
+required:
+  - endpoint
+properties:
+  id:
+    type: string
+    description: "A unique identifier for a configuration."
+    example: "41078d41-165c-4cff-9f0a-19536e3e3d49"
+  credentials:
+    type: object
+    description: "Credentials for an OpenSearch cluster user. Optional if `cluster_uuid` is passed."
+    properties:
+      username:
+        type: string
+        example: "username"
+      password:
+        type: string
+        example: "password"
+  endpoint:
+    type: string
+    example: "example.com"
+    description: "host of the OpenSearch cluster"
+  cluster_uuid:
+    type: string
+    example: "85148069-7e35-4999-80bd-6fa1637ca385"
+    description: "A unique identifier for a managed OpenSearch cluster."
+  cluster_name:
+    type: string
+    example: "managed_dbaas_cluster"
+    description: "Name of a managed OpenSearch cluster."
+  index_name:
+    type: string
+    description: "OpenSearch index to send logs to."
+    example: "logs"
+  retention_days:
+    type: integer
+    description: "Number of days to retain logs in OpenSearch (default: 14)"
+    example: 14

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config_omit_credentials.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config_omit_credentials.yml
@@ -1,0 +1,28 @@
+type: object  
+description: "OpenSearch destination configuration with `credentials` omitted."
+properties:
+  id:
+    type: string
+    description: "A unique identifier for a configuration."
+    example: "41078d41-165c-4cff-9f0a-19536e3e3d49"
+  endpoint:
+    type: string
+    example: "example.com"
+    description: "host of the OpenSearch cluster"
+  cluster_uuid:
+    type: string
+    example: "85148069-7e35-4999-80bd-6fa1637ca385"
+    description: "A unique identifier for a managed OpenSearch cluster."
+  cluster_name:
+    type: string
+    example: "managed_dbaas_cluster"
+    description: "Name of a managed OpenSearch cluster."
+  index_name:
+    type: string
+    description: "OpenSearch index to send logs to."
+    example: "logs"
+  retention_days:
+    type: integer
+    description: "Number of days to retain logs in OpenSearch."
+    example: 14
+    default: 14

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config_request.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/opensearch_config_request.yml
@@ -1,0 +1,37 @@
+type: object
+required:
+  - endpoint
+properties:
+  credentials:
+    type: object
+    description: "Credentials for an OpenSearch cluster user. Optional if `cluster_uuid` is passed."
+    properties:
+      username:
+        type: string
+        example: "username"
+      password:
+        type: string
+        example: "password"
+  endpoint:
+    type: string
+    example: "example.com"
+    description: "host of the OpenSearch cluster"
+  cluster_uuid:
+    type: string
+    example: "85148069-7e35-4999-80bd-6fa1637ca385"
+    description: "A unique identifier for a managed OpenSearch cluster."
+  cluster_name:
+    type: string
+    example: "managed_dbaas_cluster"
+    description: "Name of a managed OpenSearch cluster."
+  index_name:
+    type: string
+    description: "OpenSearch index to send logs to."
+    example: "logs"
+  retention_days:
+    type: integer
+    description: "Number of days to retain logs in an OpenSearch cluster."
+    example: 14
+    default: 14
+
+

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/sink_resource.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/sink_resource.yml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - urn
+properties:
+  urn:
+    type: string
+    pattern: ^do:kubernetes:.*
+    example: do:kubernetes:f453aa14-646e-4cf8-8c62-75a19fb24ec2
+    description: The uniform resource name (URN) for the resource in the format 
+      do:resource_type:resource_id.
+  name:
+    type: string
+    description: "resource name"
+    example: "managed_kubernetes_cluster"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/sinks_response.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/models/sinks_response.yml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - urn
+properties:
+  destination:
+    $ref: '../models/destination.yml'
+  resources:
+    type: array
+    description: "List of resources identified by their URNs."
+    items:
+      $ref: '../models/sink_resource.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_alertPolicy.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_alertPolicy.yml
@@ -44,7 +44,7 @@ requestBody:
     `v1/insights/lbaas/avg_cpu_utilization_percent`|alert on the percent of CPU utilization|load balancer ID
     `v1/insights/lbaas/connection_utilization_percent`|alert on the percent of connection utilization|load balancer ID
     `v1/insights/lbaas/droplet_health`|alert on Droplet health status changes|load balancer ID
-    `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization|load balancer ID
+    `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization (requires at least one HTTPS forwarding rule)|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_percentage_5xx`|alert on the percent increase of 5xx level http errors over 5m|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_percentage_4xx`|alert on the percent increase of 4xx level http errors over 5m|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_count_5xx`|alert on the count of 5xx level http errors over 5m|load balancer ID

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_destination.yml
@@ -1,0 +1,64 @@
+operationId: monitoring_create_destination
+
+summary: Create Logging Destination
+
+description: To create a new destination, send a POST request to `/v2/monitoring/sinks/destinations`.
+
+tags:
+  - Monitoring
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/destination_request.yml'
+
+      examples:
+        Managed OpenSearch Cluster:
+          value:
+            name: managed_opensearch_cluster
+            type: opensearch_dbaas
+            config:
+              endpoint: db-opensearch-nyc3-123456-do-user-123456-0.g.db.ondigitalocean.com
+              cluster_uuid: 85148069-7e35-4999-80bd-6fa1637ca385
+              cluster_name: managed_dbaas_cluster
+              index_name: logs
+              retention_days: 14
+        External OpenSearch Cluster:
+          value:
+            name: external_opensearch
+            type: opensearch_ext
+            config:
+              endpoint: example.com
+              credentials:
+                username: username
+                password: password
+              index_name: logs
+              retention_days: 14
+
+responses:
+  '200':
+    $ref: 'responses/destination.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_create_destination.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:create'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_create_sink.yml
@@ -1,0 +1,52 @@
+operationId: monitoring_create_sink
+
+summary: Create Sink
+
+description: |
+  To create a new sink, send a POST request to `/v2/monitoring/sinks`. Forwards logs from the 
+  resources identified in `resources` to the specified pre-existing destination.
+
+tags:
+  - Monitoring
+
+responses:
+  '202':
+    $ref: '../../shared/responses/accepted.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        properties:
+          destination_uuid:
+            type: string
+            example: "9df2b7e9-3fb2-4577-b60a-e9c0d53f9a99"
+            description: "A unique identifier for an already-existing destination."
+          resources:
+            type: array
+            description: "List of resources identified by their URNs."
+            items:
+              $ref: 'models/sink_resource.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_create_sink.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:create'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_delete_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_delete_destination.yml
@@ -1,0 +1,37 @@
+operationId: monitoring_delete_destination
+
+summary: Delete Logging Destination
+
+description: To delete a destination and all associated sinks, send a DELETE request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/destination_uuid'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_delete_destination.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:delete'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_delete_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_delete_sink.yml
@@ -1,0 +1,37 @@
+operationId: monitoring_delete_sink
+
+summary: Delete Sink
+
+description: To delete a sink, send a DELETE request to `/v2/monitoring/sinks/${sink_uuid}`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/sink_uuid'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_delete_sink.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:delete'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_get_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_get_destination.yml
@@ -1,0 +1,37 @@
+operationId: monitoring_get_destination
+
+summary: Get Logging Destination
+
+description: To get the details of a destination, send a GET request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/destination_uuid'
+
+responses:
+  '200':
+    $ref: 'responses/destination.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_get_destination.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_get_sink.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_get_sink.yml
@@ -1,0 +1,37 @@
+operationId: monitoring_get_sink
+
+summary: Get Sink
+
+description: To get the details of a sink (resources and destination), send a GET request to `/v2/monitoring/sinks/${sink_uuid}`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/sink_uuid'
+
+responses:
+  '200':
+    $ref: 'responses/sinks.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_get_sink.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_list_destinations.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_list_destinations.yml
@@ -1,0 +1,34 @@
+operationId: monitoring_list_destinations
+
+summary: List Logging Destinations
+
+description: To list all logging destinations, send a GET request to `/v2/monitoring/sinks/destinations`.
+
+tags:
+  - Monitoring
+
+responses:
+  '200':
+    $ref: 'responses/monitoring_list_destinations.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_list_destinations.yml'
+
+security:
+  - bearer_auth:
+    - 'monitoring:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_list_sinks.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_list_sinks.yml
@@ -1,0 +1,37 @@
+operationId: monitoring_list_sinks
+
+summary: Lists all sinks
+
+description: To list all sinks, send a GET request to `/v2/monitoring/sinks`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/resource_id'
+
+responses:
+  '200':
+    $ref: 'responses/list_sinks.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_list_sinks.yml'
+
+security:
+  - bearer_auth:
+    - 'monitoring:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_update_alertPolicy.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_update_alertPolicy.yml
@@ -49,7 +49,7 @@ requestBody:
     `v1/insights/lbaas/avg_cpu_utilization_percent`|alert on the percent of CPU utilization|load balancer ID
     `v1/insights/lbaas/connection_utilization_percent`|alert on the percent of connection utilization|load balancer ID
     `v1/insights/lbaas/droplet_health`|alert on Droplet health status changes|load balancer ID
-    `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization|load balancer ID
+    `v1/insights/lbaas/tls_connections_per_second_utilization_percent`|alert on the percent of TLS connections per second utilization (requires at least one HTTPS forwarding rule)|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_percentage_5xx`|alert on the percent increase of 5xx level http errors over 5m|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_percentage_4xx`|alert on the percent increase of 4xx level http errors over 5m|load balancer ID
     `v1/insights/lbaas/increase_in_http_error_rate_count_5xx`|alert on the count of 5xx level http errors over 5m|load balancer ID

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_update_destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/monitoring_update_destination.yml
@@ -1,0 +1,44 @@
+operationId: monitoring_update_destination
+
+summary: Update Logging Destination
+
+description: To update the details of a destination, send a PATCH request to `/v2/monitoring/sinks/destinations/${destination_uuid}`.
+
+tags:
+  - Monitoring
+
+parameters:
+  - $ref: 'parameters.yml#/destination_uuid'
+
+responses:
+  '204':
+    $ref: '../../shared/responses/no_content.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: 'models/destination_request.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/monitoring_update_destination.yml'
+  
+security:
+  - bearer_auth:
+    - 'monitoring:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/parameters.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/parameters.yml
@@ -25,6 +25,14 @@ load_balancer_id:
     type: string
   example: 4de7ac8b-495b-4884-9a69-1050c6793cd6
 
+resource_id:
+  in: query
+  name: resource_id
+  description: A unique URN for a resource.
+  schema:
+    $ref: '../../shared/attributes/urn.yml' 
+  example: do:kubernetes:5ba4518b-b9e2-4978-aa92-2d4c727e8824
+
 app_component:
   in: query
   name: app_component
@@ -82,3 +90,21 @@ alert_uuid:
   schema:
     type: string
   example: 4de7ac8b-495b-4884-9a69-1050c6793cd6
+
+destination_uuid:
+  in: path
+  name: destination_uuid
+  description: A unique identifier for a destination.
+  required: true
+  schema:
+    type: string
+  example: 1a64809f-1708-48ee-a742-dec8d481b8d1
+
+sink_uuid:
+  in: path
+  name: sink_uuid
+  description: A unique identifier for a sink.
+  required: true
+  schema:
+    type: string
+  example: 78b172b6-52c3-4a4b-96d5-78d3f1a0b18c

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/destination.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/destination.yml
@@ -1,0 +1,16 @@
+description: The response is a JSON object with a `destination` key.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+          destination:
+            $ref: '../models/destination_omit_credentials.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/list_sinks.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/list_sinks.yml
@@ -1,0 +1,19 @@
+description: The response is a JSON object with a `sinks` key.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+        sinks:
+          type: array
+          description: "List of sinks identified by their URNs."
+          items:
+            $ref: '../models/sinks_response.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/monitoring_list_destinations.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/monitoring_list_destinations.yml
@@ -1,0 +1,18 @@
+description: The response is a JSON object with a `destinations` key.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+          destinations:
+            type: array
+            items:
+              $ref: '../models/destination_omit_credentials.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/sinks.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/monitoring/responses/sinks.yml
@@ -1,0 +1,16 @@
+description: The response is a JSON object with a `sink` key.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      properties:
+        sink:
+            $ref: '../models/sinks_response.yml'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/registry/registry_run_garbageCollection.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/registry/registry_run_garbageCollection.yml
@@ -7,7 +7,7 @@ description: |
   manifest data) after deleting one or more manifests from a repository. If
   there are no unreferenced blobs resulting from the deletion of one or more
   manifests, garbage collection is effectively a noop.
-  [See here for more information](https://www.digitalocean.com/docs/container-registry/how-to/clean-up-container-registry/)
+  [See here for more information](https://docs.digitalocean.com/products/container-registry/how-to/clean-up-container-registry/)
   about how and why you should clean up your container registry periodically.
 
   To request a garbage collection run on your registry, send a POST request to

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/disk_info.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/disk_info.yml
@@ -1,0 +1,22 @@
+type: object
+
+properties:
+  type:
+    type: string
+    enum:
+      - local
+      - scratch
+    description: The type of disk. All Droplets contain a `local` disk. Additionally,
+      GPU Droplets can also have a `scratch` disk for non-persistent data.
+    example: local
+  size:
+    type: object
+    properties:
+      amount:
+        type: integer
+        description: The amount of space allocated to the disk.
+        example: 25
+      unit:
+        type: string
+        description: The unit of measure for the disk size.
+        example: gib

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/gpu_info.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/gpu_info.yml
@@ -1,0 +1,25 @@
+type: object
+description: >-
+  An object containing information about the GPU capabilities of Droplets
+  created with this size.
+
+properties:
+  count:
+    type: integer
+    description: The number of GPUs allocated to the Droplet.
+    example: 1
+  model:
+    type: string
+    description: The model of the GPU.
+    example: nvidia_h100
+  vram:
+    type: object
+    properties:
+      amount:
+        type: integer
+        description: The amount of VRAM allocated to the GPU.
+        example: 25
+      unit:
+        type: string
+        description: The unit of measure for the VRAM.
+        example: gib

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/size.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/models/size.yml
@@ -18,7 +18,7 @@ properties:
   vcpus:
     type: integer
     example: 1
-    description: The integer of number CPUs allocated to Droplets of this size.
+    description: The number of CPUs allocated to Droplets of this size.
 
   disk:
     type: integer
@@ -84,6 +84,16 @@ properties:
       A string describing the class of Droplets created from this size. For
       example: Basic, General Purpose, CPU-Optimized, Memory-Optimized, or
       Storage-Optimized.
+
+  disk_info:
+    type: array
+    description: An array of objects containing information about the disks
+      available to Droplets created with this size.
+    items:
+      $ref: './disk_info.yml'
+
+  gpu_info:
+    $ref: './gpu_info.yml'
 
 required:
   - available

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/responses/all_sizes.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/sizes/responses/all_sizes.yml
@@ -51,6 +51,11 @@ content:
           - tor1
           available: true
           description: Basic
+          disk_info:
+            - type: "local"
+              size:
+                amount: 25
+                unit: "gib"
         links:
           pages:
             last: "https://api.digitalocean.com/v2/sizes?page=64&per_page=1"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/volumes/volumeActions_post.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/volumes/volumeActions_post.yml
@@ -20,7 +20,7 @@ description: |
   volumes may be attached to a Droplet at a time. Pre-formatted volumes will be
   automatically mounted to Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS
   Droplets created on or after April 26, 2018 when attached. On older Droplets,
-  [additional configuration](https://www.digitalocean.com/community/tutorials/how-to-partition-and-format-digitalocean-block-storage-volumes-in-linux#mounting-the-filesystems)
+  [additional configuration](https://docs.digitalocean.com/products/volumes/how-to/mount/)
   is required.
 
   ## Remove a Block Storage Volume from a Droplet

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/volumes/volumeActions_post_byId.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/volumes/volumeActions_post_byId.yml
@@ -19,7 +19,7 @@ description: |
   volumes may be attached to a Droplet at a time. Pre-formatted volumes will be
   automatically mounted to Ubuntu, Debian, Fedora, Fedora Atomic, and CentOS
   Droplets created on or after April 26, 2018 when attached. On older Droplets,
-  [additional configuration](https://www.digitalocean.com/community/tutorials/how-to-partition-and-format-digitalocean-block-storage-volumes-in-linux#mounting-the-filesystems)
+  [additional configuration](https://docs.digitalocean.com/products/volumes/how-to/mount/)
   is required.
 
   ## Remove a Block Storage Volume from a Droplet

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_create.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_create.yml
@@ -1,0 +1,8 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name": "my-first-vpc-peering", "vpc_ids": [ "997615ce-132d-4bae-9270-9ee21b395e5d", "e51aed59-3bb1-4a6a-8de0-9d1329e9c997"]}' \
+    "https://api.digitalocean.com/v2/vpc_peerings"
+

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_delete.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_delete.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vpc_peerings/6b5c619c-359c-44ca-87e2-47e98170c01d"
+

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_get.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_get.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vpc_peerings/5a4981aa-9653-4bd1-bef5-d6bff52042e4"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_list.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_list.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vpc_peerings?region=sfo3&page=1&per_page=20"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_update.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/examples/curl/vpc_peerings_update.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PATCH \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name":"renamed-vpc-peering"}' \
+    "https://api.digitalocean.com/v2/vpc_peerings/5a4981aa-9653-4bd1-bef5-d6bff52042e4"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/models/vpc_peering.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/models/vpc_peering.yml
@@ -1,0 +1,58 @@
+vpc_peering:
+  type: object
+  allOf:
+  - $ref: '#/vpc_peering_base'
+  - $ref: '#/vpc_peering_create'
+  - $ref: '#/vpc_peering_updatable'
+
+vpc_peering_base:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+      readOnly: true
+      example: 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+      description: A unique ID that can be used to identify and reference the VPC peering.
+
+    created_at:
+      type: string
+      format: date-time
+      readOnly: true
+      example: "2020-03-13T19:20:47.442049222Z"
+      description: A time value given in ISO8601 combined date and time format.
+
+    status:
+      type: string
+      enum:
+        - PROVISIONING
+        - ACTIVE
+        - DELETING
+      readOnly: true
+      example: "ACTIVE"
+      description: The current status of the VPC peering.
+
+vpc_peering_create:
+  type: object
+  properties:
+      vpc_ids:
+        type: array
+        items:
+          type: string
+          format: uuid
+        minItems: 2
+        maxItems: 2
+        example:
+        - c140286f-e6ce-4131-8b7b-df4590ce8d6a
+        - 994a2735-dc84-11e8-80bc-3cfdfea9fba1
+        description: An array of the two peered VPCs IDs.
+
+vpc_peering_updatable:
+  type: object
+  properties:
+    name:
+      type: string
+      pattern: '^[a-zA-Z0-9\-]+$'
+      example: nyc1-blr1-peering
+      description: The name of the VPC peering. Must be unique within the team 
+        and may only contain alphanumeric characters and dashes.

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/parameters.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/parameters.yml
@@ -1,0 +1,9 @@
+vpc_peering_id:
+  in: path
+  name: vpc_peering_id
+  description: A unique identifier for a VPC peering.
+  required: true
+  schema:
+    type: string
+    format: uuid
+  example: 5a4981aa-9653-4bd1-bef5-d6bff52042e4

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/active_vpc_peering.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/active_vpc_peering.yml
@@ -1,0 +1,29 @@
+description: The response will be a JSON object with a key called `vpc_peering`. 
+  The value of this will be an object that contains the standard attributes
+  associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        vpc_peering:
+          $ref: '../models/vpc_peering.yml#/vpc_peering'
+
+      example:
+        vpc_peering:
+          id: 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: ACTIVE

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/all_vpc_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/all_vpc_peerings.yml
@@ -1,0 +1,48 @@
+description: >-
+  The response will be a JSON object with a key called `vpc_peerings`. This 
+  will be set to an array of objects, each of which will contain the standard 
+  attributes associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      allOf:
+        - type: object
+          properties:
+            vpc_peerings:
+              type: array
+              items:
+                $ref: '../models/vpc_peering.yml#/vpc_peering'
+        - $ref: '../../../shared/pages.yml#/pagination'
+        - $ref: '../../../shared/meta.yml'
+
+      example:
+        vpc_peerings:
+        - id: 6b5c619c-359c-44ca-87e2-47e98170c01d
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: ACTIVE
+        - id: c212b274-911c-44cc-a117-23b7da4a2922
+          name: another-vpc-peering
+          vpc_ids:
+          - 5a100736-b085-4f69-81fd-feee325784bb
+          - c140286f-e6ce-4131-8b7b-df4590ce8d6a
+          created_at: '2024-01-10T13:29:58Z'
+          status: ACTIVE
+        links: {}
+        meta:
+          total: 2
+
+
+

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/deleting_vpc_peering.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/deleting_vpc_peering.yml
@@ -1,0 +1,29 @@
+description: The response will be a JSON object with a key called `vpc_peering`. 
+  The value of this will be an object that contains the standard attributes
+  associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        vpc_peering:
+          $ref: '../models/vpc_peering.yml#/vpc_peering'
+
+      example:
+        vpc_peering:
+          id: 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: DELETING

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/provisioning_vpc_peering.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/responses/provisioning_vpc_peering.yml
@@ -1,0 +1,29 @@
+description: The response will be a JSON object with a key called `vpc_peering`. 
+  The value of this will be an object that contains the standard attributes
+  associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        vpc_peering:
+          $ref: '../models/vpc_peering.yml#/vpc_peering'
+
+      example:
+        vpc_peering:
+          id: 5a4981aa-9653-4bd1-bef5-d6bff52042e4
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: PROVISIONING

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_create.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_create.yml
@@ -1,0 +1,51 @@
+operationId: vpcPeerings_create
+
+summary: Create a New VPC Peering
+
+description: |
+  To create a new VPC Peering, send a POST request to `/v2/vpc_peerings` 
+  specifying a name and a list of two VPC IDs to peer. The response code, 202 
+  Accepted, does not indicate the success or failure of the operation, just 
+  that the request has been accepted for processing.
+
+tags:
+  - VPC Peerings
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        type: object
+        allOf:
+        - $ref: 'models/vpc_peering.yml#/vpc_peering_updatable'
+        - $ref: 'models/vpc_peering.yml#/vpc_peering_create'
+
+        required:
+        - name
+        - vpc_ids
+
+
+responses:
+  '202':
+    $ref: 'responses/provisioning_vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpc_peerings_create.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:create'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_delete.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_delete.yml
@@ -1,0 +1,38 @@
+operationId: vpcPeerings_delete
+
+summary: Delete a VPC peering
+
+description: |
+  To delete a VPC peering, send a DELETE request to `/v2/vpc_peerings/$VPC_PEERING_ID`.
+
+tags:
+  - VPC Peerings
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_peering_id'
+
+responses:
+  '202':
+    $ref: 'responses/deleting_vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpc_peerings_delete.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:delete'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_get.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_get.yml
@@ -1,0 +1,38 @@
+operationId: vpcPeerings_get
+
+summary: Retrieve an Existing VPC Peering
+
+description: |
+  To show information about an existing VPC Peering, send a GET request to `/v2/vpc_peerings/$VPC_PEERING_ID`.
+
+tags:
+  - VPC Peerings
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_peering_id'
+
+responses:
+  '200':
+    $ref: 'responses/active_vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpc_peerings_get.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_list.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_list.yml
@@ -1,0 +1,42 @@
+operationId: vpcPeerings_list
+
+summary: List All VPC Peerings
+
+description: To list all of the VPC peerings on your account, send a GET request
+  to `/v2/vpc_peerings`.
+
+tags:
+  - VPC Peerings
+
+parameters:
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+  - $ref: '../../shared/parameters.yml#/region'
+
+
+responses:
+  '200':
+    $ref: 'responses/all_vpc_peerings.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpc_peerings_list.yml'
+
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_update.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpc_peerings/vpc_peerings_update.yml
@@ -1,0 +1,51 @@
+operationId: vpcPeerings_patch
+
+summary: Update a VPC peering
+
+description: |
+  To update the name of a VPC peering, send a PATCH request to `/v2/vpc_peerings/$VPC_PEERING_ID` with the new `name` in the request body.
+
+tags:
+  - VPC Peerings
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_peering_id'
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        type: object
+        allOf:
+        - $ref: 'models/vpc_peering.yml#/vpc_peering_updatable'
+
+        required:
+        - name
+
+responses:
+  '200':
+    $ref: 'responses/active_vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpc_peerings_update.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_create_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_create_peerings.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name":"example-vpc-peering", "vpc_id": "e51aed59-3bb1-4a6a-8de0-9d1329e9c997"}' \
+    "https://api.digitalocean.com/v2/vpcs/5a4981aa-9653-4bd1-bef5-d6bff52042e4/peerings"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_list_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_list_peerings.yml
@@ -1,0 +1,6 @@
+lang: cURL
+source: |-
+  curl -X GET \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    "https://api.digitalocean.com/v2/vpcs/5a4981aa-9653-4bd1-bef5-d6bff52042e4/peerings"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_update_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/examples/curl/vpcs_update_peerings.yml
@@ -1,0 +1,7 @@
+lang: cURL
+source: |-
+  curl -X PATCH \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+    -d '{"name": "renamed-my-first-vpc-peering"}' \
+    "https://api.digitalocean.com/v2/vpcs/997615ce-132d-4bae-9270-9ee21b395e5d/peerings/6b5c619c-359c-44ca-87e2-47e98170c01d"

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/parameters.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/parameters.yml
@@ -17,3 +17,13 @@ vpc_resource_type:
   schema:
     type: string
   example: droplet
+
+vpc_peering_id:
+  in: path
+  name: vpc_peering_id
+  description: A unique identifier for a VPC peering.
+  required: true
+  schema:
+    type: string
+    format: uuid
+  example: 5a4981aa-9653-4bd1-bef5-d6bff52042e4

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/responses/vpc_peering.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/responses/vpc_peering.yml
@@ -1,0 +1,29 @@
+description: >-
+  The response will be a JSON object with a key called `peering`, containing 
+  the standard attributes associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        peering:
+          $ref: '../../vpc_peerings/models/vpc_peering.yml#/vpc_peering'
+
+      example:
+        peering:
+          id: 6b5c619c-359c-44ca-87e2-47e98170c01d
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: PROVISIONING

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/responses/vpc_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/responses/vpc_peerings.yml
@@ -1,0 +1,45 @@
+description: >-
+  The response will be a JSON object with a key called `peerings`. This 
+  will be set to an array of objects, each of which will contain the standard 
+  attributes associated with a VPC peering.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      allOf:
+        - type: object
+          properties:
+            peerings:
+              type: array
+              items:
+                $ref: '../../vpc_peerings/models/vpc_peering.yml#/vpc_peering'
+        - $ref: '../../../shared/pages.yml#/pagination'
+        - $ref: '../../../shared/meta.yml'
+
+      example:
+        peerings:
+        - id: 6b5c619c-359c-44ca-87e2-47e98170c01d
+          name: example-vpc-peering
+          vpc_ids:
+          - 997615ce-132d-4bae-9270-9ee21b395e5d
+          - e51aed59-3bb1-4a6a-8de0-9d1329e9c997
+          created_at: '2024-01-09T20:44:32Z'
+          status: ACTIVE
+        - id: c212b274-911c-44cc-a117-23b7da4a2922
+          name: another-vpc-peering
+          vpc_ids:
+          - 5a100736-b085-4f69-81fd-feee325784bb
+          - c140286f-e6ce-4131-8b7b-df4590ce8d6a
+          created_at: '2024-01-10T13:29:58Z'
+          status: ACTIVE
+        links: {}
+        meta:
+          total: 2

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_create_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_create_peerings.yml
@@ -1,0 +1,63 @@
+operationId: vpcs_create_peerings
+
+summary: Create a Peering with a VPC
+
+description: |
+  To create a new VPC peering for a given VPC, send a POST request to
+  `/v2/vpcs/$VPC_ID/peerings`.
+
+tags:
+  - VPCs
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_id'
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          name:
+            type: string
+            pattern: '^[a-zA-Z0-9\-\.]+$'
+            example: nyc1-blr1-peering
+            description: The name of the VPC peering. Must be unique and may only contain
+              alphanumeric characters, dashes, and periods.
+          vpc_id:
+            type: string
+            format: uuid
+            example: c140286f-e6ce-4131-8b7b-df4590ce8d6a
+            description: The ID of the VPC to peer with.
+
+        required:
+        - name
+        - vpc_id
+
+responses:
+  '202':
+    $ref: 'responses/vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpcs_create_peerings.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:create'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_list_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_list_peerings.yml
@@ -1,0 +1,41 @@
+operationId: vpcs_list_peerings
+
+summary: List the Peerings of a VPC
+
+description: |
+  To list all of a VPC's peerings, send a GET request to
+  `/v2/vpcs/$VPC_ID/peerings`.
+
+tags:
+  - VPCs
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_id'
+  - $ref: '../../shared/parameters.yml#/per_page'
+  - $ref: '../../shared/parameters.yml#/page'
+
+responses:
+  '200':
+    $ref: 'responses/vpc_peerings.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpcs_list_peerings.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:read'

--- a/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_update_peerings.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/resources/vpcs/vpcs_update_peerings.yml
@@ -1,0 +1,54 @@
+operationId: vpcs_patch_peerings
+
+summary: Update a VPC Peering
+
+description: |
+  To update the name of a VPC peering in a particular VPC, send a PATCH request 
+  to `/v2/vpcs/$VPC_ID/peerings/$VPC_PEERING_ID` with the new `name` in the 
+  request body.
+
+tags:
+  - VPCs
+
+parameters:
+  - $ref: 'parameters.yml#/vpc_id'
+  - $ref: 'parameters.yml#/vpc_peering_id'
+
+requestBody:
+  required: true
+
+  content:
+    application/json:
+      schema:
+        type: object
+        allOf:
+        - $ref: '../vpc_peerings/models/vpc_peering.yml#/vpc_peering_updatable'
+
+        required:
+        - name
+
+responses:
+  '200':
+    $ref: 'responses/vpc_peering.yml'
+
+  '401':
+    $ref: '../../shared/responses/unauthorized.yml'
+
+  '404':
+    $ref: '../../shared/responses/not_found.yml'
+
+  '429':
+    $ref: '../../shared/responses/too_many_requests.yml'
+
+  '500':
+    $ref: '../../shared/responses/server_error.yml'
+
+  default:
+    $ref: '../../shared/responses/unexpected_error.yml'
+
+x-codeSamples:
+  - $ref: 'examples/curl/vpcs_update_peerings.yml'
+
+security:
+  - bearer_auth:
+    - 'vpc_peering:update'

--- a/packages/openapi-typescript/examples/digital-ocean-api/shared/attributes/region_slug.yml
+++ b/packages/openapi-typescript/examples/digital-ocean-api/shared/attributes/region_slug.yml
@@ -17,4 +17,5 @@ enum:
   - sfo3
   - sgp1
   - tor1
+  - syd1
 example: nyc3

--- a/packages/openapi-typescript/examples/stripe-api.ts
+++ b/packages/openapi-typescript/examples/stripe-api.ts
@@ -932,7 +932,7 @@ export interface paths {
         };
         /**
          * List credit grants
-         * @description <p>Retrieve a list of credit grants</p>
+         * @description <p>Retrieve a list of credit grants.</p>
          */
         get: operations["GetBillingCreditGrants"];
         put?: never;
@@ -982,7 +982,7 @@ export interface paths {
         put?: never;
         /**
          * Expire a credit grant
-         * @description <p>Expires a credit grant</p>
+         * @description <p>Expires a credit grant.</p>
          */
         post: operations["PostBillingCreditGrantsIdExpire"];
         delete?: never;
@@ -1002,7 +1002,7 @@ export interface paths {
         put?: never;
         /**
          * Void a credit grant
-         * @description <p>Voids a credit grant</p>
+         * @description <p>Voids a credit grant.</p>
          */
         post: operations["PostBillingCreditGrantsIdVoid"];
         delete?: never;
@@ -6553,7 +6553,7 @@ export interface paths {
          *     <li>A trial starts or ends.</li>
          *     </ul>
          *
-         *     <p>In these cases, we apply a credit for the unused time on the previous price, immediately charge the customer using the new price, and reset the billing date. Learn about how <a href="/billing/subscriptions/upgrade-downgrade#immediate-payment">Stripe immediately attempts payment for subscription changes</a>.</p>
+         *     <p>In these cases, we apply a credit for the unused time on the previous price, immediately charge the customer using the new price, and reset the billing date. Learn about how <a href="/docs/billing/subscriptions/upgrade-downgrade#immediate-payment">Stripe immediately attempts payment for subscription changes</a>.</p>
          *
          *     <p>If you want to charge for an upgrade immediately, pass <code>proration_behavior</code> as <code>always_invoice</code> to create prorations, automatically invoice the customer for those proration adjustments, and attempt to collect payment. If you pass <code>create_prorations</code>, the prorations are created but not automatically invoiced. If you want to bill the customer for the prorations before the subscription’s renewal date, you need to manually <a href="/docs/api/invoices/create">invoice the customer</a>.</p>
          *
@@ -7357,6 +7357,26 @@ export interface paths {
          * @description <p>Finalize the amount on an Authorization prior to capture, when the initial authorization was for an estimated amount.</p>
          */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmount"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/test_helpers/issuing/authorizations/{authorization}/fraud_challenges/respond": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Respond to fraud challenge
+         * @description <p>Respond to a fraud challenge on a testmode Issuing authorization, simulating either a confirmation of fraud or a correction of legitimacy.</p>
+         */
+        post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespond"];
         delete?: never;
         options?: never;
         head?: never;
@@ -9285,8 +9305,11 @@ export interface components {
             current_deadline?: number | null;
             /** @description Fields that need to be collected to keep the account enabled. If not collected by `future_requirements[current_deadline]`, these fields will transition to the main `requirements` hash. */
             currently_due?: string[] | null;
-            /** @description This is typed as a string for consistency with `requirements.disabled_reason`. */
-            disabled_reason?: string | null;
+            /**
+             * @description This is typed as an enum for consistency with `requirements.disabled_reason`.
+             * @enum {string|null}
+             */
+            disabled_reason?: "action_required.requested_capabilities" | "listed" | "other" | "platform_paused" | "rejected.fraud" | "rejected.incomplete_verification" | "rejected.listed" | "rejected.other" | "rejected.platform_fraud" | "rejected.platform_other" | "rejected.platform_terms_of_service" | "rejected.terms_of_service" | "requirements.past_due" | "requirements.pending_verification" | "under_review" | null;
             /** @description Fields that are `currently_due` and need to be collected again because validation or verification failed. */
             errors?: components["schemas"]["account_requirements_error"][] | null;
             /** @description Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well. */
@@ -9371,8 +9394,11 @@ export interface components {
             current_deadline?: number | null;
             /** @description Fields that need to be collected to keep the account enabled. If not collected by `current_deadline`, these fields appear in `past_due` as well, and the account is disabled. */
             currently_due?: string[] | null;
-            /** @description If the account is disabled, this string describes why. [Learn more about handling verification issues](https://stripe.com/docs/connect/handling-api-verification). Can be `action_required.requested_capabilities`, `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.fraud`, `rejected.incomplete_verification`, `rejected.listed`, `rejected.other`, `rejected.terms_of_service`, `under_review`, or `other`. */
-            disabled_reason?: string | null;
+            /**
+             * @description If the account is disabled, this enum describes why. [Learn more about handling verification issues](https://stripe.com/docs/connect/handling-api-verification).
+             * @enum {string|null}
+             */
+            disabled_reason?: "action_required.requested_capabilities" | "listed" | "other" | "platform_paused" | "rejected.fraud" | "rejected.incomplete_verification" | "rejected.listed" | "rejected.other" | "rejected.platform_fraud" | "rejected.platform_other" | "rejected.platform_terms_of_service" | "rejected.terms_of_service" | "requirements.past_due" | "requirements.pending_verification" | "under_review" | null;
             /** @description Fields that are `currently_due` and need to be collected again because validation or verification failed. */
             errors?: components["schemas"]["account_requirements_error"][] | null;
             /** @description Fields that need to be collected assuming all volume thresholds are reached. As they become required, they appear in `currently_due` as well, and `current_deadline` becomes set. */
@@ -10103,13 +10129,12 @@ export interface components {
          * @description A credit grant is an API resource that documents the allocation of some billing credits to a customer.
          *
          *     Related guide: [Billing credits](https://docs.stripe.com/billing/subscriptions/usage-based/billing-credits)
-         *     end
          */
         "billing.credit_grant": {
             amount: components["schemas"]["billing_credit_grants_resource_amount"];
             applicability_config: components["schemas"]["billing_credit_grants_resource_applicability_config"];
             /**
-             * @description The category of this credit grant. This is for tracking purposes and will not be displayed to the customer.
+             * @description The category of this credit grant. This is for tracking purposes and isn't displayed to the customer.
              * @enum {string}
              */
             category: "paid" | "promotional";
@@ -10118,16 +10143,16 @@ export interface components {
              * @description Time at which the object was created. Measured in seconds since the Unix epoch.
              */
             created: number;
-            /** @description ID of the customer to whom the billing credits are granted. */
+            /** @description ID of the customer receiving the billing credits. */
             customer: string | components["schemas"]["customer"] | components["schemas"]["deleted_customer"];
             /**
              * Format: unix-time
-             * @description The time when the billing credits become effective i.e when they are eligible to be used.
+             * @description The time when the billing credits become effective—when they're eligible for use.
              */
             effective_at?: number | null;
             /**
              * Format: unix-time
-             * @description The time when the billing credits will expire. If not present, the billing credits will never expire.
+             * @description The time when the billing credits expire. If not present, the billing credits don't expire.
              */
             expires_at?: number | null;
             /** @description Unique identifier for the object. */
@@ -10355,7 +10380,7 @@ export interface components {
         /** BillingCreditGrantsResourceScope */
         billing_credit_grants_resource_scope: {
             /**
-             * @description The price type to which credit grants can apply to. We currently only support `metered` price type. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them.
+             * @description The price type for which credit grants can apply. We currently only support the `metered` price type. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them.
              * @enum {string}
              */
             price_type: "metered";
@@ -10828,6 +10853,8 @@ export interface components {
          *     Related guide: [Checkout quickstart](https://stripe.com/docs/checkout/quickstart)
          */
         "checkout.session": {
+            /** @description Settings for price localization with [Adaptive Pricing](https://docs.stripe.com/payments/checkout/adaptive-pricing). */
+            adaptive_pricing?: components["schemas"]["payment_pages_checkout_session_adaptive_pricing"] | null;
             /** @description When set, provides configuration for actions to take if this Checkout Session expires. */
             after_expiration?: components["schemas"]["payment_pages_checkout_session_after_expiration"] | null;
             /** @description Enables user redeemable promotion codes. */
@@ -10989,7 +11016,7 @@ export interface components {
              *     specified on Checkout Sessions in `payment` mode. If blank or `auto`, `pay` is used.
              * @enum {string|null}
              */
-            submit_type?: "auto" | "book" | "donate" | "pay" | null;
+            submit_type?: "auto" | "book" | "donate" | "pay" | "subscribe" | null;
             /** @description The ID of the subscription for Checkout Sessions in `subscription` mode. */
             subscription?: (string | components["schemas"]["subscription"]) | null;
             /** @description The URL the customer will be directed to after the payment or
@@ -11123,6 +11150,7 @@ export interface components {
         };
         /** CheckoutBacsDebitPaymentMethodOptions */
         checkout_bacs_debit_payment_method_options: {
+            mandate_options?: components["schemas"]["checkout_payment_method_options_mandate_options_bacs_debit"];
             /**
              * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
              *
@@ -11173,6 +11201,26 @@ export interface components {
         /** CheckoutCardPaymentMethodOptions */
         checkout_card_payment_method_options: {
             installments?: components["schemas"]["checkout_card_installments_options"];
+            /**
+             * @description Request ability to [capture beyond the standard authorization validity window](/payments/extended-authorization) for this CheckoutSession.
+             * @enum {string}
+             */
+            request_extended_authorization?: "if_available" | "never";
+            /**
+             * @description Request ability to [increment the authorization](/payments/incremental-authorization) for this CheckoutSession.
+             * @enum {string}
+             */
+            request_incremental_authorization?: "if_available" | "never";
+            /**
+             * @description Request ability to make [multiple captures](/payments/multicapture) for this CheckoutSession.
+             * @enum {string}
+             */
+            request_multicapture?: "if_available" | "never";
+            /**
+             * @description Request ability to [overcapture](/payments/overcapture) for this CheckoutSession.
+             * @enum {string}
+             */
+            request_overcapture?: "if_available" | "never";
             /**
              * @description We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. If not provided, this value defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
              * @enum {string}
@@ -11467,6 +11515,10 @@ export interface components {
              */
             capture_method?: "manual";
         };
+        /** checkout_payment_method_options_mandate_options_bacs_debit */
+        checkout_payment_method_options_mandate_options_bacs_debit: Record<string, never>;
+        /** checkout_payment_method_options_mandate_options_sepa_debit */
+        checkout_payment_method_options_mandate_options_sepa_debit: Record<string, never>;
         /** CheckoutPaynowPaymentMethodOptions */
         checkout_paynow_payment_method_options: {
             /**
@@ -11533,6 +11585,7 @@ export interface components {
         };
         /** CheckoutSepaDebitPaymentMethodOptions */
         checkout_sepa_debit_payment_method_options: {
+            mandate_options?: components["schemas"]["checkout_payment_method_options_mandate_options_sepa_debit"];
             /**
              * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
              *
@@ -12021,7 +12074,7 @@ export interface components {
         /** ConnectEmbeddedAccountFeaturesClaim */
         connect_embedded_account_features_claim: {
             /** @description Disables Stripe user authentication for this embedded component. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. The default value for this feature is `false` when `external_account_collection` is enabled and `true` otherwise. */
-            disable_stripe_user_authentication?: boolean;
+            disable_stripe_user_authentication: boolean;
             /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. Otherwise, bank account collection is determined by compliance requirements. The default value for this feature is `true`. */
             external_account_collection: boolean;
         };
@@ -12073,7 +12126,7 @@ export interface components {
         /** ConnectEmbeddedPayoutsFeatures */
         connect_embedded_payouts_features: {
             /** @description Disables Stripe user authentication for this embedded component. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. The default value for this feature is `false` when `external_account_collection` is enabled and `true` otherwise. */
-            disable_stripe_user_authentication?: boolean;
+            disable_stripe_user_authentication: boolean;
             /** @description Whether to allow payout schedule to be changed. Default `true` when Stripe owns Loss Liability, default `false` otherwise. */
             edit_payout_schedule: boolean;
             /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. Otherwise, bank account collection is determined by compliance requirements. The default value for this feature is `true`. */
@@ -13491,7 +13544,7 @@ export interface components {
         };
         /** DisputePaymentMethodDetailsCard */
         dispute_payment_method_details_card: {
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand: string;
             /**
              * @description The type of dispute opened. Different case types may have varying fees and financial impact.
@@ -13865,7 +13918,7 @@ export interface components {
              * @description The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.
              * @enum {string}
              */
-            purpose: "account_requirement" | "additional_verification" | "business_icon" | "business_logo" | "customer_signature" | "dispute_evidence" | "document_provider_identity_document" | "finance_report_run" | "identity_document" | "identity_document_downloadable" | "issuing_regulatory_reporting" | "pci_document" | "selfie" | "sigma_scheduled_query" | "tax_document_user_upload" | "terminal_reader_splashscreen";
+            purpose: "account_requirement" | "additional_verification" | "business_icon" | "business_logo" | "customer_signature" | "dispute_evidence" | "document_provider_identity_document" | "finance_report_run" | "financial_account_statement" | "identity_document" | "identity_document_downloadable" | "issuing_regulatory_reporting" | "pci_document" | "selfie" | "sigma_scheduled_query" | "tax_document_user_upload" | "terminal_reader_splashscreen";
             /** @description The size of the file object in bytes. */
             size: number;
             /** @description A suitable title for the document. */
@@ -14296,8 +14349,14 @@ export interface components {
          * @description ABA Records contain U.S. bank account details per the ABA format.
          */
         funding_instructions_bank_transfer_aba_record: {
+            account_holder_address: components["schemas"]["address"];
+            /** @description The account holder name */
+            account_holder_name: string;
             /** @description The ABA account number */
             account_number: string;
+            /** @description The account type */
+            account_type: string;
+            bank_address: components["schemas"]["address"];
             /** @description The bank name */
             bank_name: string;
             /** @description The ABA routing number */
@@ -14365,8 +14424,14 @@ export interface components {
          * @description SWIFT Records contain U.S. bank account details per the SWIFT format.
          */
         funding_instructions_bank_transfer_swift_record: {
+            account_holder_address: components["schemas"]["address"];
+            /** @description The account holder name */
+            account_holder_name: string;
             /** @description The account number */
             account_number: string;
+            /** @description The account type */
+            account_type: string;
+            bank_address: components["schemas"]["address"];
             /** @description The bank name */
             bank_name: string;
             /** @description The SWIFT code */
@@ -14743,7 +14808,7 @@ export interface components {
              * @enum {string}
              */
             type: "document" | "id_number" | "verification_flow";
-            /** @description The configuration token of a Verification Flow from the dashboard. */
+            /** @description The configuration token of a verification flow from the dashboard. */
             verification_flow?: string;
             /** @description ID of the VerificationSession that created this report. */
             verification_session?: string | null;
@@ -14809,7 +14874,7 @@ export interface components {
             type: "document" | "id_number" | "verification_flow";
             /** @description The short-lived URL that you use to redirect a user to Stripe to submit their identity information. This URL expires after 48 hours and can only be used once. Don’t store it, log it, send it in emails or expose it to anyone other than the user. Refer to our docs on [verifying identity documents](https://stripe.com/docs/identity/verify-identity-documents?platform=web&type=redirect) to learn how to redirect users to Stripe. */
             url?: string | null;
-            /** @description The configuration token of a Verification Flow from the dashboard. */
+            /** @description The configuration token of a verification flow from the dashboard. */
             verification_flow?: string;
             /** @description The user’s verified data. */
             verified_outputs?: components["schemas"]["gelato_verified_outputs"] | null;
@@ -15491,10 +15556,10 @@ export interface components {
         /** InvoicesResourceInvoiceTaxID */
         invoices_resource_invoice_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value?: string | null;
         };
@@ -15594,6 +15659,8 @@ export interface components {
             currency: string;
             /** @description Fleet-specific information for authorizations using Fleet cards. */
             fleet?: components["schemas"]["issuing_authorization_fleet_data"] | null;
+            /** @description Fraud challenges sent to the cardholder, if this authorization was declined for fraud risk reasons. */
+            fraud_challenges?: components["schemas"]["issuing_authorization_fraud_challenge"][] | null;
             /** @description Information about fuel that was purchased with this transaction. Typically this information is received from the merchant after the authorization has been approved and the fuel dispensed. */
             fuel?: components["schemas"]["issuing_authorization_fuel_data"] | null;
             /** @description Unique identifier for the object. */
@@ -15632,12 +15699,14 @@ export interface components {
             /** @description [Treasury](https://stripe.com/docs/api/treasury) details related to this authorization if it was created on a [FinancialAccount](https://stripe.com/docs/api/treasury/financial_accounts). */
             treasury?: components["schemas"]["issuing_authorization_treasury"] | null;
             verification_data: components["schemas"]["issuing_authorization_verification_data"];
+            /** @description Whether the authorization bypassed fraud risk checks because the cardholder has previously completed a fraud challenge on a similar high-risk authorization from the same merchant. */
+            verified_by_fraud_challenge?: boolean | null;
             /** @description The digital wallet used for this transaction. One of `apple_pay`, `google_pay`, or `samsung_pay`. Will populate as `null` when no digital wallet was utilized. */
             wallet?: string | null;
         };
         /**
          * IssuingCard
-         * @description You can [create physical or virtual cards](https://stripe.com/docs/issuing/cards) that are issued to cardholders.
+         * @description You can [create physical or virtual cards](https://stripe.com/docs/issuing) that are issued to cardholders.
          */
         "issuing.card": {
             /** @description The brand of the card. */
@@ -15711,7 +15780,7 @@ export interface components {
          * IssuingCardholder
          * @description An Issuing `Cardholder` object represents an individual or business entity who is [issued](https://stripe.com/docs/issuing) cards.
          *
-         *     Related guide: [How to create a cardholder](https://stripe.com/docs/issuing/cards#create-cardholder)
+         *     Related guide: [How to create a cardholder](https://stripe.com/docs/issuing/cards/virtual/issue-cards#create-cardholder)
          */
         "issuing.cardholder": {
             billing: components["schemas"]["issuing_cardholder_address"];
@@ -16136,6 +16205,24 @@ export interface components {
              * @description Amount of national Sales Tax or VAT included in the transaction amount. `null` if not reported by merchant or not subject to tax.
              */
             national_amount_decimal?: string | null;
+        };
+        /** IssuingAuthorizationFraudChallenge */
+        issuing_authorization_fraud_challenge: {
+            /**
+             * @description The method by which the fraud challenge was delivered to the cardholder.
+             * @enum {string}
+             */
+            channel: "sms";
+            /**
+             * @description The status of the fraud challenge.
+             * @enum {string}
+             */
+            status: "expired" | "pending" | "rejected" | "undeliverable" | "verified";
+            /**
+             * @description If the challenge is not deliverable, the reason why.
+             * @enum {string|null}
+             */
+            undeliverable_reason?: "no_phone_number" | "unsupported_phone_number" | null;
         };
         /** IssuingAuthorizationFuelData */
         issuing_authorization_fuel_data: {
@@ -17506,10 +17593,14 @@ export interface components {
         };
         /** PaymentFlowsAmountDetails */
         payment_flows_amount_details: {
-            tip?: components["schemas"]["payment_flows_amount_details_resource_tip"];
+            tip?: components["schemas"]["payment_flows_amount_details_client_resource_tip"];
         };
-        /** PaymentFlowsAmountDetailsResourceTip */
-        payment_flows_amount_details_resource_tip: {
+        /** PaymentFlowsAmountDetailsClient */
+        payment_flows_amount_details_client: {
+            tip?: components["schemas"]["payment_flows_amount_details_client_resource_tip"];
+        };
+        /** PaymentFlowsAmountDetailsClientResourceTip */
+        payment_flows_amount_details_client_resource_tip: {
             /** @description Portion of the amount that corresponds to a tip. */
             amount?: number;
         };
@@ -17671,7 +17762,7 @@ export interface components {
             amount: number;
             /** @description Amount that can be captured from this PaymentIntent. */
             amount_capturable?: number;
-            amount_details?: components["schemas"]["payment_flows_amount_details"];
+            amount_details?: components["schemas"]["payment_flows_amount_details"] | components["schemas"]["payment_flows_amount_details_client"];
             /** @description Amount that this PaymentIntent collects. */
             amount_received?: number;
             /** @description ID of the Connect application that created the PaymentIntent. */
@@ -17746,7 +17837,7 @@ export interface components {
             on_behalf_of?: (string | components["schemas"]["account"]) | null;
             /** @description ID of the payment method used in this PaymentIntent. */
             payment_method?: (string | components["schemas"]["payment_method"]) | null;
-            /** @description Information about the payment method configuration used for this PaymentIntent. */
+            /** @description Information about the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) used for this PaymentIntent. */
             payment_method_configuration_details?: components["schemas"]["payment_method_config_biz_payment_method_configuration_details"] | null;
             /** @description Payment-method-specific configuration for this PaymentIntent. */
             payment_method_options?: components["schemas"]["payment_intent_payment_method_options"] | null;
@@ -18199,7 +18290,7 @@ export interface components {
              * @description Selected network to process this payment intent on. Depends on the available networks of the card attached to the payment intent. Can be only set confirm-time.
              * @enum {string|null}
              */
-            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
+            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
             /**
              * @description Request ability to [capture beyond the standard authorization validity window](https://stripe.com/docs/payments/extended-authorization) for this PaymentIntent.
              * @enum {string}
@@ -18516,7 +18607,7 @@ export interface components {
              * @description Indicates the type of transaction being performed which customizes relevant text on the page, such as the submit button.
              * @enum {string}
              */
-            submit_type: "auto" | "book" | "donate" | "pay";
+            submit_type: "auto" | "book" | "donate" | "pay" | "subscribe";
             /** @description When creating a subscription, the specified configuration data will be used. There must be at least one line item with a recurring price to use `subscription_data`. */
             subscription_data?: components["schemas"]["payment_links_resource_subscription_data"] | null;
             tax_id_collection: components["schemas"]["payment_links_resource_tax_id_collection"];
@@ -18893,7 +18984,7 @@ export interface components {
         };
         /** payment_method_card */
         payment_method_card: {
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand: string;
             /** @description Checks on Card address and CVC if provided. */
             checks?: components["schemas"]["payment_method_card_checks"] | null;
@@ -18942,7 +19033,7 @@ export interface components {
         };
         /** payment_method_card_present */
         payment_method_card_present: {
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand?: string | null;
             /** @description The [product code](https://stripe.com/docs/card-product-codes) that identifies the specific program or product associated with a card. */
             brand_product?: string | null;
@@ -19329,7 +19420,7 @@ export interface components {
             amount_authorized?: number | null;
             /** @description Authorization code on the charge. */
             authorization_code?: string | null;
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand?: string | null;
             /**
              * Format: unix-time
@@ -19361,7 +19452,7 @@ export interface components {
             /** @description ID of the mandate used to make this payment or created by it. */
             mandate?: string | null;
             multicapture?: components["schemas"]["payment_flows_private_payment_methods_card_details_api_resource_multicapture"];
-            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             network?: string | null;
             /** @description If this card has network token credentials, this contains the details of the network token credentials. */
             network_token?: components["schemas"]["payment_method_details_card_network_token"] | null;
@@ -19410,7 +19501,7 @@ export interface components {
         payment_method_details_card_present: {
             /** @description The authorized amount */
             amount_authorized?: number | null;
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand?: string | null;
             /** @description The [product code](https://stripe.com/docs/card-product-codes) that identifies the specific program or product associated with a card. */
             brand_product?: string | null;
@@ -19445,7 +19536,7 @@ export interface components {
             issuer?: string | null;
             /** @description The last four digits of the card. */
             last4?: string | null;
-            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             network?: string | null;
             /** @description This is used by the financial networks to identify a transaction. Visa calls this the Transaction ID, Mastercard calls this the Trace ID, and American Express calls this the Acquirer Reference Data. The first three digits of the Trace ID is the Financial Network Code, the next 6 digits is the Banknet Reference Number, and the last 4 digits represent the date (MM/DD). This field will be available for successful Visa, Mastercard, or American Express transactions and always null for other card brands. */
             network_transaction_id?: string | null;
@@ -19649,7 +19740,7 @@ export interface components {
             issuer?: string | null;
             /** @description The last four digits of the card. */
             last4?: string | null;
-            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             network?: string | null;
             /** @description This is used by the financial networks to identify a transaction. Visa calls this the Transaction ID, Mastercard calls this the Trace ID, and American Express calls this the Acquirer Reference Data. The first three digits of the Trace ID is the Financial Network Code, the next 6 digits is the Banknet Reference Number, and the last 4 digits represent the date (MM/DD). This field will be available for successful Visa, Mastercard, or American Express transactions and always null for other card brands. */
             network_transaction_id?: string | null;
@@ -20727,6 +20818,11 @@ export interface components {
         payment_method_wechat_pay: Record<string, never>;
         /** payment_method_zip */
         payment_method_zip: Record<string, never>;
+        /** PaymentPagesCheckoutSessionAdaptivePricing */
+        payment_pages_checkout_session_adaptive_pricing: {
+            /** @description Whether Adaptive Pricing is enabled. */
+            enabled: boolean;
+        };
         /** PaymentPagesCheckoutSessionAfterExpiration */
         payment_pages_checkout_session_after_expiration: {
             /** @description When set, configuration used to recover the Checkout Session on expiry. */
@@ -20988,10 +21084,10 @@ export interface components {
         /** PaymentPagesCheckoutSessionTaxID */
         payment_pages_checkout_session_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value?: string | null;
         };
@@ -21098,11 +21194,20 @@ export interface components {
             statement_descriptor?: string | null;
             /** @description Current status of the payout: `paid`, `pending`, `in_transit`, `canceled` or `failed`. A payout is `pending` until it's submitted to the bank, when it becomes `in_transit`. The status changes to `paid` if the transaction succeeds, or to `failed` or `canceled` (within 5 business days). Some payouts that fail might initially show as `paid`, then change to `failed`. */
             status: string;
+            /** @description A value that generates from the beneficiary's bank that allows users to track payouts with their bank. Banks might call this a "reference number" or something similar. */
+            trace_id?: components["schemas"]["payouts_trace_id"] | null;
             /**
              * @description Can be `bank_account` or `card`.
              * @enum {string}
              */
             type: "bank_account" | "card";
+        };
+        /** PayoutsTraceID */
+        payouts_trace_id: {
+            /** @description Possible values are `pending`, `supported`, and `unsupported`. When `payout.status` is `pending` or `in_transit`, this will be `pending`. When the payout transitions to `paid`, `failed`, or `canceled`, this status will become `supported` or `unsupported` shortly after in most cases. In some cases, this may appear as `pending` for up to 10 days after `arrival_date` until transitioning to `supported` or `unsupported`. */
+            status: string;
+            /** @description The trace ID value if `trace_id.status` is `supported`, otherwise `nil`. */
+            value?: string | null;
         };
         /** paypal_seller_protection */
         paypal_seller_protection: {
@@ -22277,33 +22382,49 @@ export interface components {
             alma?: components["schemas"]["destination_details_unimplemented"];
             amazon_pay?: components["schemas"]["destination_details_unimplemented"];
             au_bank_transfer?: components["schemas"]["destination_details_unimplemented"];
-            blik?: components["schemas"]["refund_destination_details_generic"];
-            br_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
+            blik?: components["schemas"]["refund_destination_details_blik"];
+            br_bank_transfer?: components["schemas"]["refund_destination_details_br_bank_transfer"];
             card?: components["schemas"]["refund_destination_details_card"];
             cashapp?: components["schemas"]["destination_details_unimplemented"];
             customer_cash_balance?: components["schemas"]["destination_details_unimplemented"];
             eps?: components["schemas"]["destination_details_unimplemented"];
-            eu_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
-            gb_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
+            eu_bank_transfer?: components["schemas"]["refund_destination_details_eu_bank_transfer"];
+            gb_bank_transfer?: components["schemas"]["refund_destination_details_gb_bank_transfer"];
             giropay?: components["schemas"]["destination_details_unimplemented"];
             grabpay?: components["schemas"]["destination_details_unimplemented"];
-            jp_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
+            jp_bank_transfer?: components["schemas"]["refund_destination_details_jp_bank_transfer"];
             klarna?: components["schemas"]["destination_details_unimplemented"];
-            multibanco?: components["schemas"]["refund_destination_details_generic"];
-            mx_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
-            p24?: components["schemas"]["refund_destination_details_generic"];
+            multibanco?: components["schemas"]["refund_destination_details_multibanco"];
+            mx_bank_transfer?: components["schemas"]["refund_destination_details_mx_bank_transfer"];
+            p24?: components["schemas"]["refund_destination_details_p24"];
             paynow?: components["schemas"]["destination_details_unimplemented"];
             paypal?: components["schemas"]["destination_details_unimplemented"];
             pix?: components["schemas"]["destination_details_unimplemented"];
             revolut?: components["schemas"]["destination_details_unimplemented"];
             sofort?: components["schemas"]["destination_details_unimplemented"];
-            swish?: components["schemas"]["refund_destination_details_generic"];
-            th_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
+            swish?: components["schemas"]["refund_destination_details_swish"];
+            th_bank_transfer?: components["schemas"]["refund_destination_details_th_bank_transfer"];
             /** @description The type of transaction-specific details of the payment method used in the refund (e.g., `card`). An additional hash is included on `destination_details` with a name matching this value. It contains information specific to the refund transaction. */
             type: string;
-            us_bank_transfer?: components["schemas"]["refund_destination_details_generic"];
+            us_bank_transfer?: components["schemas"]["refund_destination_details_us_bank_transfer"];
             wechat_pay?: components["schemas"]["destination_details_unimplemented"];
             zip?: components["schemas"]["destination_details_unimplemented"];
+        };
+        /** refund_destination_details_blik */
+        refund_destination_details_blik: {
+            /** @description For refunds declined by the network, a decline code provided by the network which indicates the reason the refund failed. */
+            network_decline_code?: string | null;
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_br_bank_transfer */
+        refund_destination_details_br_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
         };
         /** refund_destination_details_card */
         refund_destination_details_card: {
@@ -22319,8 +22440,66 @@ export interface components {
              */
             type: "pending" | "refund" | "reversal";
         };
-        /** refund_destination_details_generic */
-        refund_destination_details_generic: {
+        /** refund_destination_details_eu_bank_transfer */
+        refund_destination_details_eu_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_gb_bank_transfer */
+        refund_destination_details_gb_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_jp_bank_transfer */
+        refund_destination_details_jp_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_multibanco */
+        refund_destination_details_multibanco: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_mx_bank_transfer */
+        refund_destination_details_mx_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_p24 */
+        refund_destination_details_p24: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_swish */
+        refund_destination_details_swish: {
+            /** @description For refunds declined by the network, a decline code provided by the network which indicates the reason the refund failed. */
+            network_decline_code?: string | null;
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_th_bank_transfer */
+        refund_destination_details_th_bank_transfer: {
+            /** @description The reference assigned to the refund. */
+            reference?: string | null;
+            /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
+            reference_status?: string | null;
+        };
+        /** refund_destination_details_us_bank_transfer */
+        refund_destination_details_us_bank_transfer: {
             /** @description The reference assigned to the refund. */
             reference?: string | null;
             /** @description Status of the reference on the refund. This can be `pending`, `available` or `unavailable`. */
@@ -22677,7 +22856,7 @@ export interface components {
         setup_attempt_payment_method_details_boleto: Record<string, never>;
         /** setup_attempt_payment_method_details_card */
         setup_attempt_payment_method_details_card: {
-            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Card brand. Can be `amex`, `diners`, `discover`, `eftpos_au`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             brand?: string | null;
             /** @description Check results by Card networks on Card address and CVC at the time of authorization */
             checks?: components["schemas"]["setup_attempt_payment_method_details_card_checks"] | null;
@@ -22695,7 +22874,7 @@ export interface components {
             funding?: string | null;
             /** @description The last four digits of the card. */
             last4?: string | null;
-            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
+            /** @description Identifies which network this charge was processed on. Can be `amex`, `cartes_bancaires`, `diners`, `discover`, `eftpos_au`, `interac`, `jcb`, `link`, `mastercard`, `unionpay`, `visa`, or `unknown`. */
             network?: string | null;
             /** @description Populated if this authorization used 3D Secure authentication. */
             three_d_secure?: components["schemas"]["three_d_secure_details"] | null;
@@ -22874,7 +23053,7 @@ export interface components {
             on_behalf_of?: (string | components["schemas"]["account"]) | null;
             /** @description ID of the payment method used with this SetupIntent. If the payment method is `card_present` and isn't a digital wallet, then the [generated_card](https://docs.stripe.com/api/setup_attempts/object#setup_attempt_object-payment_method_details-card_present-generated_card) associated with the `latest_attempt` is attached to the Customer instead. */
             payment_method?: (string | components["schemas"]["payment_method"]) | null;
-            /** @description Information about the payment method configuration used for this Setup Intent. */
+            /** @description Information about the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) used for this Setup Intent. */
             payment_method_configuration_details?: components["schemas"]["payment_method_config_biz_payment_method_configuration_details"] | null;
             /** @description Payment method-specific configuration for this SetupIntent. */
             payment_method_options?: components["schemas"]["setup_intent_payment_method_options"] | null;
@@ -22964,7 +23143,7 @@ export interface components {
              * @description Selected network to process this SetupIntent on. Depends on the available networks of the card attached to the setup intent. Can be only set confirm-time.
              * @enum {string|null}
              */
-            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
+            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
             /**
              * @description We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. If not provided, this value defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
              * @enum {string|null}
@@ -23775,7 +23954,7 @@ export interface components {
             object: "subscription";
             /** @description The account (if any) the charge was made on behalf of for charges associated with this subscription. See the Connect documentation for details. */
             on_behalf_of?: (string | components["schemas"]["account"]) | null;
-            /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](/billing/subscriptions/pause-payment). */
+            /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment). */
             pause_collection?: components["schemas"]["subscriptions_resource_pause_collection"] | null;
             /** @description Payment settings passed on to invoices created by the subscription. */
             payment_settings?: components["schemas"]["subscriptions_resource_payment_settings"] | null;
@@ -23799,7 +23978,7 @@ export interface components {
              *
              *     A subscription that is currently in a trial period is `trialing` and moves to `active` when the trial period is over.
              *
-             *     A subscription can only enter a `paused` status [when a trial ends without a payment method](/billing/subscriptions/trials#create-free-trials-without-payment). A `paused` subscription doesn't generate invoices and can be resumed after your customer adds their payment method. The `paused` status is different from [pausing collection](/billing/subscriptions/pause-payment), which still generates invoices and leaves the subscription's status unchanged.
+             *     A subscription can only enter a `paused` status [when a trial ends without a payment method](https://stripe.com/docs/billing/subscriptions/trials#create-free-trials-without-payment). A `paused` subscription doesn't generate invoices and can be resumed after your customer adds their payment method. The `paused` status is different from [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment), which still generates invoices and leaves the subscription's status unchanged.
              *
              *     If subscription `collection_method=charge_automatically`, it becomes `past_due` when payment is required but cannot be paid (due to failed payment or awaiting additional user actions). Once Stripe has exhausted all payment retry attempts, the subscription will become `canceled` or `unpaid` (depending on your subscriptions settings).
              *
@@ -23889,7 +24068,7 @@ export interface components {
              * @description Selected network to process this Subscription on. Depends on the available networks of the card attached to the Subscription. Can be only set confirm-time.
              * @enum {string|null}
              */
-            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
+            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa" | null;
             /**
              * @description We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
              * @enum {string|null}
@@ -24587,10 +24766,10 @@ export interface components {
             /** @description The account or customer the tax ID belongs to. */
             owner?: components["schemas"]["tax_i_ds_owner"] | null;
             /**
-             * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+             * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `li_vat`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description Value of the tax ID. */
             value: string;
             /** @description Tax ID verification information. */
@@ -24783,10 +24962,10 @@ export interface components {
         /** TaxProductResourceCustomerDetailsResourceTaxId */
         tax_product_resource_customer_details_resource_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value: string;
         };
@@ -24834,7 +25013,7 @@ export interface components {
              * @description The tax type, such as `vat` or `sales_tax`.
              * @enum {string}
              */
-            tax_type: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+            tax_type: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
         };
         /** TaxProductResourcePostalAddress */
         tax_product_resource_postal_address: {
@@ -24907,7 +25086,7 @@ export interface components {
              * @description The tax type, such as `vat` or `sales_tax`.
              * @enum {string|null}
              */
-            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat" | null;
+            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat" | null;
         };
         /** TaxProductResourceTaxSettingsDefaults */
         tax_product_resource_tax_settings_defaults: {
@@ -25022,7 +25201,7 @@ export interface components {
              * @description The high-level tax type, such as `vat` or `sales_tax`.
              * @enum {string|null}
              */
-            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat" | null;
+            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat" | null;
         };
         /**
          * TaxRateFlatAmount
@@ -25946,7 +26125,7 @@ export interface components {
              */
             object: "treasury.inbound_transfer";
             /** @description The origin payment method to be debited for an InboundTransfer. */
-            origin_payment_method: string;
+            origin_payment_method?: string | null;
             /** @description Details about the PaymentMethod for an InboundTransfer. */
             origin_payment_method_details?: components["schemas"]["inbound_transfers"] | null;
             /** @description Returns `true` if the funds for an InboundTransfer were returned after the InboundTransfer went to the `succeeded` state. */
@@ -31715,25 +31894,25 @@ export interface operations {
                      * @enum {string}
                      */
                     category: "paid" | "promotional";
-                    /** @description ID of the customer to whom the billing credits should be granted. */
+                    /** @description ID of the customer to receive the billing credits. */
                     customer: string;
                     /**
                      * Format: unix-time
-                     * @description The time when the billing credits become effective i.e when they are eligible to be used. Defaults to the current timestamp if not specified.
+                     * @description The time when the billing credits become effective—when they're eligible for use. Defaults to the current timestamp if not specified.
                      */
                     effective_at?: number;
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /**
                      * Format: unix-time
-                     * @description The time when the billing credits will expire. If not specified, the billing credits will never expire.
+                     * @description The time when the billing credits will expire. If not specified, the billing credits don't expire.
                      */
                     expires_at?: number;
-                    /** @description Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object (ex: cost basis) in a structured format. */
+                    /** @description Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object (for example, cost basis) in a structured format. */
                     metadata?: {
                         [key: string]: string;
                     };
-                    /** @description A descriptive name shown in dashboard. */
+                    /** @description A descriptive name shown in the Dashboard. */
                     name?: string;
                 };
             };
@@ -31813,9 +31992,9 @@ export interface operations {
                 "application/x-www-form-urlencoded": {
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
-                    /** @description The time when the billing credits created by this credit grant will expire. If set to empty, the billing credits will never expire. */
+                    /** @description The time when the billing credits created by this credit grant expire. If set to empty, the billing credits never expire. */
                     expires_at?: number | "";
-                    /** @description Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object (ex: cost basis) in a structured format. */
+                    /** @description Set of key-value pairs you can attach to an object. This can be useful for storing additional information about the object (for example, cost basis) in a structured format. */
                     metadata?: {
                         [key: string]: string;
                     };
@@ -31985,7 +32164,7 @@ export interface operations {
                     event_name: string;
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
-                    /** @description A unique identifier for the event. If not provided, one will be generated. We recommend using a globally unique identifier for this. We'll enforce uniqueness within a rolling 24 hour period. */
+                    /** @description A unique identifier for the event. If not provided, one will be generated. We strongly advise using UUID-like identifiers. We will enforce uniqueness within a rolling period of at least 24 hours. The enforcement of uniqueness primarily addresses issues arising from accidental retries or other problems occurring within extremely brief time intervals. This approach helps prevent duplicate entries and ensures data integrity in high-frequency operations. */
                     identifier?: string;
                     /** @description The payload of the event. This must contain the fields corresponding to a meter's `customer_mapping.event_payload_key` (default is `stripe_customer_id`) and `value_settings.event_payload_key` (default is `value`). Read more about the [payload](https://docs.stripe.com/billing/subscriptions/usage-based/recording-usage#payload-key-overrides). */
                     payload: {
@@ -33743,6 +33922,13 @@ export interface operations {
             content: {
                 "application/x-www-form-urlencoded": {
                     /**
+                     * adaptive_pricing_params
+                     * @description Settings for price localization with [Adaptive Pricing](https://docs.stripe.com/payments/checkout/adaptive-pricing).
+                     */
+                    adaptive_pricing?: {
+                        enabled?: boolean;
+                    };
+                    /**
                      * after_expiration_params
                      * @description Configure actions after a Checkout Session has expired.
                      */
@@ -34101,6 +34287,8 @@ export interface operations {
                         };
                         /** payment_method_options_param */
                         bacs_debit?: {
+                            /** payment_method_options_mandate_options_param */
+                            mandate_options?: Record<string, never>;
                             /** @enum {string} */
                             setup_future_usage?: "none" | "off_session" | "on_session";
                         };
@@ -34121,6 +34309,14 @@ export interface operations {
                             installments?: {
                                 enabled?: boolean;
                             };
+                            /** @enum {string} */
+                            request_extended_authorization?: "if_available" | "never";
+                            /** @enum {string} */
+                            request_incremental_authorization?: "if_available" | "never";
+                            /** @enum {string} */
+                            request_multicapture?: "if_available" | "never";
+                            /** @enum {string} */
+                            request_overcapture?: "if_available" | "never";
                             /** @enum {string} */
                             request_three_d_secure?: "any" | "automatic" | "challenge";
                             /** @enum {string} */
@@ -34178,6 +34374,8 @@ export interface operations {
                         /** payment_method_options_param */
                         kakao_pay?: {
                             /** @enum {string} */
+                            capture_method?: "manual";
+                            /** @enum {string} */
                             setup_future_usage?: "none" | "off_session";
                         };
                         /** payment_method_options_param */
@@ -34193,6 +34391,8 @@ export interface operations {
                         };
                         /** payment_method_options_param */
                         kr_card?: {
+                            /** @enum {string} */
+                            capture_method?: "manual";
                             /** @enum {string} */
                             setup_future_usage?: "none" | "off_session";
                         };
@@ -34214,6 +34414,8 @@ export interface operations {
                         /** payment_method_options_param */
                         naver_pay?: {
                             /** @enum {string} */
+                            capture_method?: "manual";
+                            /** @enum {string} */
                             setup_future_usage?: "none" | "off_session";
                         };
                         /** payment_method_options_param */
@@ -34229,7 +34431,10 @@ export interface operations {
                             tos_shown_and_accepted?: boolean;
                         };
                         /** payment_method_options_param */
-                        payco?: Record<string, never>;
+                        payco?: {
+                            /** @enum {string} */
+                            capture_method?: "manual";
+                        };
                         /** payment_method_options_param */
                         paynow?: {
                             /** @enum {string} */
@@ -34256,9 +34461,14 @@ export interface operations {
                             setup_future_usage?: "none" | "off_session";
                         };
                         /** payment_method_options_param */
-                        samsung_pay?: Record<string, never>;
+                        samsung_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "manual";
+                        };
                         /** payment_method_options_param */
                         sepa_debit?: {
+                            /** payment_method_options_mandate_options_param */
+                            mandate_options?: Record<string, never>;
                             /** @enum {string} */
                             setup_future_usage?: "none" | "off_session" | "on_session";
                         };
@@ -34399,7 +34609,7 @@ export interface operations {
                      *     specified on Checkout Sessions in `payment` mode. If blank or `auto`, `pay` is used.
                      * @enum {string}
                      */
-                    submit_type?: "auto" | "book" | "donate" | "pay";
+                    submit_type?: "auto" | "book" | "donate" | "pay" | "subscribe";
                     /**
                      * subscription_data_params
                      * @description A subset of parameters to be passed to subscription creation for Checkout Sessions in `subscription` mode.
@@ -36221,7 +36431,7 @@ export interface operations {
                     /** @description The customer's tax IDs. */
                     tax_id_data?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                     /** @description ID of the test clock to attach to the customer. */
@@ -38355,7 +38565,7 @@ export interface operations {
                                     description?: string;
                                 };
                                 /** @enum {string} */
-                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                                 /** @enum {string} */
                                 request_three_d_secure?: "any" | "automatic" | "challenge";
                             } | "";
@@ -38641,7 +38851,7 @@ export interface operations {
                     } | "";
                     /** @description Indicates if a customer is on or off-session while an invoice payment is attempted. Defaults to `false` (on-session). */
                     off_session?: boolean;
-                    /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](/billing/subscriptions/pause-payment). */
+                    /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment). */
                     pause_collection?: {
                         /** @enum {string} */
                         behavior: "keep_as_draft" | "mark_uncollectible" | "void";
@@ -38688,7 +38898,7 @@ export interface operations {
                                     description?: string;
                                 };
                                 /** @enum {string} */
-                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                                 /** @enum {string} */
                                 request_three_d_secure?: "any" | "automatic" | "challenge";
                             } | "";
@@ -38974,10 +39184,10 @@ export interface operations {
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /**
-                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
+                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `li_vat`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
                      * @enum {string}
                      */
-                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                     /** @description Value of the tax ID. */
                     value: string;
                 };
@@ -39978,7 +40188,7 @@ export interface operations {
                      * @description The link isn't usable after this future timestamp.
                      */
                     expires_at?: number;
-                    /** @description The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `identity_document_downloadable`, `issuing_regulatory_reporting`, `pci_document`, `selfie`, `sigma_scheduled_query`, `tax_document_user_upload`, or `terminal_reader_splashscreen`. */
+                    /** @description The ID of the file. The file's `purpose` must be one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `finance_report_run`, `financial_account_statement`, `identity_document_downloadable`, `issuing_regulatory_reporting`, `pci_document`, `selfie`, `sigma_scheduled_query`, `tax_document_user_upload`, or `terminal_reader_splashscreen`. */
                     file: string;
                     /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
                     metadata?: {
@@ -40107,7 +40317,7 @@ export interface operations {
                 /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
                 limit?: number;
                 /** @description Filter queries by the file purpose. If you don't provide a purpose, the queries return unfiltered files. */
-                purpose?: "account_requirement" | "additional_verification" | "business_icon" | "business_logo" | "customer_signature" | "dispute_evidence" | "document_provider_identity_document" | "finance_report_run" | "identity_document" | "identity_document_downloadable" | "issuing_regulatory_reporting" | "pci_document" | "selfie" | "sigma_scheduled_query" | "tax_document_user_upload" | "terminal_reader_splashscreen";
+                purpose?: "account_requirement" | "additional_verification" | "business_icon" | "business_logo" | "customer_signature" | "dispute_evidence" | "document_provider_identity_document" | "finance_report_run" | "financial_account_statement" | "identity_document" | "identity_document_downloadable" | "issuing_regulatory_reporting" | "pci_document" | "selfie" | "sigma_scheduled_query" | "tax_document_user_upload" | "terminal_reader_splashscreen";
                 /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
                 starting_after?: string;
             };
@@ -41139,7 +41349,7 @@ export interface operations {
                      * @enum {string}
                      */
                     type?: "document" | "id_number";
-                    /** @description The ID of a Verification Flow from the Dashboard. See https://docs.stripe.com/identity/verification-flows. */
+                    /** @description The ID of a verification flow from the Dashboard. See https://docs.stripe.com/identity/verification-flows. */
                     verification_flow?: string;
                 };
             };
@@ -42280,7 +42490,7 @@ export interface operations {
                         tax_exempt?: "" | "exempt" | "none" | "reverse";
                         tax_ids?: {
                             /** @enum {string} */
-                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                             value: string;
                         }[];
                     };
@@ -42656,7 +42866,7 @@ export interface operations {
                     tax_exempt?: "" | "exempt" | "none" | "reverse";
                     tax_ids?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                 };
@@ -43029,7 +43239,7 @@ export interface operations {
                     tax_exempt?: "" | "exempt" | "none" | "reverse";
                     tax_ids?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                 };
@@ -43774,7 +43984,7 @@ export interface operations {
                                 percentage: number;
                                 state?: string;
                                 /** @enum {string} */
-                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
                             };
                             taxable_amount: number;
                         }[] | "";
@@ -43983,7 +44193,7 @@ export interface operations {
                             percentage: number;
                             state?: string;
                             /** @enum {string} */
-                            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+                            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
                         };
                         taxable_amount: number;
                     }[] | "";
@@ -44262,7 +44472,7 @@ export interface operations {
                                 percentage: number;
                                 state?: string;
                                 /** @enum {string} */
-                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
                             };
                             taxable_amount: number;
                         }[] | "";
@@ -46856,7 +47066,7 @@ export interface operations {
                      *
                      *     If you omit this parameter with `confirm=true`, `customer.default_source` attaches as this PaymentIntent's payment instrument to improve migration for users of the Charges API. We recommend that you explicitly provide the `payment_method` moving forward. */
                     payment_method?: string;
-                    /** @description The ID of the payment method configuration to use with this PaymentIntent. */
+                    /** @description The ID of the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) to use with this PaymentIntent. */
                     payment_method_configuration?: string;
                     /**
                      * payment_method_data_params
@@ -47130,7 +47340,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_extended_authorization?: "if_available" | "never";
                             /** @enum {string} */
@@ -47380,7 +47590,7 @@ export interface operations {
                             setup_future_usage?: "none";
                         } | "";
                     };
-                    /** @description The list of payment method types (for example, a card) that this PaymentIntent can use. If you don't provide this, it defaults to ["card"]. Use `automatic_payment_methods` to manage payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods). */
+                    /** @description The list of payment method types (for example, a card) that this PaymentIntent can use. If you don't provide this, Stripe will dynamically show relevant payment methods from your [payment method settings](https://dashboard.stripe.com/settings/payment_methods). */
                     payment_method_types?: string[];
                     /**
                      * radar_options_with_hidden_options
@@ -47599,7 +47809,7 @@ export interface operations {
                     } | "";
                     /** @description ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods/transitioning#compatibility) object) to attach to this PaymentIntent. To unset this field to null, pass in an empty string. */
                     payment_method?: string;
-                    /** @description The ID of the payment method configuration to use with this PaymentIntent. */
+                    /** @description The ID of the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) to use with this PaymentIntent. */
                     payment_method_configuration?: string;
                     /**
                      * payment_method_data_params
@@ -47873,7 +48083,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_extended_authorization?: "if_available" | "never";
                             /** @enum {string} */
@@ -48678,7 +48888,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_extended_authorization?: "if_available" | "never";
                             /** @enum {string} */
@@ -49388,7 +49598,7 @@ export interface operations {
                      * @description Describes the type of transaction being performed in order to customize relevant text on the page, such as the submit button. Changing this value will also affect the hostname in the [url](https://stripe.com/docs/api/payment_links/payment_links/object#url) property (example: `donate.stripe.com`).
                      * @enum {string}
                      */
-                    submit_type?: "auto" | "book" | "donate" | "pay";
+                    submit_type?: "auto" | "book" | "donate" | "pay" | "subscribe";
                     /**
                      * subscription_data_params
                      * @description When creating a subscription, the specified configuration data will be used. There must be at least one line item with a recurring price to use `subscription_data`.
@@ -49683,6 +49893,11 @@ export interface operations {
                     shipping_address_collection?: {
                         allowed_countries: ("AC" | "AD" | "AE" | "AF" | "AG" | "AI" | "AL" | "AM" | "AO" | "AQ" | "AR" | "AT" | "AU" | "AW" | "AX" | "AZ" | "BA" | "BB" | "BD" | "BE" | "BF" | "BG" | "BH" | "BI" | "BJ" | "BL" | "BM" | "BN" | "BO" | "BQ" | "BR" | "BS" | "BT" | "BV" | "BW" | "BY" | "BZ" | "CA" | "CD" | "CF" | "CG" | "CH" | "CI" | "CK" | "CL" | "CM" | "CN" | "CO" | "CR" | "CV" | "CW" | "CY" | "CZ" | "DE" | "DJ" | "DK" | "DM" | "DO" | "DZ" | "EC" | "EE" | "EG" | "EH" | "ER" | "ES" | "ET" | "FI" | "FJ" | "FK" | "FO" | "FR" | "GA" | "GB" | "GD" | "GE" | "GF" | "GG" | "GH" | "GI" | "GL" | "GM" | "GN" | "GP" | "GQ" | "GR" | "GS" | "GT" | "GU" | "GW" | "GY" | "HK" | "HN" | "HR" | "HT" | "HU" | "ID" | "IE" | "IL" | "IM" | "IN" | "IO" | "IQ" | "IS" | "IT" | "JE" | "JM" | "JO" | "JP" | "KE" | "KG" | "KH" | "KI" | "KM" | "KN" | "KR" | "KW" | "KY" | "KZ" | "LA" | "LB" | "LC" | "LI" | "LK" | "LR" | "LS" | "LT" | "LU" | "LV" | "LY" | "MA" | "MC" | "MD" | "ME" | "MF" | "MG" | "MK" | "ML" | "MM" | "MN" | "MO" | "MQ" | "MR" | "MS" | "MT" | "MU" | "MV" | "MW" | "MX" | "MY" | "MZ" | "NA" | "NC" | "NE" | "NG" | "NI" | "NL" | "NO" | "NP" | "NR" | "NU" | "NZ" | "OM" | "PA" | "PE" | "PF" | "PG" | "PH" | "PK" | "PL" | "PM" | "PN" | "PR" | "PS" | "PT" | "PY" | "QA" | "RE" | "RO" | "RS" | "RU" | "RW" | "SA" | "SB" | "SC" | "SE" | "SG" | "SH" | "SI" | "SJ" | "SK" | "SL" | "SM" | "SN" | "SO" | "SR" | "SS" | "ST" | "SV" | "SX" | "SZ" | "TA" | "TC" | "TD" | "TF" | "TG" | "TH" | "TJ" | "TK" | "TL" | "TM" | "TN" | "TO" | "TR" | "TT" | "TV" | "TW" | "TZ" | "UA" | "UG" | "US" | "UY" | "UZ" | "VA" | "VC" | "VE" | "VG" | "VN" | "VU" | "WF" | "WS" | "XK" | "YE" | "YT" | "ZA" | "ZM" | "ZW" | "ZZ")[];
                     } | "";
+                    /**
+                     * @description Describes the type of transaction being performed in order to customize relevant text on the page, such as the submit button. Changing this value will also affect the hostname in the [url](https://stripe.com/docs/api/payment_links/payment_links/object#url) property (example: `donate.stripe.com`).
+                     * @enum {string}
+                     */
+                    submit_type?: "auto" | "book" | "donate" | "pay" | "subscribe";
                     /**
                      * subscription_data_update_params
                      * @description When creating a subscription, the specified configuration data will be used. There must be at least one line item with a recurring price to use `subscription_data`.
@@ -55543,7 +55758,7 @@ export interface operations {
                     on_behalf_of?: string;
                     /** @description ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. */
                     payment_method?: string;
-                    /** @description The ID of the payment method configuration to use with this SetupIntent. */
+                    /** @description The ID of the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) to use with this SetupIntent. */
                     payment_method_configuration?: string;
                     /**
                      * payment_method_data_params
@@ -55759,7 +55974,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_three_d_secure?: "any" | "automatic" | "challenge";
                             /** setup_intent_payment_method_options_param */
@@ -55823,7 +56038,7 @@ export interface operations {
                             verification_method?: "automatic" | "instant" | "microdeposits";
                         };
                     };
-                    /** @description The list of payment method types (for example, card) that this SetupIntent can use. If you don't provide this, it defaults to ["card"]. */
+                    /** @description The list of payment method types (for example, card) that this SetupIntent can use. If you don't provide this, Stripe will dynamically show relevant payment methods from your [payment method settings](https://dashboard.stripe.com/settings/payment_methods). */
                     payment_method_types?: string[];
                     /** @description The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site. To redirect to a mobile application, you can alternatively supply an application URI scheme. This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm). */
                     return_url?: string;
@@ -55940,7 +56155,7 @@ export interface operations {
                     } | "";
                     /** @description ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent. To unset this field to null, pass in an empty string. */
                     payment_method?: string;
-                    /** @description The ID of the payment method configuration to use with this SetupIntent. */
+                    /** @description The ID of the [payment method configuration](https://stripe.com/docs/api/payment_method_configurations) to use with this SetupIntent. */
                     payment_method_configuration?: string;
                     /**
                      * payment_method_data_params
@@ -56156,7 +56371,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_three_d_secure?: "any" | "automatic" | "challenge";
                             /** setup_intent_payment_method_options_param */
@@ -56220,7 +56435,7 @@ export interface operations {
                             verification_method?: "automatic" | "instant" | "microdeposits";
                         };
                     };
-                    /** @description The list of payment method types (for example, card) that this SetupIntent can set up. If you don't provide this array, it defaults to ["card"]. */
+                    /** @description The list of payment method types (for example, card) that this SetupIntent can set up. If you don't provide this, Stripe will dynamically show relevant payment methods from your [payment method settings](https://dashboard.stripe.com/settings/payment_methods). */
                     payment_method_types?: string[];
                 };
             };
@@ -56552,7 +56767,7 @@ export interface operations {
                                 supported_types?: "india"[];
                             };
                             /** @enum {string} */
-                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                            network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                             /** @enum {string} */
                             request_three_d_secure?: "any" | "automatic" | "challenge";
                             /** setup_intent_payment_method_options_param */
@@ -58881,7 +59096,7 @@ export interface operations {
                                     description?: string;
                                 };
                                 /** @enum {string} */
-                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                                 /** @enum {string} */
                                 request_three_d_secure?: "any" | "automatic" | "challenge";
                             } | "";
@@ -59223,7 +59438,7 @@ export interface operations {
                     off_session?: boolean;
                     /** @description The account on behalf of which to charge, for each of the subscription's invoices. */
                     on_behalf_of?: string | "";
-                    /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](/billing/subscriptions/pause-payment). */
+                    /** @description If specified, payment collection for this subscription will be paused. Note that the subscription status will be unchanged and will not be updated to `paused`. Learn more about [pausing collection](https://stripe.com/docs/billing/subscriptions/pause-payment). */
                     pause_collection?: {
                         /** @enum {string} */
                         behavior: "keep_as_draft" | "mark_uncollectible" | "void";
@@ -59270,7 +59485,7 @@ export interface operations {
                                     description?: string;
                                 };
                                 /** @enum {string} */
-                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "mastercard" | "unionpay" | "unknown" | "visa";
+                                network?: "amex" | "cartes_bancaires" | "diners" | "discover" | "eftpos_au" | "girocard" | "interac" | "jcb" | "link" | "mastercard" | "unionpay" | "unknown" | "visa";
                                 /** @enum {string} */
                                 request_three_d_secure?: "any" | "automatic" | "challenge";
                             } | "";
@@ -59539,7 +59754,7 @@ export interface operations {
                         ip_address?: string;
                         tax_ids?: {
                             /** @enum {string} */
-                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                             value: string;
                         }[];
                         /** @enum {string} */
@@ -60854,10 +61069,10 @@ export interface operations {
                         type: "account" | "application" | "customer" | "self";
                     };
                     /**
-                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
+                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `li_vat`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
                      * @enum {string}
                      */
-                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
+                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "li_vat" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                     /** @description Value of the tax ID. */
                     value: string;
                 };
@@ -61057,7 +61272,7 @@ export interface operations {
                      * @description The high-level tax type, such as `vat` or `sales_tax`.
                      * @enum {string}
                      */
-                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
                 };
             };
         };
@@ -61154,7 +61369,7 @@ export interface operations {
                      * @description The high-level tax type, such as `vat` or `sales_tax`.
                      * @enum {string}
                      */
-                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
+                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "service_tax" | "vat";
                 };
             };
         };
@@ -62671,7 +62886,7 @@ export interface operations {
             content: {
                 "application/x-www-form-urlencoded": {
                     /** @description The total amount to attempt to authorize. This amount is in the provided currency, or defaults to the card's currency, and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
-                    amount: number;
+                    amount?: number;
                     /**
                      * amount_details_specs
                      * @description Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
@@ -62746,6 +62961,10 @@ export interface operations {
                     };
                     /** @description If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization. */
                     is_amount_controllable?: boolean;
+                    /** @description The total amount to attempt to authorize. This amount is in the provided merchant currency, and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). */
+                    merchant_amount?: number;
+                    /** @description The currency of the authorization. If not provided, defaults to the currency of the card. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+                    merchant_currency?: string;
                     /**
                      * merchant_data_specs
                      * @description Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
@@ -63056,6 +63275,46 @@ export interface operations {
                         /** Format: decimal */
                         unit_cost_decimal?: string;
                     };
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["issuing.authorization"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostTestHelpersIssuingAuthorizationsAuthorizationFraudChallengesRespond: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                authorization: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description Whether to simulate the user confirming that the transaction was legitimate (true) or telling Stripe that it was fraudulent (false). */
+                    confirmed: boolean;
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
                 };
             };
         };
@@ -64172,7 +64431,7 @@ export interface operations {
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /**
-                     * failure_details_params
+                     * failure_details_param
                      * @description Details about a failed InboundTransfer.
                      */
                     failure_details?: {

--- a/packages/openapi-typescript/examples/stripe-api.ts
+++ b/packages/openapi-typescript/examples/stripe-api.ts
@@ -11,7 +11,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an account.</p> */
+        /**
+         * Retrieve account
+         * @description <p>Retrieves the details of an account.</p>
+         */
         get: operations["GetAccount"];
         put?: never;
         post?: never;
@@ -30,7 +33,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.</p> */
+        /**
+         * Create an account link
+         * @description <p>Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.</p>
+         */
         post: operations["PostAccountLinks"];
         delete?: never;
         options?: never;
@@ -47,7 +53,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a AccountSession object that includes a single-use token that the platform can use on their front-end to grant client-side API access.</p> */
+        /**
+         * Create an Account Session
+         * @description <p>Creates a AccountSession object that includes a single-use token that the platform can use on their front-end to grant client-side API access.</p>
+         */
         post: operations["PostAccountSessions"];
         delete?: never;
         options?: never;
@@ -62,7 +71,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of accounts connected to your platform via <a href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.</p> */
+        /**
+         * List all connected accounts
+         * @description <p>Returns a list of accounts connected to your platform via <a href="/docs/connect">Connect</a>. If you’re not a platform, the list is empty.</p>
+         */
         get: operations["GetAccounts"];
         put?: never;
         /** @description <p>With <a href="/docs/connect">Connect</a>, you can create Stripe accounts for your users.
@@ -85,10 +97,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an account.</p> */
+        /**
+         * Retrieve account
+         * @description <p>Retrieves the details of an account.</p>
+         */
         get: operations["GetAccountsAccount"];
         put?: never;
-        /** @description <p>Updates a <a href="/connect/accounts">connected account</a> by setting the values of the parameters passed. Any parameters not provided are
+        /**
+         * Update an account
+         * @description <p>Updates a <a href="/connect/accounts">connected account</a> by setting the values of the parameters passed. Any parameters not provided are
          *     left unchanged.</p>
          *
          *     <p>For accounts where <a href="/api/accounts/object#account_object-controller-requirement_collection">controller.requirement_collection</a>
@@ -100,15 +117,19 @@ export interface paths {
          *     after which some properties can no longer be updated.</p>
          *
          *     <p>To update your own account, use the <a href="https://dashboard.stripe.com/settings/account">Dashboard</a>. Refer to our
-         *     <a href="/docs/connect/updating-accounts">Connect</a> documentation to learn more about updating accounts.</p> */
+         *     <a href="/docs/connect/updating-accounts">Connect</a> documentation to learn more about updating accounts.</p>
+         */
         post: operations["PostAccountsAccount"];
-        /** @description <p>With <a href="/connect">Connect</a>, you can delete accounts you manage.</p>
+        /**
+         * Delete an account
+         * @description <p>With <a href="/connect">Connect</a>, you can delete accounts you manage.</p>
          *
          *     <p>Test-mode accounts can be deleted at any time.</p>
          *
          *     <p>Live-mode accounts where Stripe is responsible for negative account balances cannot be deleted, which includes Standard accounts. Live-mode accounts where your platform is liable for negative account balances, which includes Custom and Express accounts, can be deleted when all <a href="/api/balance/balance_object">balances</a> are zero.</p>
          *
-         *     <p>If you want to delete your own account, use the <a href="https://dashboard.stripe.com/settings/account">account information tab in your account settings</a> instead.</p> */
+         *     <p>If you want to delete your own account, use the <a href="https://dashboard.stripe.com/settings/account">account information tab in your account settings</a> instead.</p>
+         */
         delete: operations["DeleteAccountsAccount"];
         options?: never;
         head?: never;
@@ -124,7 +145,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Create an external account for a given account.</p> */
+        /**
+         * Create an external account
+         * @description <p>Create an external account for a given account.</p>
+         */
         post: operations["PostAccountsAccountBankAccounts"];
         delete?: never;
         options?: never;
@@ -139,7 +163,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a specified external account for a given account.</p> */
+        /**
+         * Retrieve an external account
+         * @description <p>Retrieve a specified external account for a given account.</p>
+         */
         get: operations["GetAccountsAccountBankAccountsId"];
         put?: never;
         /** @description <p>Updates the metadata, account holder name, account holder type of a bank account belonging to
@@ -151,7 +178,10 @@ export interface paths {
          *     <p>You can re-enable a disabled bank account by performing an update call without providing any
          *     arguments or changes.</p> */
         post: operations["PostAccountsAccountBankAccountsId"];
-        /** @description <p>Delete a specified external account for a given account.</p> */
+        /**
+         * Delete an external account
+         * @description <p>Delete a specified external account for a given account.</p>
+         */
         delete: operations["DeleteAccountsAccountBankAccountsId"];
         options?: never;
         head?: never;
@@ -165,7 +195,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.</p> */
+        /**
+         * List all account capabilities
+         * @description <p>Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.</p>
+         */
         get: operations["GetAccountsAccountCapabilities"];
         put?: never;
         post?: never;
@@ -182,10 +215,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves information about the specified Account Capability.</p> */
+        /**
+         * Retrieve an Account Capability
+         * @description <p>Retrieves information about the specified Account Capability.</p>
+         */
         get: operations["GetAccountsAccountCapabilitiesCapability"];
         put?: never;
-        /** @description <p>Updates an existing Account Capability. Request or remove a capability by updating its <code>requested</code> parameter.</p> */
+        /**
+         * Update an Account Capability
+         * @description <p>Updates an existing Account Capability. Request or remove a capability by updating its <code>requested</code> parameter.</p>
+         */
         post: operations["PostAccountsAccountCapabilitiesCapability"];
         delete?: never;
         options?: never;
@@ -200,10 +239,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List external accounts for an account.</p> */
+        /**
+         * List all external accounts
+         * @description <p>List external accounts for an account.</p>
+         */
         get: operations["GetAccountsAccountExternalAccounts"];
         put?: never;
-        /** @description <p>Create an external account for a given account.</p> */
+        /**
+         * Create an external account
+         * @description <p>Create an external account for a given account.</p>
+         */
         post: operations["PostAccountsAccountExternalAccounts"];
         delete?: never;
         options?: never;
@@ -218,7 +263,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a specified external account for a given account.</p> */
+        /**
+         * Retrieve an external account
+         * @description <p>Retrieve a specified external account for a given account.</p>
+         */
         get: operations["GetAccountsAccountExternalAccountsId"];
         put?: never;
         /** @description <p>Updates the metadata, account holder name, account holder type of a bank account belonging to
@@ -230,7 +278,10 @@ export interface paths {
          *     <p>You can re-enable a disabled bank account by performing an update call without providing any
          *     arguments or changes.</p> */
         post: operations["PostAccountsAccountExternalAccountsId"];
-        /** @description <p>Delete a specified external account for a given account.</p> */
+        /**
+         * Delete an external account
+         * @description <p>Delete a specified external account for a given account.</p>
+         */
         delete: operations["DeleteAccountsAccountExternalAccountsId"];
         options?: never;
         head?: never;
@@ -246,9 +297,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a single-use login link for a connected account to access the Express Dashboard.</p>
+        /**
+         * Create a login link
+         * @description <p>Creates a login link for a connected account to access the Express Dashboard.</p>
          *
-         *     <p><strong>You can only create login links for accounts that use the <a href="/connect/express-dashboard">Express Dashboard</a> and are connected to your platform</strong>.</p> */
+         *     <p><strong>You can only create login links for accounts that use the <a href="/connect/express-dashboard">Express Dashboard</a> and are connected to your platform</strong>.</p>
+         */
         post: operations["PostAccountsAccountLoginLinks"];
         delete?: never;
         options?: never;
@@ -263,10 +317,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of people associated with the account’s legal entity. The people are returned sorted by creation date, with the most recent people appearing first.</p> */
+        /**
+         * List all persons
+         * @description <p>Returns a list of people associated with the account’s legal entity. The people are returned sorted by creation date, with the most recent people appearing first.</p>
+         */
         get: operations["GetAccountsAccountPeople"];
         put?: never;
-        /** @description <p>Creates a new person.</p> */
+        /**
+         * Create a person
+         * @description <p>Creates a new person.</p>
+         */
         post: operations["PostAccountsAccountPeople"];
         delete?: never;
         options?: never;
@@ -281,12 +341,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an existing person.</p> */
+        /**
+         * Retrieve a person
+         * @description <p>Retrieves an existing person.</p>
+         */
         get: operations["GetAccountsAccountPeoplePerson"];
         put?: never;
-        /** @description <p>Updates an existing person.</p> */
+        /**
+         * Update a person
+         * @description <p>Updates an existing person.</p>
+         */
         post: operations["PostAccountsAccountPeoplePerson"];
-        /** @description <p>Deletes an existing person’s relationship to the account’s legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the <code>account_opener</code>. If your integration is using the <code>executive</code> parameter, you cannot delete the only verified <code>executive</code> on file.</p> */
+        /**
+         * Delete a person
+         * @description <p>Deletes an existing person’s relationship to the account’s legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the <code>account_opener</code>. If your integration is using the <code>executive</code> parameter, you cannot delete the only verified <code>executive</code> on file.</p>
+         */
         delete: operations["DeleteAccountsAccountPeoplePerson"];
         options?: never;
         head?: never;
@@ -300,10 +369,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of people associated with the account’s legal entity. The people are returned sorted by creation date, with the most recent people appearing first.</p> */
+        /**
+         * List all persons
+         * @description <p>Returns a list of people associated with the account’s legal entity. The people are returned sorted by creation date, with the most recent people appearing first.</p>
+         */
         get: operations["GetAccountsAccountPersons"];
         put?: never;
-        /** @description <p>Creates a new person.</p> */
+        /**
+         * Create a person
+         * @description <p>Creates a new person.</p>
+         */
         post: operations["PostAccountsAccountPersons"];
         delete?: never;
         options?: never;
@@ -318,12 +393,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an existing person.</p> */
+        /**
+         * Retrieve a person
+         * @description <p>Retrieves an existing person.</p>
+         */
         get: operations["GetAccountsAccountPersonsPerson"];
         put?: never;
-        /** @description <p>Updates an existing person.</p> */
+        /**
+         * Update a person
+         * @description <p>Updates an existing person.</p>
+         */
         post: operations["PostAccountsAccountPersonsPerson"];
-        /** @description <p>Deletes an existing person’s relationship to the account’s legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the <code>account_opener</code>. If your integration is using the <code>executive</code> parameter, you cannot delete the only verified <code>executive</code> on file.</p> */
+        /**
+         * Delete a person
+         * @description <p>Deletes an existing person’s relationship to the account’s legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the <code>account_opener</code>. If your integration is using the <code>executive</code> parameter, you cannot delete the only verified <code>executive</code> on file.</p>
+         */
         delete: operations["DeleteAccountsAccountPersonsPerson"];
         options?: never;
         head?: never;
@@ -339,9 +423,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>With <a href="/connect">Connect</a>, you can reject accounts that you have flagged as suspicious.</p>
+        /**
+         * Reject an account
+         * @description <p>With <a href="/connect">Connect</a>, you can reject accounts that you have flagged as suspicious.</p>
          *
-         *     <p>Only accounts where your platform is liable for negative account balances, which includes Custom and Express accounts, can be rejected. Test-mode accounts can be rejected at any time. Live-mode accounts can only be rejected after all balances are zero.</p> */
+         *     <p>Only accounts where your platform is liable for negative account balances, which includes Custom and Express accounts, can be rejected. Test-mode accounts can be rejected at any time. Live-mode accounts can only be rejected after all balances are zero.</p>
+         */
         post: operations["PostAccountsAccountReject"];
         delete?: never;
         options?: never;
@@ -392,7 +479,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.</p> */
+        /**
+         * List all application fees
+         * @description <p>Returns a list of application fees you’ve previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.</p>
+         */
         get: operations["GetApplicationFees"];
         put?: never;
         post?: never;
@@ -409,12 +499,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.</p> */
+        /**
+         * Retrieve an application fee refund
+         * @description <p>By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.</p>
+         */
         get: operations["GetApplicationFeesFeeRefundsId"];
         put?: never;
-        /** @description <p>Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+        /**
+         * Update an application fee refund
+         * @description <p>Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
          *
-         *     <p>This request only accepts metadata as an argument.</p> */
+         *     <p>This request only accepts metadata as an argument.</p>
+         */
         post: operations["PostApplicationFeesFeeRefundsId"];
         delete?: never;
         options?: never;
@@ -429,7 +525,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.</p> */
+        /**
+         * Retrieve an application fee
+         * @description <p>Retrieves the details of an application fee that your account has collected. The same information is returned when refunding the application fee.</p>
+         */
         get: operations["GetApplicationFeesId"];
         put?: never;
         post?: never;
@@ -462,10 +561,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p> */
+        /**
+         * List all application fee refunds
+         * @description <p>You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p>
+         */
         get: operations["GetApplicationFeesIdRefunds"];
         put?: never;
-        /** @description <p>Refunds an application fee that has previously been collected but not yet refunded.
+        /**
+         * Create an application fee refund
+         * @description <p>Refunds an application fee that has previously been collected but not yet refunded.
          *     Funds will be refunded to the Stripe account from which the fee was originally collected.</p>
          *
          *     <p>You can optionally refund only part of an application fee.
@@ -473,7 +577,8 @@ export interface paths {
          *
          *     <p>Once entirely refunded, an application fee can’t be refunded again.
          *     This method will raise an error when called on an already-refunded application fee,
-         *     or when trying to refund more money than is left on an application fee.</p> */
+         *     or when trying to refund more money than is left on an application fee.</p>
+         */
         post: operations["PostApplicationFeesIdRefunds"];
         delete?: never;
         options?: never;
@@ -488,10 +593,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List all secrets stored on the given scope.</p> */
+        /**
+         * List secrets
+         * @description <p>List all secrets stored on the given scope.</p>
+         */
         get: operations["GetAppsSecrets"];
         put?: never;
-        /** @description <p>Create or replace a secret in the secret store.</p> */
+        /**
+         * Set a Secret
+         * @description <p>Create or replace a secret in the secret store.</p>
+         */
         post: operations["PostAppsSecrets"];
         delete?: never;
         options?: never;
@@ -508,7 +619,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Deletes a secret from the secret store by name and scope.</p> */
+        /**
+         * Delete a Secret
+         * @description <p>Deletes a secret from the secret store by name and scope.</p>
+         */
         post: operations["PostAppsSecretsDelete"];
         delete?: never;
         options?: never;
@@ -523,7 +637,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Finds a secret in the secret store by name and scope.</p> */
+        /**
+         * Find a Secret
+         * @description <p>Finds a secret in the secret store by name and scope.</p>
+         */
         get: operations["GetAppsSecretsFind"];
         put?: never;
         post?: never;
@@ -540,8 +657,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the current account balance, based on the authentication that was used to make the request.
-         *      For a sample request, see <a href="/docs/connect/account-balances#accounting-for-negative-balances">Accounting for negative balances</a>.</p> */
+        /**
+         * Retrieve balance
+         * @description <p>Retrieves the current account balance, based on the authentication that was used to make the request.
+         *      For a sample request, see <a href="/docs/connect/account-balances#accounting-for-negative-balances">Accounting for negative balances</a>.</p>
+         */
         get: operations["GetBalance"];
         put?: never;
         post?: never;
@@ -558,9 +678,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.</p>
+        /**
+         * List all balance transactions
+         * @description <p>Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.</p>
          *
-         *     <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p> */
+         *     <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p>
+         */
         get: operations["GetBalanceHistory"];
         put?: never;
         post?: never;
@@ -577,9 +700,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the balance transaction with the given ID.</p>
+        /**
+         * Retrieve a balance transaction
+         * @description <p>Retrieves the balance transaction with the given ID.</p>
          *
-         *     <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.</p> */
+         *     <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.</p>
+         */
         get: operations["GetBalanceHistoryId"];
         put?: never;
         post?: never;
@@ -596,9 +722,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.</p>
+        /**
+         * List all balance transactions
+         * @description <p>Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.</p>
          *
-         *     <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p> */
+         *     <p>Note that this endpoint was previously called “Balance history” and used the path <code>/v1/balance/history</code>.</p>
+         */
         get: operations["GetBalanceTransactions"];
         put?: never;
         post?: never;
@@ -615,9 +744,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the balance transaction with the given ID.</p>
+        /**
+         * Retrieve a balance transaction
+         * @description <p>Retrieves the balance transaction with the given ID.</p>
          *
-         *     <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.</p> */
+         *     <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.</p>
+         */
         get: operations["GetBalanceTransactionsId"];
         put?: never;
         post?: never;
@@ -634,10 +766,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists billing active and inactive alerts</p> */
+        /**
+         * List billing alerts
+         * @description <p>Lists billing active and inactive alerts</p>
+         */
         get: operations["GetBillingAlerts"];
         put?: never;
-        /** @description <p>Creates a billing alert</p> */
+        /**
+         * Create a billing alert
+         * @description <p>Creates a billing alert</p>
+         */
         post: operations["PostBillingAlerts"];
         delete?: never;
         options?: never;
@@ -652,7 +790,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a billing alert given an ID</p> */
+        /**
+         * Retrieve a billing alert
+         * @description <p>Retrieves a billing alert given an ID</p>
+         */
         get: operations["GetBillingAlertsId"];
         put?: never;
         post?: never;
@@ -671,7 +812,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Reactivates this alert, allowing it to trigger again.</p> */
+        /**
+         * Activate a billing alert
+         * @description <p>Reactivates this alert, allowing it to trigger again.</p>
+         */
         post: operations["PostBillingAlertsIdActivate"];
         delete?: never;
         options?: never;
@@ -688,7 +832,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Archives this alert, removing it from the list view and APIs. This is non-reversible.</p> */
+        /**
+         * Archive a billing alert
+         * @description <p>Archives this alert, removing it from the list view and APIs. This is non-reversible.</p>
+         */
         post: operations["PostBillingAlertsIdArchive"];
         delete?: never;
         options?: never;
@@ -705,8 +852,159 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Deactivates this alert, preventing it from triggering.</p> */
+        /**
+         * Deactivate a billing alert
+         * @description <p>Deactivates this alert, preventing it from triggering.</p>
+         */
         post: operations["PostBillingAlertsIdDeactivate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_balance_summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve the credit balance summary for a customer
+         * @description <p>Retrieves the credit balance summary for a customer</p>
+         */
+        get: operations["GetBillingCreditBalanceSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_balance_transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List credit balance transactions
+         * @description <p>Retrieve a list of credit balance transactions</p>
+         */
+        get: operations["GetBillingCreditBalanceTransactions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_balance_transactions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve a credit balance transaction
+         * @description <p>Retrieves a credit balance transaction</p>
+         */
+        get: operations["GetBillingCreditBalanceTransactionsId"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List credit grants
+         * @description <p>Retrieve a list of credit grants</p>
+         */
+        get: operations["GetBillingCreditGrants"];
+        put?: never;
+        /**
+         * Create a credit grant
+         * @description <p>Creates a credit grant</p>
+         */
+        post: operations["PostBillingCreditGrants"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_grants/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Retrieve a credit grant
+         * @description <p>Retrieves a credit grant</p>
+         */
+        get: operations["GetBillingCreditGrantsId"];
+        put?: never;
+        /**
+         * Update a credit grant
+         * @description <p>Updates a credit grant</p>
+         */
+        post: operations["PostBillingCreditGrantsId"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_grants/{id}/expire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Expire a credit grant
+         * @description <p>Expires a credit grant</p>
+         */
+        post: operations["PostBillingCreditGrantsIdExpire"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/billing/credit_grants/{id}/void": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Void a credit grant
+         * @description <p>Voids a credit grant</p>
+         */
+        post: operations["PostBillingCreditGrantsIdVoid"];
         delete?: never;
         options?: never;
         head?: never;
@@ -722,7 +1020,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a billing meter event adjustment</p> */
+        /**
+         * Create a billing meter event adjustment
+         * @description <p>Creates a billing meter event adjustment</p>
+         */
         post: operations["PostBillingMeterEventAdjustments"];
         delete?: never;
         options?: never;
@@ -739,7 +1040,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a billing meter event</p> */
+        /**
+         * Create a billing meter event
+         * @description <p>Creates a billing meter event</p>
+         */
         post: operations["PostBillingMeterEvents"];
         delete?: never;
         options?: never;
@@ -754,10 +1058,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a list of billing meters.</p> */
+        /**
+         * List billing meters
+         * @description <p>Retrieve a list of billing meters.</p>
+         */
         get: operations["GetBillingMeters"];
         put?: never;
-        /** @description <p>Creates a billing meter</p> */
+        /**
+         * Create a billing meter
+         * @description <p>Creates a billing meter</p>
+         */
         post: operations["PostBillingMeters"];
         delete?: never;
         options?: never;
@@ -772,10 +1082,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a billing meter given an ID</p> */
+        /**
+         * Retrieve a billing meter
+         * @description <p>Retrieves a billing meter given an ID</p>
+         */
         get: operations["GetBillingMetersId"];
         put?: never;
-        /** @description <p>Updates a billing meter</p> */
+        /**
+         * Update a billing meter
+         * @description <p>Updates a billing meter</p>
+         */
         post: operations["PostBillingMetersId"];
         delete?: never;
         options?: never;
@@ -792,7 +1108,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Deactivates a billing meter</p> */
+        /**
+         * Deactivate a billing meter
+         * @description <p>Deactivates a billing meter</p>
+         */
         post: operations["PostBillingMetersIdDeactivate"];
         delete?: never;
         options?: never;
@@ -807,7 +1126,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a list of billing meter event summaries.</p> */
+        /**
+         * List billing meter event summaries
+         * @description <p>Retrieve a list of billing meter event summaries.</p>
+         */
         get: operations["GetBillingMetersIdEventSummaries"];
         put?: never;
         post?: never;
@@ -826,7 +1148,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Reactivates a billing meter</p> */
+        /**
+         * Reactivate a billing meter
+         * @description <p>Reactivates a billing meter</p>
+         */
         post: operations["PostBillingMetersIdReactivate"];
         delete?: never;
         options?: never;
@@ -841,10 +1166,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of configurations that describe the functionality of the customer portal.</p> */
+        /**
+         * List portal configurations
+         * @description <p>Returns a list of configurations that describe the functionality of the customer portal.</p>
+         */
         get: operations["GetBillingPortalConfigurations"];
         put?: never;
-        /** @description <p>Creates a configuration that describes the functionality and behavior of a PortalSession</p> */
+        /**
+         * Create a portal configuration
+         * @description <p>Creates a configuration that describes the functionality and behavior of a PortalSession</p>
+         */
         post: operations["PostBillingPortalConfigurations"];
         delete?: never;
         options?: never;
@@ -859,10 +1190,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a configuration that describes the functionality of the customer portal.</p> */
+        /**
+         * Retrieve a portal configuration
+         * @description <p>Retrieves a configuration that describes the functionality of the customer portal.</p>
+         */
         get: operations["GetBillingPortalConfigurationsConfiguration"];
         put?: never;
-        /** @description <p>Updates a configuration that describes the functionality of the customer portal.</p> */
+        /**
+         * Update a portal configuration
+         * @description <p>Updates a configuration that describes the functionality of the customer portal.</p>
+         */
         post: operations["PostBillingPortalConfigurationsConfiguration"];
         delete?: never;
         options?: never;
@@ -879,7 +1216,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a session of the customer portal.</p> */
+        /**
+         * Create a portal session
+         * @description <p>Creates a session of the customer portal.</p>
+         */
         post: operations["PostBillingPortalSessions"];
         delete?: never;
         options?: never;
@@ -894,7 +1234,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of charges you’ve previously created. The charges are returned in sorted order, with the most recent charges appearing first.</p> */
+        /**
+         * List all charges
+         * @description <p>Returns a list of charges you’ve previously created. The charges are returned in sorted order, with the most recent charges appearing first.</p>
+         */
         get: operations["GetCharges"];
         put?: never;
         /** @description <p>This method is no longer recommended—use the <a href="/docs/api/payment_intents">Payment Intents API</a>
@@ -914,10 +1257,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for charges you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search charges
+         * @description <p>Search for charges you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetChargesSearch"];
         put?: never;
         post?: never;
@@ -934,10 +1280,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.</p> */
+        /**
+         * Retrieve a charge
+         * @description <p>Retrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.</p>
+         */
         get: operations["GetChargesCharge"];
         put?: never;
-        /** @description <p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a charge
+         * @description <p>Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostChargesCharge"];
         delete?: never;
         options?: never;
@@ -954,11 +1306,14 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Capture the payment of an existing, uncaptured charge that was created with the <code>capture</code> option set to false.</p>
+        /**
+         * Capture a payment
+         * @description <p>Capture the payment of an existing, uncaptured charge that was created with the <code>capture</code> option set to false.</p>
          *
          *     <p>Uncaptured payments expire a set number of days after they are created (<a href="/docs/charges/placing-a-hold">7 by default</a>), after which they are marked as refunded and capture attempts will fail.</p>
          *
-         *     <p>Don’t use this method to capture a PaymentIntent-initiated charge. Use <a href="/docs/api/payment_intents/capture">Capture a PaymentIntent</a>.</p> */
+         *     <p>Don’t use this method to capture a PaymentIntent-initiated charge. Use <a href="/docs/api/payment_intents/capture">Capture a PaymentIntent</a>.</p>
+         */
         post: operations["PostChargesChargeCapture"];
         delete?: never;
         options?: never;
@@ -1008,7 +1363,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>When you create a new refund, you must specify either a Charge or a PaymentIntent object.</p>
+        /**
+         * Create a refund
+         * @description <p>When you create a new refund, you must specify either a Charge or a PaymentIntent object.</p>
          *
          *     <p>This action refunds a previously created charge that’s not refunded yet.
          *     Funds are refunded to the credit or debit card that’s originally charged.</p>
@@ -1018,7 +1375,8 @@ export interface paths {
          *
          *     <p>After you entirely refund a charge, you can’t refund it again.
          *     This method raises an error when it’s called on an already-refunded charge,
-         *     or when you attempt to refund more money than is left on a charge.</p> */
+         *     or when you attempt to refund more money than is left on a charge.</p>
+         */
         post: operations["PostChargesChargeRefund"];
         delete?: never;
         options?: never;
@@ -1033,10 +1391,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p> */
+        /**
+         * List all refunds
+         * @description <p>You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p>
+         */
         get: operations["GetChargesChargeRefunds"];
         put?: never;
-        /** @description <p>When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.</p>
+        /**
+         * Create customer balance refund
+         * @description <p>When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.</p>
          *
          *     <p>Creating a new refund will refund a charge that has previously been created but not yet refunded.
          *     Funds will be refunded to the credit or debit card that was originally charged.</p>
@@ -1046,7 +1409,8 @@ export interface paths {
          *
          *     <p>Once entirely refunded, a charge can’t be refunded again.
          *     This method will raise an error when called on an already-refunded charge,
-         *     or when trying to refund more money than is left on a charge.</p> */
+         *     or when trying to refund more money than is left on a charge.</p>
+         */
         post: operations["PostChargesChargeRefunds"];
         delete?: never;
         options?: never;
@@ -1079,10 +1443,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Checkout Sessions.</p> */
+        /**
+         * List all Checkout Sessions
+         * @description <p>Returns a list of Checkout Sessions.</p>
+         */
         get: operations["GetCheckoutSessions"];
         put?: never;
-        /** @description <p>Creates a Session object.</p> */
+        /**
+         * Create a Session
+         * @description <p>Creates a Session object.</p>
+         */
         post: operations["PostCheckoutSessions"];
         delete?: never;
         options?: never;
@@ -1097,10 +1467,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Session object.</p> */
+        /**
+         * Retrieve a Session
+         * @description <p>Retrieves a Session object.</p>
+         */
         get: operations["GetCheckoutSessionsSession"];
         put?: never;
-        /** @description <p>Updates a Session object.</p> */
+        /**
+         * Update a Session
+         * @description <p>Updates a Session object.</p>
+         */
         post: operations["PostCheckoutSessionsSession"];
         delete?: never;
         options?: never;
@@ -1117,9 +1493,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>A Session can be expired when it is in one of these statuses: <code>open</code> </p>
+        /**
+         * Expire a Session
+         * @description <p>A Session can be expired when it is in one of these statuses: <code>open</code> </p>
          *
-         *     <p>After it expires, a customer can’t complete a Session and customers loading the Session see a message saying the Session is expired.</p> */
+         *     <p>After it expires, a customer can’t complete a Session and customers loading the Session see a message saying the Session is expired.</p>
+         */
         post: operations["PostCheckoutSessionsSessionExpire"];
         delete?: never;
         options?: never;
@@ -1134,7 +1513,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a Checkout Session, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve a Checkout Session's line items
+         * @description <p>When retrieving a Checkout Session, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetCheckoutSessionsSessionLineItems"];
         put?: never;
         post?: never;
@@ -1151,12 +1533,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all Climate order objects. The orders are returned sorted by creation date, with the
-         *     most recently created orders appearing first.</p> */
+        /**
+         * List orders
+         * @description <p>Lists all Climate order objects. The orders are returned sorted by creation date, with the
+         *     most recently created orders appearing first.</p>
+         */
         get: operations["GetClimateOrders"];
         put?: never;
-        /** @description <p>Creates a Climate order object for a given Climate product. The order will be processed immediately
-         *     after creation and payment will be deducted your Stripe balance.</p> */
+        /**
+         * Create an order
+         * @description <p>Creates a Climate order object for a given Climate product. The order will be processed immediately
+         *     after creation and payment will be deducted your Stripe balance.</p>
+         */
         post: operations["PostClimateOrders"];
         delete?: never;
         options?: never;
@@ -1171,10 +1559,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Climate order object with the given ID.</p> */
+        /**
+         * Retrieve an order
+         * @description <p>Retrieves the details of a Climate order object with the given ID.</p>
+         */
         get: operations["GetClimateOrdersOrder"];
         put?: never;
-        /** @description <p>Updates the specified order by setting the values of the parameters passed.</p> */
+        /**
+         * Update an order
+         * @description <p>Updates the specified order by setting the values of the parameters passed.</p>
+         */
         post: operations["PostClimateOrdersOrder"];
         delete?: never;
         options?: never;
@@ -1191,10 +1585,13 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels a Climate order. You can cancel an order within 24 hours of creation. Stripe refunds the
+        /**
+         * Cancel an order
+         * @description <p>Cancels a Climate order. You can cancel an order within 24 hours of creation. Stripe refunds the
          *     reservation <code>amount_subtotal</code>, but not the <code>amount_fees</code> for user-triggered cancellations. Frontier
          *     might cancel reservations if suppliers fail to deliver. If Frontier cancels the reservation, Stripe
-         *     provides 90 days advance notice and refunds the <code>amount_total</code>.</p> */
+         *     provides 90 days advance notice and refunds the <code>amount_total</code>.</p>
+         */
         post: operations["PostClimateOrdersOrderCancel"];
         delete?: never;
         options?: never;
@@ -1209,7 +1606,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all available Climate product objects.</p> */
+        /**
+         * List products
+         * @description <p>Lists all available Climate product objects.</p>
+         */
         get: operations["GetClimateProducts"];
         put?: never;
         post?: never;
@@ -1226,7 +1626,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Climate product with the given ID.</p> */
+        /**
+         * Retrieve a product
+         * @description <p>Retrieves the details of a Climate product with the given ID.</p>
+         */
         get: operations["GetClimateProductsProduct"];
         put?: never;
         post?: never;
@@ -1243,7 +1646,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all available Climate supplier objects.</p> */
+        /**
+         * List suppliers
+         * @description <p>Lists all available Climate supplier objects.</p>
+         */
         get: operations["GetClimateSuppliers"];
         put?: never;
         post?: never;
@@ -1260,7 +1666,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Climate supplier object.</p> */
+        /**
+         * Retrieve a supplier
+         * @description <p>Retrieves a Climate supplier object.</p>
+         */
         get: operations["GetClimateSuppliersSupplier"];
         put?: never;
         post?: never;
@@ -1277,7 +1686,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an existing ConfirmationToken object</p> */
+        /**
+         * Retrieve a ConfirmationToken
+         * @description <p>Retrieves an existing ConfirmationToken object</p>
+         */
         get: operations["GetConfirmationTokensConfirmationToken"];
         put?: never;
         post?: never;
@@ -1294,7 +1706,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all Country Spec objects available in the API.</p> */
+        /**
+         * List Country Specs
+         * @description <p>Lists all Country Spec objects available in the API.</p>
+         */
         get: operations["GetCountrySpecs"];
         put?: never;
         post?: never;
@@ -1311,7 +1726,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a Country Spec for a given Country code.</p> */
+        /**
+         * Retrieve a Country Spec
+         * @description <p>Returns a Country Spec for a given Country code.</p>
+         */
         get: operations["GetCountrySpecsCountry"];
         put?: never;
         post?: never;
@@ -1328,12 +1746,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your coupons.</p> */
+        /**
+         * List all coupons
+         * @description <p>Returns a list of your coupons.</p>
+         */
         get: operations["GetCoupons"];
         put?: never;
-        /** @description <p>You can create coupons easily via the <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.</p>
+        /**
+         * Create a coupon
+         * @description <p>You can create coupons easily via the <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of the Stripe dashboard. Coupon creation is also accessible via the API if you need to create coupons on the fly.</p>
          *
-         *     <p>A coupon has either a <code>percent_off</code> or an <code>amount_off</code> and <code>currency</code>. If you set an <code>amount_off</code>, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of <currency>100</currency> will have a final total of <currency>0</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it and an invoice with a subtotal of <currency>300</currency> will have a final total of <currency>100</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it.</p> */
+         *     <p>A coupon has either a <code>percent_off</code> or an <code>amount_off</code> and <code>currency</code>. If you set an <code>amount_off</code>, that amount will be subtracted from any invoice’s subtotal. For example, an invoice with a subtotal of <currency>100</currency> will have a final total of <currency>0</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it and an invoice with a subtotal of <currency>300</currency> will have a final total of <currency>100</currency> if a coupon with an <code>amount_off</code> of <amount>200</amount> is applied to it.</p>
+         */
         post: operations["PostCoupons"];
         delete?: never;
         options?: never;
@@ -1348,12 +1772,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the coupon with the given ID.</p> */
+        /**
+         * Retrieve a coupon
+         * @description <p>Retrieves the coupon with the given ID.</p>
+         */
         get: operations["GetCouponsCoupon"];
         put?: never;
-        /** @description <p>Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.</p> */
+        /**
+         * Update a coupon
+         * @description <p>Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.</p>
+         */
         post: operations["PostCouponsCoupon"];
-        /** @description <p>You can delete coupons via the <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon. You can also delete coupons via the API.</p> */
+        /**
+         * Delete a coupon
+         * @description <p>You can delete coupons via the <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of the Stripe dashboard. However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon. You can also delete coupons via the API.</p>
+         */
         delete: operations["DeleteCouponsCoupon"];
         options?: never;
         head?: never;
@@ -1367,10 +1800,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of credit notes.</p> */
+        /**
+         * List all credit notes
+         * @description <p>Returns a list of credit notes.</p>
+         */
         get: operations["GetCreditNotes"];
         put?: never;
-        /** @description <p>Issue a credit note to adjust the amount of a finalized invoice. For a <code>status=open</code> invoice, a credit note reduces
+        /**
+         * Create a credit note
+         * @description <p>Issue a credit note to adjust the amount of a finalized invoice. For a <code>status=open</code> invoice, a credit note reduces
          *     its <code>amount_due</code>. For a <code>status=paid</code> invoice, a credit note does not affect its <code>amount_due</code>. Instead, it can result
          *     in any combination of the following:</p>
          *
@@ -1383,7 +1821,8 @@ export interface paths {
          *     <p>For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts must equal the credit note total.</p>
          *
          *     <p>You may issue multiple credit notes for an invoice. Each credit note will increment the invoice’s <code>pre_payment_credit_notes_amount</code>
-         *     or <code>post_payment_credit_notes_amount</code> depending on its <code>status</code> at the time of credit note creation.</p> */
+         *     or <code>post_payment_credit_notes_amount</code> depending on its <code>status</code> at the time of credit note creation.</p>
+         */
         post: operations["PostCreditNotes"];
         delete?: never;
         options?: never;
@@ -1398,7 +1837,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Get a preview of a credit note without creating it.</p> */
+        /**
+         * Preview a credit note
+         * @description <p>Get a preview of a credit note without creating it.</p>
+         */
         get: operations["GetCreditNotesPreview"];
         put?: never;
         post?: never;
@@ -1415,7 +1857,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a credit note preview, you’ll get a <strong>lines</strong> property containing the first handful of those items. This URL you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve a credit note preview's line items
+         * @description <p>When retrieving a credit note preview, you’ll get a <strong>lines</strong> property containing the first handful of those items. This URL you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetCreditNotesPreviewLines"];
         put?: never;
         post?: never;
@@ -1432,7 +1877,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a credit note, you’ll get a <strong>lines</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve a credit note's line items
+         * @description <p>When retrieving a credit note, you’ll get a <strong>lines</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetCreditNotesCreditNoteLines"];
         put?: never;
         post?: never;
@@ -1449,10 +1897,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the credit note object with the given identifier.</p> */
+        /**
+         * Retrieve a credit note
+         * @description <p>Retrieves the credit note object with the given identifier.</p>
+         */
         get: operations["GetCreditNotesId"];
         put?: never;
-        /** @description <p>Updates an existing credit note.</p> */
+        /**
+         * Update a credit note
+         * @description <p>Updates an existing credit note.</p>
+         */
         post: operations["PostCreditNotesId"];
         delete?: never;
         options?: never;
@@ -1469,7 +1923,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Marks a credit note as void. Learn more about <a href="/docs/billing/invoices/credit-notes#voiding">voiding credit notes</a>.</p> */
+        /**
+         * Void a credit note
+         * @description <p>Marks a credit note as void. Learn more about <a href="/docs/billing/invoices/credit-notes#voiding">voiding credit notes</a>.</p>
+         */
         post: operations["PostCreditNotesIdVoid"];
         delete?: never;
         options?: never;
@@ -1486,7 +1943,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a Customer Session object that includes a single-use client secret that you can use on your front-end to grant client-side API access for certain customer resources.</p> */
+        /**
+         * Create a Customer Session
+         * @description <p>Creates a Customer Session object that includes a single-use client secret that you can use on your front-end to grant client-side API access for certain customer resources.</p>
+         */
         post: operations["PostCustomerSessions"];
         delete?: never;
         options?: never;
@@ -1501,10 +1961,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.</p> */
+        /**
+         * List all customers
+         * @description <p>Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.</p>
+         */
         get: operations["GetCustomers"];
         put?: never;
-        /** @description <p>Creates a new customer object.</p> */
+        /**
+         * Create a customer
+         * @description <p>Creates a new customer object.</p>
+         */
         post: operations["PostCustomers"];
         delete?: never;
         options?: never;
@@ -1519,10 +1985,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for customers you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search customers
+         * @description <p>Search for customers you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetCustomersSearch"];
         put?: never;
         post?: never;
@@ -1539,14 +2008,23 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Customer object.</p> */
+        /**
+         * Retrieve a customer
+         * @description <p>Retrieves a Customer object.</p>
+         */
         get: operations["GetCustomersCustomer"];
         put?: never;
-        /** @description <p>Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the <strong>source</strong> parameter, that becomes the customer’s active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the <strong>source</strong> parameter: for each of the customer’s current subscriptions, if the subscription bills automatically and is in the <code>past_due</code> state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the <strong>default_source</strong> for a customer will not trigger this behavior.</p>
+        /**
+         * Update a customer
+         * @description <p>Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the <strong>source</strong> parameter, that becomes the customer’s active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the <strong>source</strong> parameter: for each of the customer’s current subscriptions, if the subscription bills automatically and is in the <code>past_due</code> state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the <strong>default_source</strong> for a customer will not trigger this behavior.</p>
          *
-         *     <p>This request accepts mostly the same arguments as the customer creation call.</p> */
+         *     <p>This request accepts mostly the same arguments as the customer creation call.</p>
+         */
         post: operations["PostCustomersCustomer"];
-        /** @description <p>Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.</p> */
+        /**
+         * Delete a customer
+         * @description <p>Permanently deletes a customer. It cannot be undone. Also immediately cancels any active subscriptions on the customer.</p>
+         */
         delete: operations["DeleteCustomersCustomer"];
         options?: never;
         head?: never;
@@ -1560,10 +2038,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of transactions that updated the customer’s <a href="/docs/billing/customer/balance">balances</a>.</p> */
+        /**
+         * List customer balance transactions
+         * @description <p>Returns a list of transactions that updated the customer’s <a href="/docs/billing/customer/balance">balances</a>.</p>
+         */
         get: operations["GetCustomersCustomerBalanceTransactions"];
         put?: never;
-        /** @description <p>Creates an immutable transaction that updates the customer’s credit <a href="/docs/billing/customer/balance">balance</a>.</p> */
+        /**
+         * Create a customer balance transaction
+         * @description <p>Creates an immutable transaction that updates the customer’s credit <a href="/docs/billing/customer/balance">balance</a>.</p>
+         */
         post: operations["PostCustomersCustomerBalanceTransactions"];
         delete?: never;
         options?: never;
@@ -1578,10 +2062,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a specific customer balance transaction that updated the customer’s <a href="/docs/billing/customer/balance">balances</a>.</p> */
+        /**
+         * Retrieve a customer balance transaction
+         * @description <p>Retrieves a specific customer balance transaction that updated the customer’s <a href="/docs/billing/customer/balance">balances</a>.</p>
+         */
         get: operations["GetCustomersCustomerBalanceTransactionsTransaction"];
         put?: never;
-        /** @description <p>Most credit balance transaction fields are immutable, but you may update its <code>description</code> and <code>metadata</code>.</p> */
+        /**
+         * Update a customer credit balance transaction
+         * @description <p>Most credit balance transaction fields are immutable, but you may update its <code>description</code> and <code>metadata</code>.</p>
+         */
         post: operations["PostCustomersCustomerBalanceTransactionsTransaction"];
         delete?: never;
         options?: never;
@@ -1597,16 +2087,20 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * List all bank accounts
          * @deprecated
          * @description <p>You can see a list of the bank accounts belonging to a Customer. Note that the 10 most recent sources are always available by default on the Customer. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional bank accounts.</p>
          */
         get: operations["GetCustomersCustomerBankAccounts"];
         put?: never;
-        /** @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
+        /**
+         * Create a card
+         * @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
          *
          *     <p>If the card’s owner has no default card, then the new card will become the default.
          *     However, if the owner already has a default, then it will not change.
-         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p> */
+         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p>
+         */
         post: operations["PostCustomersCustomerBankAccounts"];
         delete?: never;
         options?: never;
@@ -1622,6 +2116,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Retrieve a bank account
          * @deprecated
          * @description <p>By default, you can see the 10 most recent sources stored on a Customer directly on the object, but you can also retrieve details about a specific bank account stored on the Stripe account.</p>
          */
@@ -1629,7 +2124,10 @@ export interface paths {
         put?: never;
         /** @description <p>Update a specified source for a given customer.</p> */
         post: operations["PostCustomersCustomerBankAccountsId"];
-        /** @description <p>Delete a specified source for a given customer.</p> */
+        /**
+         * Delete a customer source
+         * @description <p>Delete a specified source for a given customer.</p>
+         */
         delete: operations["DeleteCustomersCustomerBankAccountsId"];
         options?: never;
         head?: never;
@@ -1645,7 +2143,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Verify a specified bank account for a given customer.</p> */
+        /**
+         * Verify a bank account
+         * @description <p>Verify a specified bank account for a given customer.</p>
+         */
         post: operations["PostCustomersCustomerBankAccountsIdVerify"];
         delete?: never;
         options?: never;
@@ -1661,6 +2162,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * List all cards
          * @deprecated
          * @description <p>You can see a list of the cards belonging to a customer.
          *     Note that the 10 most recent sources are always available on the <code>Customer</code> object.
@@ -1668,11 +2170,14 @@ export interface paths {
          */
         get: operations["GetCustomersCustomerCards"];
         put?: never;
-        /** @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
+        /**
+         * Create a card
+         * @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
          *
          *     <p>If the card’s owner has no default card, then the new card will become the default.
          *     However, if the owner already has a default, then it will not change.
-         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p> */
+         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p>
+         */
         post: operations["PostCustomersCustomerCards"];
         delete?: never;
         options?: never;
@@ -1688,6 +2193,7 @@ export interface paths {
             cookie?: never;
         };
         /**
+         * Retrieve a card
          * @deprecated
          * @description <p>You can always see the 10 most recent cards directly on a customer; this method lets you retrieve details about a specific card stored on the customer.</p>
          */
@@ -1695,7 +2201,10 @@ export interface paths {
         put?: never;
         /** @description <p>Update a specified source for a given customer.</p> */
         post: operations["PostCustomersCustomerCardsId"];
-        /** @description <p>Delete a specified source for a given customer.</p> */
+        /**
+         * Delete a customer source
+         * @description <p>Delete a specified source for a given customer.</p>
+         */
         delete: operations["DeleteCustomersCustomerCardsId"];
         options?: never;
         head?: never;
@@ -1709,10 +2218,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a customer’s cash balance.</p> */
+        /**
+         * Retrieve a cash balance
+         * @description <p>Retrieves a customer’s cash balance.</p>
+         */
         get: operations["GetCustomersCustomerCashBalance"];
         put?: never;
-        /** @description <p>Changes the settings on a customer’s cash balance.</p> */
+        /**
+         * Update a cash balance's settings
+         * @description <p>Changes the settings on a customer’s cash balance.</p>
+         */
         post: operations["PostCustomersCustomerCashBalance"];
         delete?: never;
         options?: never;
@@ -1727,7 +2242,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of transactions that modified the customer’s <a href="/docs/payments/customer-balance">cash balance</a>.</p> */
+        /**
+         * List cash balance transactions
+         * @description <p>Returns a list of transactions that modified the customer’s <a href="/docs/payments/customer-balance">cash balance</a>.</p>
+         */
         get: operations["GetCustomersCustomerCashBalanceTransactions"];
         put?: never;
         post?: never;
@@ -1744,7 +2262,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a specific cash balance transaction, which updated the customer’s <a href="/docs/payments/customer-balance">cash balance</a>.</p> */
+        /**
+         * Retrieve a cash balance transaction
+         * @description <p>Retrieves a specific cash balance transaction, which updated the customer’s <a href="/docs/payments/customer-balance">cash balance</a>.</p>
+         */
         get: operations["GetCustomersCustomerCashBalanceTransactionsTransaction"];
         put?: never;
         post?: never;
@@ -1764,7 +2285,10 @@ export interface paths {
         get: operations["GetCustomersCustomerDiscount"];
         put?: never;
         post?: never;
-        /** @description <p>Removes the currently applied discount on a customer.</p> */
+        /**
+         * Delete a customer discount
+         * @description <p>Removes the currently applied discount on a customer.</p>
+         */
         delete: operations["DeleteCustomersCustomerDiscount"];
         options?: never;
         head?: never;
@@ -1780,9 +2304,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
+        /**
+         * Create or retrieve funding instructions for a customer cash balance
+         * @description <p>Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
          *     funding instructions will be created. If funding instructions have already been created for a given customer, the same
-         *     funding instructions will be retrieved. In other words, we will return the same funding instructions each time.</p> */
+         *     funding instructions will be retrieved. In other words, we will return the same funding instructions each time.</p>
+         */
         post: operations["PostCustomersCustomerFundingInstructions"];
         delete?: never;
         options?: never;
@@ -1797,7 +2324,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of PaymentMethods for a given Customer</p> */
+        /**
+         * List a Customer's PaymentMethods
+         * @description <p>Returns a list of PaymentMethods for a given Customer</p>
+         */
         get: operations["GetCustomersCustomerPaymentMethods"];
         put?: never;
         post?: never;
@@ -1814,7 +2344,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a PaymentMethod object for a given Customer.</p> */
+        /**
+         * Retrieve a Customer's PaymentMethod
+         * @description <p>Retrieves a PaymentMethod object for a given Customer.</p>
+         */
         get: operations["GetCustomersCustomerPaymentMethodsPaymentMethod"];
         put?: never;
         post?: never;
@@ -1834,11 +2367,14 @@ export interface paths {
         /** @description <p>List sources for a specified customer.</p> */
         get: operations["GetCustomersCustomerSources"];
         put?: never;
-        /** @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
+        /**
+         * Create a card
+         * @description <p>When you create a new credit card, you must specify a customer or recipient on which to create it.</p>
          *
          *     <p>If the card’s owner has no default card, then the new card will become the default.
          *     However, if the owner already has a default, then it will not change.
-         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p> */
+         *     To change the default, you should <a href="/docs/api#update_customer">update the customer</a> to have a new <code>default_source</code>.</p>
+         */
         post: operations["PostCustomersCustomerSources"];
         delete?: never;
         options?: never;
@@ -1858,7 +2394,10 @@ export interface paths {
         put?: never;
         /** @description <p>Update a specified source for a given customer.</p> */
         post: operations["PostCustomersCustomerSourcesId"];
-        /** @description <p>Delete a specified source for a given customer.</p> */
+        /**
+         * Delete a customer source
+         * @description <p>Delete a specified source for a given customer.</p>
+         */
         delete: operations["DeleteCustomersCustomerSourcesId"];
         options?: never;
         head?: never;
@@ -1874,7 +2413,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Verify a specified bank account for a given customer.</p> */
+        /**
+         * Verify a bank account
+         * @description <p>Verify a specified bank account for a given customer.</p>
+         */
         post: operations["PostCustomersCustomerSourcesIdVerify"];
         delete?: never;
         options?: never;
@@ -1889,10 +2431,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>You can see a list of the customer’s active subscriptions. Note that the 10 most recent active subscriptions are always available by default on the customer object. If you need more than those 10, you can use the limit and starting_after parameters to page through additional subscriptions.</p> */
+        /**
+         * List active subscriptions
+         * @description <p>You can see a list of the customer’s active subscriptions. Note that the 10 most recent active subscriptions are always available by default on the customer object. If you need more than those 10, you can use the limit and starting_after parameters to page through additional subscriptions.</p>
+         */
         get: operations["GetCustomersCustomerSubscriptions"];
         put?: never;
-        /** @description <p>Creates a new subscription on an existing customer.</p> */
+        /**
+         * Create a subscription
+         * @description <p>Creates a new subscription on an existing customer.</p>
+         */
         post: operations["PostCustomersCustomerSubscriptions"];
         delete?: never;
         options?: never;
@@ -1907,16 +2455,25 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the subscription with the given ID.</p> */
+        /**
+         * Retrieve a subscription
+         * @description <p>Retrieves the subscription with the given ID.</p>
+         */
         get: operations["GetCustomersCustomerSubscriptionsSubscriptionExposedId"];
         put?: never;
-        /** @description <p>Updates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the <a href="#upcoming_invoice">upcoming invoice</a> endpoint.</p> */
+        /**
+         * Update a subscription on a customer
+         * @description <p>Updates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the <a href="#upcoming_invoice">upcoming invoice</a> endpoint.</p>
+         */
         post: operations["PostCustomersCustomerSubscriptionsSubscriptionExposedId"];
-        /** @description <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to <code>true</code>, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. Otherwise, with the default <code>false</code> value, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription.</p>
+        /**
+         * Cancel a subscription
+         * @description <p>Cancels a customer’s subscription. If you set the <code>at_period_end</code> parameter to <code>true</code>, the subscription will remain active until the end of the period, at which point it will be canceled and not renewed. Otherwise, with the default <code>false</code> value, the subscription is terminated immediately. In either case, the customer will not be charged again for the subscription.</p>
          *
          *     <p>Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period, unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel at the end of the period, any pending prorations will also be left in place and collected at the end of the period. But if the subscription is set to cancel immediately, pending prorations will be removed.</p>
          *
-         *     <p>By default, upon subscription cancellation, Stripe will stop automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.</p> */
+         *     <p>By default, upon subscription cancellation, Stripe will stop automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.</p>
+         */
         delete: operations["DeleteCustomersCustomerSubscriptionsSubscriptionExposedId"];
         options?: never;
         head?: never;
@@ -1933,7 +2490,10 @@ export interface paths {
         get: operations["GetCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount"];
         put?: never;
         post?: never;
-        /** @description <p>Removes the currently applied discount on a customer.</p> */
+        /**
+         * Delete a customer discount
+         * @description <p>Removes the currently applied discount on a customer.</p>
+         */
         delete: operations["DeleteCustomersCustomerSubscriptionsSubscriptionExposedIdDiscount"];
         options?: never;
         head?: never;
@@ -1947,10 +2507,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of tax IDs for a customer.</p> */
+        /**
+         * List all Customer tax IDs
+         * @description <p>Returns a list of tax IDs for a customer.</p>
+         */
         get: operations["GetCustomersCustomerTaxIds"];
         put?: never;
-        /** @description <p>Creates a new <code>tax_id</code> object for a customer.</p> */
+        /**
+         * Create a Customer tax ID
+         * @description <p>Creates a new <code>tax_id</code> object for a customer.</p>
+         */
         post: operations["PostCustomersCustomerTaxIds"];
         delete?: never;
         options?: never;
@@ -1965,11 +2531,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the <code>tax_id</code> object with the given identifier.</p> */
+        /**
+         * Retrieve a Customer tax ID
+         * @description <p>Retrieves the <code>tax_id</code> object with the given identifier.</p>
+         */
         get: operations["GetCustomersCustomerTaxIdsId"];
         put?: never;
         post?: never;
-        /** @description <p>Deletes an existing <code>tax_id</code> object.</p> */
+        /**
+         * Delete a Customer tax ID
+         * @description <p>Deletes an existing <code>tax_id</code> object.</p>
+         */
         delete: operations["DeleteCustomersCustomerTaxIdsId"];
         options?: never;
         head?: never;
@@ -1983,7 +2555,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your disputes.</p> */
+        /**
+         * List all disputes
+         * @description <p>Returns a list of your disputes.</p>
+         */
         get: operations["GetDisputes"];
         put?: never;
         post?: never;
@@ -2000,12 +2575,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the dispute with the given ID.</p> */
+        /**
+         * Retrieve a dispute
+         * @description <p>Retrieves the dispute with the given ID.</p>
+         */
         get: operations["GetDisputesDispute"];
         put?: never;
-        /** @description <p>When you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence to help us resolve the dispute in your favor. You can do this in your <a href="https://dashboard.stripe.com/disputes">dashboard</a>, but if you prefer, you can use the API to submit evidence programmatically.</p>
+        /**
+         * Update a dispute
+         * @description <p>When you get a dispute, contacting your customer is always the best first step. If that doesn’t work, you can submit evidence to help us resolve the dispute in your favor. You can do this in your <a href="https://dashboard.stripe.com/disputes">dashboard</a>, but if you prefer, you can use the API to submit evidence programmatically.</p>
          *
-         *     <p>Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our <a href="/docs/disputes/categories">guide to dispute types</a>.</p> */
+         *     <p>Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute. To figure out which evidence fields to provide, see our <a href="/docs/disputes/categories">guide to dispute types</a>.</p>
+         */
         post: operations["PostDisputesDispute"];
         delete?: never;
         options?: never;
@@ -2022,9 +2603,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.</p>
+        /**
+         * Close a dispute
+         * @description <p>Closing the dispute for a charge indicates that you do not have any evidence to submit and are essentially dismissing the dispute, acknowledging it as lost.</p>
          *
-         *     <p>The status of the dispute will change from <code>needs_response</code> to <code>lost</code>. <em>Closing a dispute is irreversible</em>.</p> */
+         *     <p>The status of the dispute will change from <code>needs_response</code> to <code>lost</code>. <em>Closing a dispute is irreversible</em>.</p>
+         */
         post: operations["PostDisputesDisputeClose"];
         delete?: never;
         options?: never;
@@ -2039,7 +2623,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a list of active entitlements for a customer</p> */
+        /**
+         * List all active entitlements
+         * @description <p>Retrieve a list of active entitlements for a customer</p>
+         */
         get: operations["GetEntitlementsActiveEntitlements"];
         put?: never;
         post?: never;
@@ -2056,7 +2643,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve an active entitlement</p> */
+        /**
+         * Retrieve an active entitlement
+         * @description <p>Retrieve an active entitlement</p>
+         */
         get: operations["GetEntitlementsActiveEntitlementsId"];
         put?: never;
         post?: never;
@@ -2073,10 +2663,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a list of features</p> */
+        /**
+         * List all features
+         * @description <p>Retrieve a list of features</p>
+         */
         get: operations["GetEntitlementsFeatures"];
         put?: never;
-        /** @description <p>Creates a feature</p> */
+        /**
+         * Create a feature
+         * @description <p>Creates a feature</p>
+         */
         post: operations["PostEntitlementsFeatures"];
         delete?: never;
         options?: never;
@@ -2091,10 +2687,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a feature</p> */
+        /**
+         * Retrieve a feature
+         * @description <p>Retrieves a feature</p>
+         */
         get: operations["GetEntitlementsFeaturesId"];
         put?: never;
-        /** @description <p>Update a feature’s metadata or permanently deactivate it.</p> */
+        /**
+         * Updates a feature
+         * @description <p>Update a feature’s metadata or permanently deactivate it.</p>
+         */
         post: operations["PostEntitlementsFeaturesId"];
         delete?: never;
         options?: never;
@@ -2111,7 +2713,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a short-lived API key for a given resource.</p> */
+        /**
+         * Create an ephemeral key
+         * @description <p>Creates a short-lived API key for a given resource.</p>
+         */
         post: operations["PostEphemeralKeys"];
         delete?: never;
         options?: never;
@@ -2129,7 +2734,10 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** @description <p>Invalidates a short-lived API key for a given resource.</p> */
+        /**
+         * Immediately invalidate an ephemeral key
+         * @description <p>Invalidates a short-lived API key for a given resource.</p>
+         */
         delete: operations["DeleteEphemeralKeysKey"];
         options?: never;
         head?: never;
@@ -2143,7 +2751,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in <a href="https://docs.stripe.com/api/events/object">event object</a> <code>api_version</code> attribute (not according to your current Stripe API version or <code>Stripe-Version</code> header).</p> */
+        /**
+         * List all events
+         * @description <p>List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in <a href="https://docs.stripe.com/api/events/object">event object</a> <code>api_version</code> attribute (not according to your current Stripe API version or <code>Stripe-Version</code> header).</p>
+         */
         get: operations["GetEvents"];
         put?: never;
         post?: never;
@@ -2160,7 +2771,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an event if it was created in the last 30 days. Supply the unique identifier of the event, which you might have received in a webhook.</p> */
+        /**
+         * Retrieve an event
+         * @description <p>Retrieves the details of an event if it was created in the last 30 days. Supply the unique identifier of the event, which you might have received in a webhook.</p>
+         */
         get: operations["GetEventsId"];
         put?: never;
         post?: never;
@@ -2177,7 +2791,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.</p> */
+        /**
+         * List all exchange rates
+         * @description <p>Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.</p>
+         */
         get: operations["GetExchangeRates"];
         put?: never;
         post?: never;
@@ -2194,7 +2811,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the exchange rates from the given currency to every supported currency.</p> */
+        /**
+         * Retrieve an exchange rate
+         * @description <p>Retrieves the exchange rates from the given currency to every supported currency.</p>
+         */
         get: operations["GetExchangeRatesRateId"];
         put?: never;
         post?: never;
@@ -2211,10 +2831,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of file links.</p> */
+        /**
+         * List all file links
+         * @description <p>Returns a list of file links.</p>
+         */
         get: operations["GetFileLinks"];
         put?: never;
-        /** @description <p>Creates a new file link object.</p> */
+        /**
+         * Create a file link
+         * @description <p>Creates a new file link object.</p>
+         */
         post: operations["PostFileLinks"];
         delete?: never;
         options?: never;
@@ -2229,10 +2855,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the file link with the given ID.</p> */
+        /**
+         * Retrieve a file link
+         * @description <p>Retrieves the file link with the given ID.</p>
+         */
         get: operations["GetFileLinksLink"];
         put?: never;
-        /** @description <p>Updates an existing file link object. Expired links can no longer be updated.</p> */
+        /**
+         * Update a file link
+         * @description <p>Updates an existing file link object. Expired links can no longer be updated.</p>
+         */
         post: operations["PostFileLinksLink"];
         delete?: never;
         options?: never;
@@ -2247,12 +2879,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of the files that your account has access to. Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.</p> */
+        /**
+         * List all files
+         * @description <p>Returns a list of the files that your account has access to. Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.</p>
+         */
         get: operations["GetFiles"];
         put?: never;
-        /** @description <p>To upload a file to Stripe, you need to send a request of type <code>multipart/form-data</code>. Include the file you want to upload in the request, and the parameters for creating a file.</p>
+        /**
+         * Create a file
+         * @description <p>To upload a file to Stripe, you need to send a request of type <code>multipart/form-data</code>. Include the file you want to upload in the request, and the parameters for creating a file.</p>
          *
-         *     <p>All of Stripe’s officially supported Client libraries support sending <code>multipart/form-data</code>.</p> */
+         *     <p>All of Stripe’s officially supported Client libraries support sending <code>multipart/form-data</code>.</p>
+         */
         post: operations["PostFiles"];
         delete?: never;
         options?: never;
@@ -2267,7 +2905,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing file object. After you supply a unique file ID, Stripe returns the corresponding file object. Learn how to <a href="/docs/file-upload#download-file-contents">access file contents</a>.</p> */
+        /**
+         * Retrieve a file
+         * @description <p>Retrieves the details of an existing file object. After you supply a unique file ID, Stripe returns the corresponding file object. Learn how to <a href="/docs/file-upload#download-file-contents">access file contents</a>.</p>
+         */
         get: operations["GetFilesFile"];
         put?: never;
         post?: never;
@@ -2284,7 +2925,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p> */
+        /**
+         * List Accounts
+         * @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p>
+         */
         get: operations["GetFinancialConnectionsAccounts"];
         put?: never;
         post?: never;
@@ -2301,7 +2945,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p> */
+        /**
+         * Retrieve an Account
+         * @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p>
+         */
         get: operations["GetFinancialConnectionsAccountsAccount"];
         put?: never;
         post?: never;
@@ -2320,7 +2967,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Disables your access to a Financial Connections <code>Account</code>. You will no longer be able to access data associated with the account (e.g. balances, transactions).</p> */
+        /**
+         * Disconnect an Account
+         * @description <p>Disables your access to a Financial Connections <code>Account</code>. You will no longer be able to access data associated with the account (e.g. balances, transactions).</p>
+         */
         post: operations["PostFinancialConnectionsAccountsAccountDisconnect"];
         delete?: never;
         options?: never;
@@ -2335,7 +2985,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all owners for a given <code>Account</code></p> */
+        /**
+         * List Account Owners
+         * @description <p>Lists all owners for a given <code>Account</code></p>
+         */
         get: operations["GetFinancialConnectionsAccountsAccountOwners"];
         put?: never;
         post?: never;
@@ -2354,7 +3007,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Refreshes the data associated with a Financial Connections <code>Account</code>.</p> */
+        /**
+         * Refresh Account data
+         * @description <p>Refreshes the data associated with a Financial Connections <code>Account</code>.</p>
+         */
         post: operations["PostFinancialConnectionsAccountsAccountRefresh"];
         delete?: never;
         options?: never;
@@ -2371,7 +3027,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Subscribes to periodic refreshes of data associated with a Financial Connections <code>Account</code>.</p> */
+        /**
+         * Subscribe to data refreshes for an Account
+         * @description <p>Subscribes to periodic refreshes of data associated with a Financial Connections <code>Account</code>.</p>
+         */
         post: operations["PostFinancialConnectionsAccountsAccountSubscribe"];
         delete?: never;
         options?: never;
@@ -2388,7 +3047,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Unsubscribes from periodic refreshes of data associated with a Financial Connections <code>Account</code>.</p> */
+        /**
+         * Unsubscribe from data refreshes for an Account
+         * @description <p>Unsubscribes from periodic refreshes of data associated with a Financial Connections <code>Account</code>.</p>
+         */
         post: operations["PostFinancialConnectionsAccountsAccountUnsubscribe"];
         delete?: never;
         options?: never;
@@ -2405,7 +3067,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>To launch the Financial Connections authorization flow, create a <code>Session</code>. The session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.</p> */
+        /**
+         * Create a Session
+         * @description <p>To launch the Financial Connections authorization flow, create a <code>Session</code>. The session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.</p>
+         */
         post: operations["PostFinancialConnectionsSessions"];
         delete?: never;
         options?: never;
@@ -2420,7 +3085,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Financial Connections <code>Session</code></p> */
+        /**
+         * Retrieve a Session
+         * @description <p>Retrieves the details of a Financial Connections <code>Session</code></p>
+         */
         get: operations["GetFinancialConnectionsSessionsSession"];
         put?: never;
         post?: never;
@@ -2437,7 +3105,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Financial Connections <code>Transaction</code> objects.</p> */
+        /**
+         * List Transactions
+         * @description <p>Returns a list of Financial Connections <code>Transaction</code> objects.</p>
+         */
         get: operations["GetFinancialConnectionsTransactions"];
         put?: never;
         post?: never;
@@ -2454,7 +3125,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Financial Connections <code>Transaction</code></p> */
+        /**
+         * Retrieve a Transaction
+         * @description <p>Retrieves the details of a Financial Connections <code>Transaction</code></p>
+         */
         get: operations["GetFinancialConnectionsTransactionsTransaction"];
         put?: never;
         post?: never;
@@ -2471,10 +3145,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all ForwardingRequest objects.</p> */
+        /**
+         * List all ForwardingRequests
+         * @description <p>Lists all ForwardingRequest objects.</p>
+         */
         get: operations["GetForwardingRequests"];
         put?: never;
-        /** @description <p>Creates a ForwardingRequest object.</p> */
+        /**
+         * Create a ForwardingRequest
+         * @description <p>Creates a ForwardingRequest object.</p>
+         */
         post: operations["PostForwardingRequests"];
         delete?: never;
         options?: never;
@@ -2489,7 +3169,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a ForwardingRequest object.</p> */
+        /**
+         * Retrieve a ForwardingRequest
+         * @description <p>Retrieves a ForwardingRequest object.</p>
+         */
         get: operations["GetForwardingRequestsId"];
         put?: never;
         post?: never;
@@ -2506,7 +3189,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List all verification reports.</p> */
+        /**
+         * List VerificationReports
+         * @description <p>List all verification reports.</p>
+         */
         get: operations["GetIdentityVerificationReports"];
         put?: never;
         post?: never;
@@ -2523,7 +3209,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an existing VerificationReport</p> */
+        /**
+         * Retrieve a VerificationReport
+         * @description <p>Retrieves an existing VerificationReport</p>
+         */
         get: operations["GetIdentityVerificationReportsReport"];
         put?: never;
         post?: never;
@@ -2540,16 +3229,22 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of VerificationSessions</p> */
+        /**
+         * List VerificationSessions
+         * @description <p>Returns a list of VerificationSessions</p>
+         */
         get: operations["GetIdentityVerificationSessions"];
         put?: never;
-        /** @description <p>Creates a VerificationSession object.</p>
+        /**
+         * Create a VerificationSession
+         * @description <p>Creates a VerificationSession object.</p>
          *
          *     <p>After the VerificationSession is created, display a verification modal using the session <code>client_secret</code> or send your users to the session’s <code>url</code>.</p>
          *
          *     <p>If your API key is in test mode, verification checks won’t actually process, though everything else will occur as if in live mode.</p>
          *
-         *     <p>Related guide: <a href="/docs/identity/verify-identity-documents">Verify your users’ identity documents</a></p> */
+         *     <p>Related guide: <a href="/docs/identity/verify-identity-documents">Verify your users’ identity documents</a></p>
+         */
         post: operations["PostIdentityVerificationSessions"];
         delete?: never;
         options?: never;
@@ -2564,16 +3259,22 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a VerificationSession that was previously created.</p>
+        /**
+         * Retrieve a VerificationSession
+         * @description <p>Retrieves the details of a VerificationSession that was previously created.</p>
          *
          *     <p>When the session status is <code>requires_input</code>, you can use this method to retrieve a valid
-         *     <code>client_secret</code> or <code>url</code> to allow re-submission.</p> */
+         *     <code>client_secret</code> or <code>url</code> to allow re-submission.</p>
+         */
         get: operations["GetIdentityVerificationSessionsSession"];
         put?: never;
-        /** @description <p>Updates a VerificationSession object.</p>
+        /**
+         * Update a VerificationSession
+         * @description <p>Updates a VerificationSession object.</p>
          *
          *     <p>When the session status is <code>requires_input</code>, you can use this method to update the
-         *     verification check and options.</p> */
+         *     verification check and options.</p>
+         */
         post: operations["PostIdentityVerificationSessionsSession"];
         delete?: never;
         options?: never;
@@ -2590,9 +3291,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>A VerificationSession object can be canceled when it is in <code>requires_input</code> <a href="/docs/identity/how-sessions-work">status</a>.</p>
+        /**
+         * Cancel a VerificationSession
+         * @description <p>A VerificationSession object can be canceled when it is in <code>requires_input</code> <a href="/docs/identity/how-sessions-work">status</a>.</p>
          *
-         *     <p>Once canceled, future submission attempts are disabled. This cannot be undone. <a href="/docs/identity/verification-sessions#cancel">Learn more</a>.</p> */
+         *     <p>Once canceled, future submission attempts are disabled. This cannot be undone. <a href="/docs/identity/verification-sessions#cancel">Learn more</a>.</p>
+         */
         post: operations["PostIdentityVerificationSessionsSessionCancel"];
         delete?: never;
         options?: never;
@@ -2609,7 +3313,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Redact a VerificationSession to remove all collected information from Stripe. This will redact
+        /**
+         * Redact a VerificationSession
+         * @description <p>Redact a VerificationSession to remove all collected information from Stripe. This will redact
          *     the VerificationSession and all objects related to it, including VerificationReports, Events,
          *     request logs, etc.</p>
          *
@@ -2627,7 +3333,8 @@ export interface paths {
          *     placeholder. The <code>metadata</code> field will also be erased. Redacted objects cannot be updated or
          *     used for any purpose.</p>
          *
-         *     <p><a href="/docs/identity/verification-sessions#redact">Learn more</a>.</p> */
+         *     <p><a href="/docs/identity/verification-sessions#redact">Learn more</a>.</p>
+         */
         post: operations["PostIdentityVerificationSessionsSessionRedact"];
         delete?: never;
         options?: never;
@@ -2642,7 +3349,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List all templates, ordered by creation date, with the most recently created template appearing first.</p> */
+        /**
+         * List all invoice rendering templates
+         * @description <p>List all templates, ordered by creation date, with the most recently created template appearing first.</p>
+         */
         get: operations["GetInvoiceRenderingTemplates"];
         put?: never;
         post?: never;
@@ -2659,7 +3369,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an invoice rendering template with the given ID. It by default returns the latest version of the template. Optionally, specify a version to see previous versions.</p> */
+        /**
+         * Retrieve an invoice rendering template
+         * @description <p>Retrieves an invoice rendering template with the given ID. It by default returns the latest version of the template. Optionally, specify a version to see previous versions.</p>
+         */
         get: operations["GetInvoiceRenderingTemplatesTemplate"];
         put?: never;
         post?: never;
@@ -2678,7 +3391,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the status of an invoice rendering template to ‘archived’ so no new Stripe objects (customers, invoices, etc.) can reference it. The template can also no longer be updated. However, if the template is already set on a Stripe object, it will continue to be applied on invoices generated by it.</p> */
+        /**
+         * Archive an invoice rendering template
+         * @description <p>Updates the status of an invoice rendering template to ‘archived’ so no new Stripe objects (customers, invoices, etc.) can reference it. The template can also no longer be updated. However, if the template is already set on a Stripe object, it will continue to be applied on invoices generated by it.</p>
+         */
         post: operations["PostInvoiceRenderingTemplatesTemplateArchive"];
         delete?: never;
         options?: never;
@@ -2695,7 +3411,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Unarchive an invoice rendering template so it can be used on new Stripe objects again.</p> */
+        /**
+         * Unarchive an invoice rendering template
+         * @description <p>Unarchive an invoice rendering template so it can be used on new Stripe objects again.</p>
+         */
         post: operations["PostInvoiceRenderingTemplatesTemplateUnarchive"];
         delete?: never;
         options?: never;
@@ -2710,10 +3429,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.</p> */
+        /**
+         * List all invoice items
+         * @description <p>Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.</p>
+         */
         get: operations["GetInvoiceitems"];
         put?: never;
-        /** @description <p>Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is specified, the item will be on the next invoice created for the customer specified.</p> */
+        /**
+         * Create an invoice item
+         * @description <p>Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is specified, the item will be on the next invoice created for the customer specified.</p>
+         */
         post: operations["PostInvoiceitems"];
         delete?: never;
         options?: never;
@@ -2728,12 +3453,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the invoice item with the given ID.</p> */
+        /**
+         * Retrieve an invoice item
+         * @description <p>Retrieves the invoice item with the given ID.</p>
+         */
         get: operations["GetInvoiceitemsInvoiceitem"];
         put?: never;
-        /** @description <p>Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it’s attached to is closed.</p> */
+        /**
+         * Update an invoice item
+         * @description <p>Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it’s attached to is closed.</p>
+         */
         post: operations["PostInvoiceitemsInvoiceitem"];
-        /** @description <p>Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they’re not attached to invoices, or if it’s attached to a draft invoice.</p> */
+        /**
+         * Delete an invoice item
+         * @description <p>Deletes an invoice item, removing it from an invoice. Deleting invoice items is only possible when they’re not attached to invoices, or if it’s attached to a draft invoice.</p>
+         */
         delete: operations["DeleteInvoiceitemsInvoiceitem"];
         options?: never;
         head?: never;
@@ -2747,10 +3481,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.</p> */
+        /**
+         * List all invoices
+         * @description <p>You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.</p>
+         */
         get: operations["GetInvoices"];
         put?: never;
-        /** @description <p>This endpoint creates a draft invoice for a given customer. The invoice remains a draft until you <a href="#finalize_invoice">finalize</a> the invoice, which allows you to <a href="#pay_invoice">pay</a> or <a href="#send_invoice">send</a> the invoice to your customers.</p> */
+        /**
+         * Create an invoice
+         * @description <p>This endpoint creates a draft invoice for a given customer. The invoice remains a draft until you <a href="#finalize_invoice">finalize</a> the invoice, which allows you to <a href="#pay_invoice">pay</a> or <a href="#send_invoice">send</a> the invoice to your customers.</p>
+         */
         post: operations["PostInvoices"];
         delete?: never;
         options?: never;
@@ -2767,13 +3507,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.</p>
+        /**
+         * Create a preview invoice
+         * @description <p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.</p>
          *
          *     <p>Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer’s discount.</p>
          *
          *     <p>You can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass the <code>subscription_details.proration_date</code> parameter when doing the actual subscription update. The recommended way to get only the prorations being previewed is to consider only proration line items where <code>period[start]</code> is equal to the <code>subscription_details.proration_date</code> value passed in the request. </p>
          *
-         *     <p>Note: Currency conversion calculations use the latest exchange rates. Exchange rates may vary between the time of the preview and the time of the actual invoice creation. <a href="https://docs.stripe.com/currencies/conversions">Learn more</a></p> */
+         *     <p>Note: Currency conversion calculations use the latest exchange rates. Exchange rates may vary between the time of the preview and the time of the actual invoice creation. <a href="https://docs.stripe.com/currencies/conversions">Learn more</a></p>
+         */
         post: operations["PostInvoicesCreatePreview"];
         delete?: never;
         options?: never;
@@ -2788,10 +3531,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for invoices you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search invoices
+         * @description <p>Search for invoices you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetInvoicesSearch"];
         put?: never;
         post?: never;
@@ -2808,13 +3554,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.</p>
+        /**
+         * Retrieve an upcoming invoice
+         * @description <p>At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.</p>
          *
          *     <p>Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer’s discount.</p>
          *
          *     <p>You can preview the effects of updating a subscription, including a preview of what proration will take place. To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass the <code>subscription_details.proration_date</code> parameter when doing the actual subscription update. The recommended way to get only the prorations being previewed is to consider only proration line items where <code>period[start]</code> is equal to the <code>subscription_details.proration_date</code> value passed in the request.</p>
          *
-         *     <p>Note: Currency conversion calculations use the latest exchange rates. Exchange rates may vary between the time of the preview and the time of the actual invoice creation. <a href="https://docs.stripe.com/currencies/conversions">Learn more</a></p> */
+         *     <p>Note: Currency conversion calculations use the latest exchange rates. Exchange rates may vary between the time of the preview and the time of the actual invoice creation. <a href="https://docs.stripe.com/currencies/conversions">Learn more</a></p>
+         */
         get: operations["GetInvoicesUpcoming"];
         put?: never;
         post?: never;
@@ -2831,7 +3580,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving an upcoming invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve an upcoming invoice's line items
+         * @description <p>When retrieving an upcoming invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetInvoicesUpcomingLines"];
         put?: never;
         post?: never;
@@ -2848,17 +3600,26 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the invoice with the given ID.</p> */
+        /**
+         * Retrieve an invoice
+         * @description <p>Retrieves the invoice with the given ID.</p>
+         */
         get: operations["GetInvoicesInvoice"];
         put?: never;
-        /** @description <p>Draft invoices are fully editable. Once an invoice is <a href="/docs/billing/invoices/workflow#finalized">finalized</a>,
+        /**
+         * Update an invoice
+         * @description <p>Draft invoices are fully editable. Once an invoice is <a href="/docs/billing/invoices/workflow#finalized">finalized</a>,
          *     monetary values, as well as <code>collection_method</code>, become uneditable.</p>
          *
          *     <p>If you would like to stop the Stripe Billing engine from automatically finalizing, reattempting payments on,
          *     sending reminders for, or <a href="/docs/billing/invoices/reconciliation">automatically reconciling</a> invoices, pass
-         *     <code>auto_advance=false</code>.</p> */
+         *     <code>auto_advance=false</code>.</p>
+         */
         post: operations["PostInvoicesInvoice"];
-        /** @description <p>Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be <a href="#void_invoice">voided</a>.</p> */
+        /**
+         * Delete a draft invoice
+         * @description <p>Permanently deletes a one-off invoice draft. This cannot be undone. Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be <a href="#void_invoice">voided</a>.</p>
+         */
         delete: operations["DeleteInvoicesInvoice"];
         options?: never;
         head?: never;
@@ -2874,7 +3635,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Adds multiple line items to an invoice. This is only possible when an invoice is still a draft.</p> */
+        /**
+         * Bulk add invoice line items
+         * @description <p>Adds multiple line items to an invoice. This is only possible when an invoice is still a draft.</p>
+         */
         post: operations["PostInvoicesInvoiceAddLines"];
         delete?: never;
         options?: never;
@@ -2891,7 +3655,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you’d like to finalize a draft invoice manually, you can do so using this method.</p> */
+        /**
+         * Finalize an invoice
+         * @description <p>Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you’d like to finalize a draft invoice manually, you can do so using this method.</p>
+         */
         post: operations["PostInvoicesInvoiceFinalize"];
         delete?: never;
         options?: never;
@@ -2906,7 +3673,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving an invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve an invoice's line items
+         * @description <p>When retrieving an invoice, you’ll get a <strong>lines</strong> property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetInvoicesInvoiceLines"];
         put?: never;
         post?: never;
@@ -2925,10 +3695,13 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates an invoice’s line item. Some fields, such as <code>tax_amounts</code>, only live on the invoice line item,
+        /**
+         * Update an invoice's line item
+         * @description <p>Updates an invoice’s line item. Some fields, such as <code>tax_amounts</code>, only live on the invoice line item,
          *     so they can only be updated through this endpoint. Other fields, such as <code>amount</code>, live on both the invoice
          *     item and the invoice line item, so updates on this endpoint will propagate to the invoice item as well.
-         *     Updating an invoice’s line item is only possible before the invoice is finalized.</p> */
+         *     Updating an invoice’s line item is only possible before the invoice is finalized.</p>
+         */
         post: operations["PostInvoicesInvoiceLinesLineItemId"];
         delete?: never;
         options?: never;
@@ -2945,7 +3718,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.</p> */
+        /**
+         * Mark an invoice as uncollectible
+         * @description <p>Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.</p>
+         */
         post: operations["PostInvoicesInvoiceMarkUncollectible"];
         delete?: never;
         options?: never;
@@ -2962,7 +3738,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your <a href="https://dashboard.stripe.com/account/billing/automatic">subscriptions settings</a>. However, if you’d like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.</p> */
+        /**
+         * Pay an invoice
+         * @description <p>Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your <a href="https://dashboard.stripe.com/account/billing/automatic">subscriptions settings</a>. However, if you’d like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.</p>
+         */
         post: operations["PostInvoicesInvoicePay"];
         delete?: never;
         options?: never;
@@ -2979,7 +3758,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Removes multiple line items from an invoice. This is only possible when an invoice is still a draft.</p> */
+        /**
+         * Bulk remove invoice line items
+         * @description <p>Removes multiple line items from an invoice. This is only possible when an invoice is still a draft.</p>
+         */
         post: operations["PostInvoicesInvoiceRemoveLines"];
         delete?: never;
         options?: never;
@@ -2996,9 +3778,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Stripe will automatically send invoices to customers according to your <a href="https://dashboard.stripe.com/account/billing/automatic">subscriptions settings</a>. However, if you’d like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.</p>
+        /**
+         * Send an invoice for manual payment
+         * @description <p>Stripe will automatically send invoices to customers according to your <a href="https://dashboard.stripe.com/account/billing/automatic">subscriptions settings</a>. However, if you’d like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.</p>
          *
-         *     <p>Requests made in test-mode result in no emails being sent, despite sending an <code>invoice.sent</code> event.</p> */
+         *     <p>Requests made in test-mode result in no emails being sent, despite sending an <code>invoice.sent</code> event.</p>
+         */
         post: operations["PostInvoicesInvoiceSend"];
         delete?: never;
         options?: never;
@@ -3015,7 +3800,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates multiple line items on an invoice. This is only possible when an invoice is still a draft.</p> */
+        /**
+         * Bulk update invoice line items
+         * @description <p>Updates multiple line items on an invoice. This is only possible when an invoice is still a draft.</p>
+         */
         post: operations["PostInvoicesInvoiceUpdateLines"];
         delete?: never;
         options?: never;
@@ -3032,9 +3820,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to <a href="#delete_invoice">deletion</a>, however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.</p>
+        /**
+         * Void an invoice
+         * @description <p>Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to <a href="#delete_invoice">deletion</a>, however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.</p>
          *
-         *     <p>Consult with local regulations to determine whether and how an invoice might be amended, canceled, or voided in the jurisdiction you’re doing business in. You might need to <a href="#create_invoice">issue another invoice</a> or <a href="#create_credit_note">credit note</a> instead. Stripe recommends that you consult with your legal counsel for advice specific to your business.</p> */
+         *     <p>Consult with local regulations to determine whether and how an invoice might be amended, canceled, or voided in the jurisdiction you’re doing business in. You might need to <a href="#create_invoice">issue another invoice</a> or <a href="#create_credit_note">credit note</a> instead. Stripe recommends that you consult with your legal counsel for advice specific to your business.</p>
+         */
         post: operations["PostInvoicesInvoiceVoid"];
         delete?: never;
         options?: never;
@@ -3049,7 +3840,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Issuing <code>Authorization</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all authorizations
+         * @description <p>Returns a list of Issuing <code>Authorization</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingAuthorizations"];
         put?: never;
         post?: never;
@@ -3066,10 +3860,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Authorization</code> object.</p> */
+        /**
+         * Retrieve an authorization
+         * @description <p>Retrieves an Issuing <code>Authorization</code> object.</p>
+         */
         get: operations["GetIssuingAuthorizationsAuthorization"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Authorization</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update an authorization
+         * @description <p>Updates the specified Issuing <code>Authorization</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostIssuingAuthorizationsAuthorization"];
         delete?: never;
         options?: never;
@@ -3087,6 +3887,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
+         * Approve an authorization
          * @deprecated
          * @description <p>[Deprecated] Approves a pending Issuing <code>Authorization</code> object. This request should be made within the timeout window of the <a href="/docs/issuing/controls/real-time-authorizations">real-time authorization</a> flow.
          *     This method is deprecated. Instead, <a href="/docs/issuing/controls/real-time-authorizations#authorization-handling">respond directly to the webhook request to approve an authorization</a>.</p>
@@ -3108,6 +3909,7 @@ export interface paths {
         get?: never;
         put?: never;
         /**
+         * Decline an authorization
          * @deprecated
          * @description <p>[Deprecated] Declines a pending Issuing <code>Authorization</code> object. This request should be made within the timeout window of the <a href="/docs/issuing/controls/real-time-authorizations">real time authorization</a> flow.
          *     This method is deprecated. Instead, <a href="/docs/issuing/controls/real-time-authorizations#authorization-handling">respond directly to the webhook request to decline an authorization</a>.</p>
@@ -3126,10 +3928,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Issuing <code>Cardholder</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all cardholders
+         * @description <p>Returns a list of Issuing <code>Cardholder</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingCardholders"];
         put?: never;
-        /** @description <p>Creates a new Issuing <code>Cardholder</code> object that can be issued cards.</p> */
+        /**
+         * Create a cardholder
+         * @description <p>Creates a new Issuing <code>Cardholder</code> object that can be issued cards.</p>
+         */
         post: operations["PostIssuingCardholders"];
         delete?: never;
         options?: never;
@@ -3144,10 +3952,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Cardholder</code> object.</p> */
+        /**
+         * Retrieve a cardholder
+         * @description <p>Retrieves an Issuing <code>Cardholder</code> object.</p>
+         */
         get: operations["GetIssuingCardholdersCardholder"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Cardholder</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a cardholder
+         * @description <p>Updates the specified Issuing <code>Cardholder</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostIssuingCardholdersCardholder"];
         delete?: never;
         options?: never;
@@ -3162,10 +3976,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all cards
+         * @description <p>Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingCards"];
         put?: never;
-        /** @description <p>Creates an Issuing <code>Card</code> object.</p> */
+        /**
+         * Create a card
+         * @description <p>Creates an Issuing <code>Card</code> object.</p>
+         */
         post: operations["PostIssuingCards"];
         delete?: never;
         options?: never;
@@ -3180,10 +4000,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Card</code> object.</p> */
+        /**
+         * Retrieve a card
+         * @description <p>Retrieves an Issuing <code>Card</code> object.</p>
+         */
         get: operations["GetIssuingCardsCard"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Card</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a card
+         * @description <p>Updates the specified Issuing <code>Card</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostIssuingCardsCard"];
         delete?: never;
         options?: never;
@@ -3198,10 +4024,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Issuing <code>Dispute</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all disputes
+         * @description <p>Returns a list of Issuing <code>Dispute</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingDisputes"];
         put?: never;
-        /** @description <p>Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>evidence</code> object are optional at this point. Stripe only validates that required evidence is present during submission. Refer to <a href="/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute reasons and evidence</a> for more details about evidence requirements.</p> */
+        /**
+         * Create a dispute
+         * @description <p>Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>evidence</code> object are optional at this point. Stripe only validates that required evidence is present during submission. Refer to <a href="/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute reasons and evidence</a> for more details about evidence requirements.</p>
+         */
         post: operations["PostIssuingDisputes"];
         delete?: never;
         options?: never;
@@ -3216,10 +4048,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Dispute</code> object.</p> */
+        /**
+         * Retrieve a dispute
+         * @description <p>Retrieves an Issuing <code>Dispute</code> object.</p>
+         */
         get: operations["GetIssuingDisputesDispute"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Dispute</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>evidence</code> object can be unset by passing in an empty string.</p> */
+        /**
+         * Update a dispute
+         * @description <p>Updates the specified Issuing <code>Dispute</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>evidence</code> object can be unset by passing in an empty string.</p>
+         */
         post: operations["PostIssuingDisputesDispute"];
         delete?: never;
         options?: never;
@@ -3236,7 +4074,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence fields required for the dispute’s reason are present. For more details, see <a href="/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute reasons and evidence</a>.</p> */
+        /**
+         * Submit a dispute
+         * @description <p>Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence fields required for the dispute’s reason are present. For more details, see <a href="/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute reasons and evidence</a>.</p>
+         */
         post: operations["PostIssuingDisputesDisputeSubmit"];
         delete?: never;
         options?: never;
@@ -3251,10 +4092,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of personalization design objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all personalization designs
+         * @description <p>Returns a list of personalization design objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingPersonalizationDesigns"];
         put?: never;
-        /** @description <p>Creates a personalization design object.</p> */
+        /**
+         * Create a personalization design
+         * @description <p>Creates a personalization design object.</p>
+         */
         post: operations["PostIssuingPersonalizationDesigns"];
         delete?: never;
         options?: never;
@@ -3269,10 +4116,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a personalization design object.</p> */
+        /**
+         * Retrieve a personalization design
+         * @description <p>Retrieves a personalization design object.</p>
+         */
         get: operations["GetIssuingPersonalizationDesignsPersonalizationDesign"];
         put?: never;
-        /** @description <p>Updates a card personalization object.</p> */
+        /**
+         * Update a personalization design
+         * @description <p>Updates a card personalization object.</p>
+         */
         post: operations["PostIssuingPersonalizationDesignsPersonalizationDesign"];
         delete?: never;
         options?: never;
@@ -3287,7 +4140,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of physical bundle objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all physical bundles
+         * @description <p>Returns a list of physical bundle objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingPhysicalBundles"];
         put?: never;
         post?: never;
@@ -3304,7 +4160,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a physical bundle object.</p> */
+        /**
+         * Retrieve a physical bundle
+         * @description <p>Retrieves a physical bundle object.</p>
+         */
         get: operations["GetIssuingPhysicalBundlesPhysicalBundle"];
         put?: never;
         post?: never;
@@ -3321,10 +4180,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Settlement</code> object.</p> */
+        /**
+         * Retrieve a settlement
+         * @description <p>Retrieves an Issuing <code>Settlement</code> object.</p>
+         */
         get: operations["GetIssuingSettlementsSettlement"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Settlement</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a settlement
+         * @description <p>Updates the specified Issuing <code>Settlement</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostIssuingSettlementsSettlement"];
         delete?: never;
         options?: never;
@@ -3339,7 +4204,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all Issuing <code>Token</code> objects for a given card.</p> */
+        /**
+         * List all issuing tokens for card
+         * @description <p>Lists all Issuing <code>Token</code> objects for a given card.</p>
+         */
         get: operations["GetIssuingTokens"];
         put?: never;
         post?: never;
@@ -3356,10 +4224,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Token</code> object.</p> */
+        /**
+         * Retrieve an issuing token
+         * @description <p>Retrieves an Issuing <code>Token</code> object.</p>
+         */
         get: operations["GetIssuingTokensToken"];
         put?: never;
-        /** @description <p>Attempts to update the specified Issuing <code>Token</code> object to the status specified.</p> */
+        /**
+         * Update a token status
+         * @description <p>Attempts to update the specified Issuing <code>Token</code> object to the status specified.</p>
+         */
         post: operations["PostIssuingTokensToken"];
         delete?: never;
         options?: never;
@@ -3374,7 +4248,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Issuing <code>Transaction</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all transactions
+         * @description <p>Returns a list of Issuing <code>Transaction</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetIssuingTransactions"];
         put?: never;
         post?: never;
@@ -3391,10 +4268,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an Issuing <code>Transaction</code> object.</p> */
+        /**
+         * Retrieve a transaction
+         * @description <p>Retrieves an Issuing <code>Transaction</code> object.</p>
+         */
         get: operations["GetIssuingTransactionsTransaction"];
         put?: never;
-        /** @description <p>Updates the specified Issuing <code>Transaction</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a transaction
+         * @description <p>Updates the specified Issuing <code>Transaction</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostIssuingTransactionsTransaction"];
         delete?: never;
         options?: never;
@@ -3411,7 +4294,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>To launch the Financial Connections authorization flow, create a <code>Session</code>. The session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.</p> */
+        /**
+         * Create a Session
+         * @description <p>To launch the Financial Connections authorization flow, create a <code>Session</code>. The session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.</p>
+         */
         post: operations["PostLinkAccountSessions"];
         delete?: never;
         options?: never;
@@ -3426,7 +4312,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Financial Connections <code>Session</code></p> */
+        /**
+         * Retrieve a Session
+         * @description <p>Retrieves the details of a Financial Connections <code>Session</code></p>
+         */
         get: operations["GetLinkAccountSessionsSession"];
         put?: never;
         post?: never;
@@ -3443,7 +4332,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p> */
+        /**
+         * List Accounts
+         * @description <p>Returns a list of Financial Connections <code>Account</code> objects.</p>
+         */
         get: operations["GetLinkedAccounts"];
         put?: never;
         post?: never;
@@ -3460,7 +4352,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p> */
+        /**
+         * Retrieve an Account
+         * @description <p>Retrieves the details of an Financial Connections <code>Account</code>.</p>
+         */
         get: operations["GetLinkedAccountsAccount"];
         put?: never;
         post?: never;
@@ -3479,7 +4374,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Disables your access to a Financial Connections <code>Account</code>. You will no longer be able to access data associated with the account (e.g. balances, transactions).</p> */
+        /**
+         * Disconnect an Account
+         * @description <p>Disables your access to a Financial Connections <code>Account</code>. You will no longer be able to access data associated with the account (e.g. balances, transactions).</p>
+         */
         post: operations["PostLinkedAccountsAccountDisconnect"];
         delete?: never;
         options?: never;
@@ -3494,7 +4392,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists all owners for a given <code>Account</code></p> */
+        /**
+         * List Account Owners
+         * @description <p>Lists all owners for a given <code>Account</code></p>
+         */
         get: operations["GetLinkedAccountsAccountOwners"];
         put?: never;
         post?: never;
@@ -3513,7 +4414,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Refreshes the data associated with a Financial Connections <code>Account</code>.</p> */
+        /**
+         * Refresh Account data
+         * @description <p>Refreshes the data associated with a Financial Connections <code>Account</code>.</p>
+         */
         post: operations["PostLinkedAccountsAccountRefresh"];
         delete?: never;
         options?: never;
@@ -3528,7 +4432,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Mandate object.</p> */
+        /**
+         * Retrieve a Mandate
+         * @description <p>Retrieves a Mandate object.</p>
+         */
         get: operations["GetMandatesMandate"];
         put?: never;
         post?: never;
@@ -3545,10 +4452,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of PaymentIntents.</p> */
+        /**
+         * List all PaymentIntents
+         * @description <p>Returns a list of PaymentIntents.</p>
+         */
         get: operations["GetPaymentIntents"];
         put?: never;
-        /** @description <p>Creates a PaymentIntent object.</p>
+        /**
+         * Create a PaymentIntent
+         * @description <p>Creates a PaymentIntent object.</p>
          *
          *     <p>After the PaymentIntent is created, attach a payment method and <a href="/docs/api/payment_intents/confirm">confirm</a>
          *     to continue the payment. Learn more about <a href="/docs/payments/payment-intents">the available payment flows
@@ -3557,7 +4469,8 @@ export interface paths {
          *     <p>When you use <code>confirm=true</code> during creation, it’s equivalent to creating
          *     and confirming the PaymentIntent in the same call. You can use any parameters
          *     available in the <a href="/docs/api/payment_intents/confirm">confirm API</a> when you supply
-         *     <code>confirm=true</code>.</p> */
+         *     <code>confirm=true</code>.</p>
+         */
         post: operations["PostPaymentIntents"];
         delete?: never;
         options?: never;
@@ -3572,10 +4485,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for PaymentIntents you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search PaymentIntents
+         * @description <p>Search for PaymentIntents you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetPaymentIntentsSearch"];
         put?: never;
         post?: never;
@@ -3592,20 +4508,26 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a PaymentIntent that has previously been created. </p>
+        /**
+         * Retrieve a PaymentIntent
+         * @description <p>Retrieves the details of a PaymentIntent that has previously been created. </p>
          *
          *     <p>You can retrieve a PaymentIntent client-side using a publishable key when the <code>client_secret</code> is in the query string. </p>
          *
-         *     <p>If you retrieve a PaymentIntent with a publishable key, it only returns a subset of properties. Refer to the <a href="#payment_intent_object">payment intent</a> object reference for more details.</p> */
+         *     <p>If you retrieve a PaymentIntent with a publishable key, it only returns a subset of properties. Refer to the <a href="#payment_intent_object">payment intent</a> object reference for more details.</p>
+         */
         get: operations["GetPaymentIntentsIntent"];
         put?: never;
-        /** @description <p>Updates properties on a PaymentIntent object without confirming.</p>
+        /**
+         * Update a PaymentIntent
+         * @description <p>Updates properties on a PaymentIntent object without confirming.</p>
          *
          *     <p>Depending on which properties you update, you might need to confirm the
          *     PaymentIntent again. For example, updating the <code>payment_method</code>
          *     always requires you to confirm the PaymentIntent again. If you prefer to
          *     update and confirm at the same time, we recommend updating properties through
-         *     the <a href="/docs/api/payment_intents/confirm">confirm API</a> instead.</p> */
+         *     the <a href="/docs/api/payment_intents/confirm">confirm API</a> instead.</p>
+         */
         post: operations["PostPaymentIntentsIntent"];
         delete?: never;
         options?: never;
@@ -3622,7 +4544,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Manually reconcile the remaining amount for a <code>customer_balance</code> PaymentIntent.</p> */
+        /**
+         * Reconcile a customer_balance PaymentIntent
+         * @description <p>Manually reconcile the remaining amount for a <code>customer_balance</code> PaymentIntent.</p>
+         */
         post: operations["PostPaymentIntentsIntentApplyCustomerBalance"];
         delete?: never;
         options?: never;
@@ -3639,11 +4564,14 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>You can cancel a PaymentIntent object when it’s in one of these statuses: <code>requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation</code>, <code>requires_action</code> or, <a href="/docs/payments/intents">in rare cases</a>, <code>processing</code>. </p>
+        /**
+         * Cancel a PaymentIntent
+         * @description <p>You can cancel a PaymentIntent object when it’s in one of these statuses: <code>requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation</code>, <code>requires_action</code> or, <a href="/docs/payments/intents">in rare cases</a>, <code>processing</code>. </p>
          *
          *     <p>After it’s canceled, no additional charges are made by the PaymentIntent and any operations on the PaymentIntent fail with an error. For PaymentIntents with a <code>status</code> of <code>requires_capture</code>, the remaining <code>amount_capturable</code> is automatically refunded. </p>
          *
-         *     <p>You can’t cancel the PaymentIntent for a Checkout Session. <a href="/docs/api/checkout/sessions/expire">Expire the Checkout Session</a> instead.</p> */
+         *     <p>You can’t cancel the PaymentIntent for a Checkout Session. <a href="/docs/api/checkout/sessions/expire">Expire the Checkout Session</a> instead.</p>
+         */
         post: operations["PostPaymentIntentsIntentCancel"];
         delete?: never;
         options?: never;
@@ -3660,11 +4588,14 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Capture the funds of an existing uncaptured PaymentIntent when its status is <code>requires_capture</code>.</p>
+        /**
+         * Capture a PaymentIntent
+         * @description <p>Capture the funds of an existing uncaptured PaymentIntent when its status is <code>requires_capture</code>.</p>
          *
          *     <p>Uncaptured PaymentIntents are cancelled a set number of days (7 by default) after their creation.</p>
          *
-         *     <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and capture</a>.</p> */
+         *     <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and capture</a>.</p>
+         */
         post: operations["PostPaymentIntentsIntentCapture"];
         delete?: never;
         options?: never;
@@ -3681,7 +4612,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Confirm that your customer intends to pay with current or provided
+        /**
+         * Confirm a PaymentIntent
+         * @description <p>Confirm that your customer intends to pay with current or provided
          *     payment method. Upon confirmation, the PaymentIntent will attempt to initiate
          *     a payment.
          *     If the selected payment method requires additional authentication steps, the
@@ -3705,7 +4638,8 @@ export interface paths {
          *     attempt.
          *     There is a variable upper limit on how many times a PaymentIntent can be confirmed.
          *     After this limit is reached, any further calls to this endpoint will
-         *     transition the PaymentIntent to the <code>canceled</code> state.</p> */
+         *     transition the PaymentIntent to the <code>canceled</code> state.</p>
+         */
         post: operations["PostPaymentIntentsIntentConfirm"];
         delete?: never;
         options?: never;
@@ -3722,7 +4656,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Perform an incremental authorization on an eligible
+        /**
+         * Increment an authorization
+         * @description <p>Perform an incremental authorization on an eligible
          *     <a href="/docs/api/payment_intents/object">PaymentIntent</a>. To be eligible, the
          *     PaymentIntent’s status must be <code>requires_capture</code> and
          *     <a href="/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported">incremental_authorization_supported</a>
@@ -3745,7 +4681,8 @@ export interface paths {
          *     <p>Each PaymentIntent can have a maximum of 10 incremental authorization attempts, including declines.
          *     After it’s captured, a PaymentIntent can no longer be incremented.</p>
          *
-         *     <p>Learn more about <a href="/docs/terminal/features/incremental-authorizations">incremental authorizations</a>.</p> */
+         *     <p>Learn more about <a href="/docs/terminal/features/incremental-authorizations">incremental authorizations</a>.</p>
+         */
         post: operations["PostPaymentIntentsIntentIncrementAuthorization"];
         delete?: never;
         options?: never;
@@ -3762,7 +4699,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Verifies microdeposits on a PaymentIntent object.</p> */
+        /**
+         * Verify microdeposits on a PaymentIntent
+         * @description <p>Verifies microdeposits on a PaymentIntent object.</p>
+         */
         post: operations["PostPaymentIntentsIntentVerifyMicrodeposits"];
         delete?: never;
         options?: never;
@@ -3777,10 +4717,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your payment links.</p> */
+        /**
+         * List all payment links
+         * @description <p>Returns a list of your payment links.</p>
+         */
         get: operations["GetPaymentLinks"];
         put?: never;
-        /** @description <p>Creates a payment link.</p> */
+        /**
+         * Create a payment link
+         * @description <p>Creates a payment link.</p>
+         */
         post: operations["PostPaymentLinks"];
         delete?: never;
         options?: never;
@@ -3795,10 +4741,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a payment link.</p> */
+        /**
+         * Retrieve payment link
+         * @description <p>Retrieve a payment link.</p>
+         */
         get: operations["GetPaymentLinksPaymentLink"];
         put?: never;
-        /** @description <p>Updates a payment link.</p> */
+        /**
+         * Update a payment link
+         * @description <p>Updates a payment link.</p>
+         */
         post: operations["PostPaymentLinksPaymentLink"];
         delete?: never;
         options?: never;
@@ -3813,7 +4765,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a payment link, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve a payment link's line items
+         * @description <p>When retrieving a payment link, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetPaymentLinksPaymentLinkLineItems"];
         put?: never;
         post?: never;
@@ -3830,10 +4785,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>List payment method configurations</p> */
+        /**
+         * List payment method configurations
+         * @description <p>List payment method configurations</p>
+         */
         get: operations["GetPaymentMethodConfigurations"];
         put?: never;
-        /** @description <p>Creates a payment method configuration</p> */
+        /**
+         * Create a payment method configuration
+         * @description <p>Creates a payment method configuration</p>
+         */
         post: operations["PostPaymentMethodConfigurations"];
         delete?: never;
         options?: never;
@@ -3848,10 +4809,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve payment method configuration</p> */
+        /**
+         * Retrieve payment method configuration
+         * @description <p>Retrieve payment method configuration</p>
+         */
         get: operations["GetPaymentMethodConfigurationsConfiguration"];
         put?: never;
-        /** @description <p>Update payment method configuration</p> */
+        /**
+         * Update payment method configuration
+         * @description <p>Update payment method configuration</p>
+         */
         post: operations["PostPaymentMethodConfigurationsConfiguration"];
         delete?: never;
         options?: never;
@@ -3866,10 +4833,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Lists the details of existing payment method domains.</p> */
+        /**
+         * List payment method domains
+         * @description <p>Lists the details of existing payment method domains.</p>
+         */
         get: operations["GetPaymentMethodDomains"];
         put?: never;
-        /** @description <p>Creates a payment method domain.</p> */
+        /**
+         * Create a payment method domain
+         * @description <p>Creates a payment method domain.</p>
+         */
         post: operations["PostPaymentMethodDomains"];
         delete?: never;
         options?: never;
@@ -3884,10 +4857,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing payment method domain.</p> */
+        /**
+         * Retrieve a payment method domain
+         * @description <p>Retrieves the details of an existing payment method domain.</p>
+         */
         get: operations["GetPaymentMethodDomainsPaymentMethodDomain"];
         put?: never;
-        /** @description <p>Updates an existing payment method domain.</p> */
+        /**
+         * Update a payment method domain
+         * @description <p>Updates an existing payment method domain.</p>
+         */
         post: operations["PostPaymentMethodDomainsPaymentMethodDomain"];
         delete?: never;
         options?: never;
@@ -3904,12 +4883,15 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren’t satisfied when the domain was created, the payment method will be inactive on the domain.
+        /**
+         * Validate an existing payment method domain
+         * @description <p>Some payment methods such as Apple Pay require additional steps to verify a domain. If the requirements weren’t satisfied when the domain was created, the payment method will be inactive on the domain.
          *     The payment method doesn’t appear in Elements for this domain until it is active.</p>
          *
          *     <p>To activate a payment method on an existing payment method domain, complete the required validation steps specific to the payment method, and then validate the payment method domain with this endpoint.</p>
          *
-         *     <p>Related guides: <a href="/docs/payments/payment-methods/pmd-registration">Payment method domains</a>.</p> */
+         *     <p>Related guides: <a href="/docs/payments/payment-methods/pmd-registration">Payment method domains</a>.</p>
+         */
         post: operations["PostPaymentMethodDomainsPaymentMethodDomainValidate"];
         delete?: never;
         options?: never;
@@ -3924,12 +4906,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of PaymentMethods for Treasury flows. If you want to list the PaymentMethods attached to a Customer for payments, you should use the <a href="/docs/api/payment_methods/customer_list">List a Customer’s PaymentMethods</a> API instead.</p> */
+        /**
+         * List PaymentMethods
+         * @description <p>Returns a list of PaymentMethods for Treasury flows. If you want to list the PaymentMethods attached to a Customer for payments, you should use the <a href="/docs/api/payment_methods/customer_list">List a Customer’s PaymentMethods</a> API instead.</p>
+         */
         get: operations["GetPaymentMethods"];
         put?: never;
-        /** @description <p>Creates a PaymentMethod object. Read the <a href="/docs/stripe-js/reference#stripe-create-payment-method">Stripe.js reference</a> to learn how to create PaymentMethods via Stripe.js.</p>
+        /**
+         * Shares a PaymentMethod
+         * @description <p>Creates a PaymentMethod object. Read the <a href="/docs/stripe-js/reference#stripe-create-payment-method">Stripe.js reference</a> to learn how to create PaymentMethods via Stripe.js.</p>
          *
-         *     <p>Instead of creating a PaymentMethod directly, we recommend using the <a href="/docs/payments/accept-a-payment">PaymentIntents</a> API to accept a payment immediately or the <a href="/docs/payments/save-and-reuse">SetupIntent</a> API to collect payment method details ahead of a future payment.</p> */
+         *     <p>Instead of creating a PaymentMethod directly, we recommend using the <a href="/docs/payments/accept-a-payment">PaymentIntents</a> API to accept a payment immediately or the <a href="/docs/payments/save-and-reuse">SetupIntent</a> API to collect payment method details ahead of a future payment.</p>
+         */
         post: operations["PostPaymentMethods"];
         delete?: never;
         options?: never;
@@ -3944,10 +4932,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a PaymentMethod object attached to the StripeAccount. To retrieve a payment method attached to a Customer, you should use <a href="/docs/api/payment_methods/customer">Retrieve a Customer’s PaymentMethods</a></p> */
+        /**
+         * Retrieve a PaymentMethod
+         * @description <p>Retrieves a PaymentMethod object attached to the StripeAccount. To retrieve a payment method attached to a Customer, you should use <a href="/docs/api/payment_methods/customer">Retrieve a Customer’s PaymentMethods</a></p>
+         */
         get: operations["GetPaymentMethodsPaymentMethod"];
         put?: never;
-        /** @description <p>Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.</p> */
+        /**
+         * Update a PaymentMethod
+         * @description <p>Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.</p>
+         */
         post: operations["PostPaymentMethodsPaymentMethod"];
         delete?: never;
         options?: never;
@@ -3964,7 +4958,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Attaches a PaymentMethod object to a Customer.</p>
+        /**
+         * Attach a PaymentMethod to a Customer
+         * @description <p>Attaches a PaymentMethod object to a Customer.</p>
          *
          *     <p>To attach a new PaymentMethod to a customer for future payments, we recommend you use a <a href="/docs/api/setup_intents">SetupIntent</a>
          *     or a PaymentIntent with <a href="/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
@@ -3976,7 +4972,8 @@ export interface paths {
          *
          *     <p>To use this PaymentMethod as the default for invoice or subscription payments,
          *     set <a href="/docs/api/customers/update#update_customer-invoice_settings-default_payment_method"><code>invoice_settings.default_payment_method</code></a>,
-         *     on the Customer to the PaymentMethod’s ID.</p> */
+         *     on the Customer to the PaymentMethod’s ID.</p>
+         */
         post: operations["PostPaymentMethodsPaymentMethodAttach"];
         delete?: never;
         options?: never;
@@ -3993,7 +4990,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.</p> */
+        /**
+         * Detach a PaymentMethod from a Customer
+         * @description <p>Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.</p>
+         */
         post: operations["PostPaymentMethodsPaymentMethodDetach"];
         delete?: never;
         options?: never;
@@ -4008,14 +5008,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of existing payouts sent to third-party bank accounts or payouts that Stripe sent to you. The payouts return in sorted order, with the most recently created payouts appearing first.</p> */
+        /**
+         * List all payouts
+         * @description <p>Returns a list of existing payouts sent to third-party bank accounts or payouts that Stripe sent to you. The payouts return in sorted order, with the most recently created payouts appearing first.</p>
+         */
         get: operations["GetPayouts"];
         put?: never;
-        /** @description <p>To send funds to your own bank account, create a new payout object. Your <a href="#balance">Stripe balance</a> must cover the payout amount. If it doesn’t, you receive an “Insufficient Funds” error.</p>
+        /**
+         * Create a payout
+         * @description <p>To send funds to your own bank account, create a new payout object. Your <a href="#balance">Stripe balance</a> must cover the payout amount. If it doesn’t, you receive an “Insufficient Funds” error.</p>
          *
          *     <p>If your API key is in test mode, money won’t actually be sent, though every other action occurs as if you’re in live mode.</p>
          *
-         *     <p>If you create a manual payout on a Stripe account that uses multiple payment source types, you need to specify the source type balance that the payout draws from. The <a href="#balance_object">balance object</a> details available and pending amounts by source type.</p> */
+         *     <p>If you create a manual payout on a Stripe account that uses multiple payment source types, you need to specify the source type balance that the payout draws from. The <a href="#balance_object">balance object</a> details available and pending amounts by source type.</p>
+         */
         post: operations["PostPayouts"];
         delete?: never;
         options?: never;
@@ -4030,10 +5036,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing payout. Supply the unique payout ID from either a payout creation request or the payout list. Stripe returns the corresponding payout information.</p> */
+        /**
+         * Retrieve a payout
+         * @description <p>Retrieves the details of an existing payout. Supply the unique payout ID from either a payout creation request or the payout list. Stripe returns the corresponding payout information.</p>
+         */
         get: operations["GetPayoutsPayout"];
         put?: never;
-        /** @description <p>Updates the specified payout by setting the values of the parameters you pass. We don’t change parameters that you don’t provide. This request only accepts the metadata as arguments.</p> */
+        /**
+         * Update a payout
+         * @description <p>Updates the specified payout by setting the values of the parameters you pass. We don’t change parameters that you don’t provide. This request only accepts the metadata as arguments.</p>
+         */
         post: operations["PostPayoutsPayout"];
         delete?: never;
         options?: never;
@@ -4050,7 +5062,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>You can cancel a previously created payout if its status is <code>pending</code>. Stripe refunds the funds to your available balance. You can’t cancel automatic Stripe payouts.</p> */
+        /**
+         * Cancel a payout
+         * @description <p>You can cancel a previously created payout if its status is <code>pending</code>. Stripe refunds the funds to your available balance. You can’t cancel automatic Stripe payouts.</p>
+         */
         post: operations["PostPayoutsPayoutCancel"];
         delete?: never;
         options?: never;
@@ -4067,9 +5082,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is manual and in the <code>pending</code> status, use <code>/v1/payouts/:id/cancel</code> instead.</p>
+        /**
+         * Reverse a payout
+         * @description <p>Reverses a payout by debiting the destination bank account. At this time, you can only reverse payouts for connected accounts to US bank accounts. If the payout is manual and in the <code>pending</code> status, use <code>/v1/payouts/:id/cancel</code> instead.</p>
          *
-         *     <p>By requesting a reversal through <code>/v1/payouts/:id/reverse</code>, you confirm that the authorized signatory of the selected bank account authorizes the debit on the bank account and that no other authorization is required.</p> */
+         *     <p>By requesting a reversal through <code>/v1/payouts/:id/reverse</code>, you confirm that the authorized signatory of the selected bank account authorizes the debit on the bank account and that no other authorization is required.</p>
+         */
         post: operations["PostPayoutsPayoutReverse"];
         delete?: never;
         options?: never;
@@ -4084,10 +5102,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your plans.</p> */
+        /**
+         * List all plans
+         * @description <p>Returns a list of your plans.</p>
+         */
         get: operations["GetPlans"];
         put?: never;
-        /** @description <p>You can now model subscriptions more flexibly using the <a href="#prices">Prices API</a>. It replaces the Plans API and is backwards compatible to simplify your migration.</p> */
+        /**
+         * Create a plan
+         * @description <p>You can now model subscriptions more flexibly using the <a href="#prices">Prices API</a>. It replaces the Plans API and is backwards compatible to simplify your migration.</p>
+         */
         post: operations["PostPlans"];
         delete?: never;
         options?: never;
@@ -4102,12 +5126,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the plan with the given ID.</p> */
+        /**
+         * Retrieve a plan
+         * @description <p>Retrieves the plan with the given ID.</p>
+         */
         get: operations["GetPlansPlan"];
         put?: never;
-        /** @description <p>Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan’s ID, amount, currency, or billing cycle.</p> */
+        /**
+         * Update a plan
+         * @description <p>Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan’s ID, amount, currency, or billing cycle.</p>
+         */
         post: operations["PostPlansPlan"];
-        /** @description <p>Deleting plans means new subscribers can’t be added. Existing subscribers aren’t affected.</p> */
+        /**
+         * Delete a plan
+         * @description <p>Deleting plans means new subscribers can’t be added. Existing subscribers aren’t affected.</p>
+         */
         delete: operations["DeletePlansPlan"];
         options?: never;
         head?: never;
@@ -4121,10 +5154,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your active prices, excluding <a href="/docs/products-prices/pricing-models#inline-pricing">inline prices</a>. For the list of inactive prices, set <code>active</code> to false.</p> */
+        /**
+         * List all prices
+         * @description <p>Returns a list of your active prices, excluding <a href="/docs/products-prices/pricing-models#inline-pricing">inline prices</a>. For the list of inactive prices, set <code>active</code> to false.</p>
+         */
         get: operations["GetPrices"];
         put?: never;
-        /** @description <p>Creates a new price for an existing product. The price can be recurring or one-time.</p> */
+        /**
+         * Create a price
+         * @description <p>Creates a new price for an existing product. The price can be recurring or one-time.</p>
+         */
         post: operations["PostPrices"];
         delete?: never;
         options?: never;
@@ -4139,10 +5178,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for prices you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search prices
+         * @description <p>Search for prices you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetPricesSearch"];
         put?: never;
         post?: never;
@@ -4159,10 +5201,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the price with the given ID.</p> */
+        /**
+         * Retrieve a price
+         * @description <p>Retrieves the price with the given ID.</p>
+         */
         get: operations["GetPricesPrice"];
         put?: never;
-        /** @description <p>Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.</p> */
+        /**
+         * Update a price
+         * @description <p>Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.</p>
+         */
         post: operations["PostPricesPrice"];
         delete?: never;
         options?: never;
@@ -4177,10 +5225,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p> */
+        /**
+         * List all products
+         * @description <p>Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.</p>
+         */
         get: operations["GetProducts"];
         put?: never;
-        /** @description <p>Creates a new product object.</p> */
+        /**
+         * Create a product
+         * @description <p>Creates a new product object.</p>
+         */
         post: operations["PostProducts"];
         delete?: never;
         options?: never;
@@ -4195,10 +5249,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for products you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search products
+         * @description <p>Search for products you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetProductsSearch"];
         put?: never;
         post?: never;
@@ -4215,12 +5272,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p> */
+        /**
+         * Retrieve a product
+         * @description <p>Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.</p>
+         */
         get: operations["GetProductsId"];
         put?: never;
-        /** @description <p>Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a product
+         * @description <p>Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostProductsId"];
-        /** @description <p>Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with <code>type=good</code> is only possible if it has no SKUs associated with it.</p> */
+        /**
+         * Delete a product
+         * @description <p>Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with <code>type=good</code> is only possible if it has no SKUs associated with it.</p>
+         */
         delete: operations["DeleteProductsId"];
         options?: never;
         head?: never;
@@ -4234,10 +5300,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve a list of features for a product</p> */
+        /**
+         * List all features attached to a product
+         * @description <p>Retrieve a list of features for a product</p>
+         */
         get: operations["GetProductsProductFeatures"];
         put?: never;
-        /** @description <p>Creates a product_feature, which represents a feature attachment to a product</p> */
+        /**
+         * Attach a feature to a product
+         * @description <p>Creates a product_feature, which represents a feature attachment to a product</p>
+         */
         post: operations["PostProductsProductFeatures"];
         delete?: never;
         options?: never;
@@ -4252,11 +5324,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a product_feature, which represents a feature attachment to a product</p> */
+        /**
+         * Retrieve a product_feature
+         * @description <p>Retrieves a product_feature, which represents a feature attachment to a product</p>
+         */
         get: operations["GetProductsProductFeaturesId"];
         put?: never;
         post?: never;
-        /** @description <p>Deletes the feature attachment to a product</p> */
+        /**
+         * Remove a feature from a product
+         * @description <p>Deletes the feature attachment to a product</p>
+         */
         delete: operations["DeleteProductsProductFeaturesId"];
         options?: never;
         head?: never;
@@ -4270,10 +5348,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your promotion codes.</p> */
+        /**
+         * List all promotion codes
+         * @description <p>Returns a list of your promotion codes.</p>
+         */
         get: operations["GetPromotionCodes"];
         put?: never;
-        /** @description <p>A promotion code points to a coupon. You can optionally restrict the code to a specific customer, redemption limit, and expiration date.</p> */
+        /**
+         * Create a promotion code
+         * @description <p>A promotion code points to a coupon. You can optionally restrict the code to a specific customer, redemption limit, and expiration date.</p>
+         */
         post: operations["PostPromotionCodes"];
         delete?: never;
         options?: never;
@@ -4288,10 +5372,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the promotion code with the given ID. In order to retrieve a promotion code by the customer-facing <code>code</code> use <a href="/docs/api/promotion_codes/list">list</a> with the desired <code>code</code>.</p> */
+        /**
+         * Retrieve a promotion code
+         * @description <p>Retrieves the promotion code with the given ID. In order to retrieve a promotion code by the customer-facing <code>code</code> use <a href="/docs/api/promotion_codes/list">list</a> with the desired <code>code</code>.</p>
+         */
         get: operations["GetPromotionCodesPromotionCode"];
         put?: never;
-        /** @description <p>Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.</p> */
+        /**
+         * Update a promotion code
+         * @description <p>Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.</p>
+         */
         post: operations["PostPromotionCodesPromotionCode"];
         delete?: never;
         options?: never;
@@ -4306,10 +5396,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your quotes.</p> */
+        /**
+         * List all quotes
+         * @description <p>Returns a list of your quotes.</p>
+         */
         get: operations["GetQuotes"];
         put?: never;
-        /** @description <p>A quote models prices and services for a customer. Default options for <code>header</code>, <code>description</code>, <code>footer</code>, and <code>expires_at</code> can be set in the dashboard via the <a href="https://dashboard.stripe.com/settings/billing/quote">quote template</a>.</p> */
+        /**
+         * Create a quote
+         * @description <p>A quote models prices and services for a customer. Default options for <code>header</code>, <code>description</code>, <code>footer</code>, and <code>expires_at</code> can be set in the dashboard via the <a href="https://dashboard.stripe.com/settings/billing/quote">quote template</a>.</p>
+         */
         post: operations["PostQuotes"];
         delete?: never;
         options?: never;
@@ -4324,10 +5420,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the quote with the given ID.</p> */
+        /**
+         * Retrieve a quote
+         * @description <p>Retrieves the quote with the given ID.</p>
+         */
         get: operations["GetQuotesQuote"];
         put?: never;
-        /** @description <p>A quote models prices and services for a customer.</p> */
+        /**
+         * Update a quote
+         * @description <p>A quote models prices and services for a customer.</p>
+         */
         post: operations["PostQuotesQuote"];
         delete?: never;
         options?: never;
@@ -4344,7 +5446,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Accepts the specified quote.</p> */
+        /**
+         * Accept a quote
+         * @description <p>Accepts the specified quote.</p>
+         */
         post: operations["PostQuotesQuoteAccept"];
         delete?: never;
         options?: never;
@@ -4361,7 +5466,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels the quote.</p> */
+        /**
+         * Cancel a quote
+         * @description <p>Cancels the quote.</p>
+         */
         post: operations["PostQuotesQuoteCancel"];
         delete?: never;
         options?: never;
@@ -4376,7 +5484,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a quote, there is an includable <a href="https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items"><strong>computed.upfront.line_items</strong></a> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.</p> */
+        /**
+         * Retrieve a quote's upfront line items
+         * @description <p>When retrieving a quote, there is an includable <a href="https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items"><strong>computed.upfront.line_items</strong></a> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.</p>
+         */
         get: operations["GetQuotesQuoteComputedUpfrontLineItems"];
         put?: never;
         post?: never;
@@ -4395,7 +5506,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Finalizes the quote.</p> */
+        /**
+         * Finalize a quote
+         * @description <p>Finalizes the quote.</p>
+         */
         post: operations["PostQuotesQuoteFinalize"];
         delete?: never;
         options?: never;
@@ -4410,7 +5524,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>When retrieving a quote, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p> */
+        /**
+         * Retrieve a quote's line items
+         * @description <p>When retrieving a quote, there is an includable <strong>line_items</strong> property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.</p>
+         */
         get: operations["GetQuotesQuoteLineItems"];
         put?: never;
         post?: never;
@@ -4427,7 +5544,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Download the PDF for a finalized quote. Explanation for special handling can be found <a href="https://docs.stripe.com/quotes/overview#quote_pdf">here</a></p> */
+        /**
+         * Download quote PDF
+         * @description <p>Download the PDF for a finalized quote. Explanation for special handling can be found <a href="https://docs.stripe.com/quotes/overview#quote_pdf">here</a></p>
+         */
         get: operations["GetQuotesQuotePdf"];
         put?: never;
         post?: never;
@@ -4444,7 +5564,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of early fraud warnings.</p> */
+        /**
+         * List all early fraud warnings
+         * @description <p>Returns a list of early fraud warnings.</p>
+         */
         get: operations["GetRadarEarlyFraudWarnings"];
         put?: never;
         post?: never;
@@ -4461,9 +5584,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an early fraud warning that has previously been created. </p>
+        /**
+         * Retrieve an early fraud warning
+         * @description <p>Retrieves the details of an early fraud warning that has previously been created. </p>
          *
-         *     <p>Please refer to the <a href="#early_fraud_warning_object">early fraud warning</a> object reference for more details.</p> */
+         *     <p>Please refer to the <a href="#early_fraud_warning_object">early fraud warning</a> object reference for more details.</p>
+         */
         get: operations["GetRadarEarlyFraudWarningsEarlyFraudWarning"];
         put?: never;
         post?: never;
@@ -4480,10 +5606,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>ValueListItem</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all value list items
+         * @description <p>Returns a list of <code>ValueListItem</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetRadarValueListItems"];
         put?: never;
-        /** @description <p>Creates a new <code>ValueListItem</code> object, which is added to the specified parent value list.</p> */
+        /**
+         * Create a value list item
+         * @description <p>Creates a new <code>ValueListItem</code> object, which is added to the specified parent value list.</p>
+         */
         post: operations["PostRadarValueListItems"];
         delete?: never;
         options?: never;
@@ -4498,11 +5630,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>ValueListItem</code> object.</p> */
+        /**
+         * Retrieve a value list item
+         * @description <p>Retrieves a <code>ValueListItem</code> object.</p>
+         */
         get: operations["GetRadarValueListItemsItem"];
         put?: never;
         post?: never;
-        /** @description <p>Deletes a <code>ValueListItem</code> object, removing it from its parent value list.</p> */
+        /**
+         * Delete a value list item
+         * @description <p>Deletes a <code>ValueListItem</code> object, removing it from its parent value list.</p>
+         */
         delete: operations["DeleteRadarValueListItemsItem"];
         options?: never;
         head?: never;
@@ -4516,10 +5654,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>ValueList</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all value lists
+         * @description <p>Returns a list of <code>ValueList</code> objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetRadarValueLists"];
         put?: never;
-        /** @description <p>Creates a new <code>ValueList</code> object, which can then be referenced in rules.</p> */
+        /**
+         * Create a value list
+         * @description <p>Creates a new <code>ValueList</code> object, which can then be referenced in rules.</p>
+         */
         post: operations["PostRadarValueLists"];
         delete?: never;
         options?: never;
@@ -4534,12 +5678,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>ValueList</code> object.</p> */
+        /**
+         * Retrieve a value list
+         * @description <p>Retrieves a <code>ValueList</code> object.</p>
+         */
         get: operations["GetRadarValueListsValueList"];
         put?: never;
-        /** @description <p>Updates a <code>ValueList</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that <code>item_type</code> is immutable.</p> */
+        /**
+         * Update a value list
+         * @description <p>Updates a <code>ValueList</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that <code>item_type</code> is immutable.</p>
+         */
         post: operations["PostRadarValueListsValueList"];
-        /** @description <p>Deletes a <code>ValueList</code> object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.</p> */
+        /**
+         * Delete a value list
+         * @description <p>Deletes a <code>ValueList</code> object, also deleting any items contained within the value list. To be deleted, a value list must not be referenced in any rules.</p>
+         */
         delete: operations["DeleteRadarValueListsValueList"];
         options?: never;
         head?: never;
@@ -4553,10 +5706,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of all refunds you created. We return the refunds in sorted order, with the most recent refunds appearing first. The 10 most recent refunds are always available by default on the Charge object.</p> */
+        /**
+         * List all refunds
+         * @description <p>Returns a list of all refunds you created. We return the refunds in sorted order, with the most recent refunds appearing first. The 10 most recent refunds are always available by default on the Charge object.</p>
+         */
         get: operations["GetRefunds"];
         put?: never;
-        /** @description <p>When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.</p>
+        /**
+         * Create customer balance refund
+         * @description <p>When you create a new refund, you must specify a Charge or a PaymentIntent object on which to create it.</p>
          *
          *     <p>Creating a new refund will refund a charge that has previously been created but not yet refunded.
          *     Funds will be refunded to the credit or debit card that was originally charged.</p>
@@ -4566,7 +5724,8 @@ export interface paths {
          *
          *     <p>Once entirely refunded, a charge can’t be refunded again.
          *     This method will raise an error when called on an already-refunded charge,
-         *     or when trying to refund more money than is left on a charge.</p> */
+         *     or when trying to refund more money than is left on a charge.</p>
+         */
         post: operations["PostRefunds"];
         delete?: never;
         options?: never;
@@ -4581,12 +5740,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing refund.</p> */
+        /**
+         * Retrieve a refund
+         * @description <p>Retrieves the details of an existing refund.</p>
+         */
         get: operations["GetRefundsRefund"];
         put?: never;
-        /** @description <p>Updates the refund that you specify by setting the values of the passed parameters. Any parameters that you don’t provide remain unchanged.</p>
+        /**
+         * Update a refund
+         * @description <p>Updates the refund that you specify by setting the values of the passed parameters. Any parameters that you don’t provide remain unchanged.</p>
          *
-         *     <p>This request only accepts <code>metadata</code> as an argument.</p> */
+         *     <p>This request only accepts <code>metadata</code> as an argument.</p>
+         */
         post: operations["PostRefundsRefund"];
         delete?: never;
         options?: never;
@@ -4603,9 +5768,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels a refund with a status of <code>requires_action</code>.</p>
+        /**
+         * Cancel a refund
+         * @description <p>Cancels a refund with a status of <code>requires_action</code>.</p>
          *
-         *     <p>You can’t cancel refunds in other states. Only refunds for payment methods that require customer action can enter the <code>requires_action</code> state.</p> */
+         *     <p>You can’t cancel refunds in other states. Only refunds for payment methods that require customer action can enter the <code>requires_action</code> state.</p>
+         */
         post: operations["PostRefundsRefundCancel"];
         delete?: never;
         options?: never;
@@ -4620,10 +5788,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Report Runs, with the most recent appearing first.</p> */
+        /**
+         * List all Report Runs
+         * @description <p>Returns a list of Report Runs, with the most recent appearing first.</p>
+         */
         get: operations["GetReportingReportRuns"];
         put?: never;
-        /** @description <p>Creates a new object and begin running the report. (Certain report types require a <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.)</p> */
+        /**
+         * Create a Report Run
+         * @description <p>Creates a new object and begin running the report. (Certain report types require a <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.)</p>
+         */
         post: operations["PostReportingReportRuns"];
         delete?: never;
         options?: never;
@@ -4638,7 +5812,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing Report Run.</p> */
+        /**
+         * Retrieve a Report Run
+         * @description <p>Retrieves the details of an existing Report Run.</p>
+         */
         get: operations["GetReportingReportRunsReportRun"];
         put?: never;
         post?: never;
@@ -4655,7 +5832,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a full list of Report Types.</p> */
+        /**
+         * List all Report Types
+         * @description <p>Returns a full list of Report Types.</p>
+         */
         get: operations["GetReportingReportTypes"];
         put?: never;
         post?: never;
@@ -4672,7 +5852,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a Report Type. (Certain report types require a <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.)</p> */
+        /**
+         * Retrieve a Report Type
+         * @description <p>Retrieves the details of a Report Type. (Certain report types require a <a href="https://stripe.com/docs/keys#test-live-modes">live-mode API key</a>.)</p>
+         */
         get: operations["GetReportingReportTypesReportType"];
         put?: never;
         post?: never;
@@ -4689,7 +5872,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>Review</code> objects that have <code>open</code> set to <code>true</code>. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p> */
+        /**
+         * List all open reviews
+         * @description <p>Returns a list of <code>Review</code> objects that have <code>open</code> set to <code>true</code>. The objects are sorted in descending order by creation date, with the most recently created object appearing first.</p>
+         */
         get: operations["GetReviews"];
         put?: never;
         post?: never;
@@ -4706,7 +5892,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>Review</code> object.</p> */
+        /**
+         * Retrieve a review
+         * @description <p>Retrieves a <code>Review</code> object.</p>
+         */
         get: operations["GetReviewsReview"];
         put?: never;
         post?: never;
@@ -4725,7 +5914,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Approves a <code>Review</code> object, closing it and removing it from the list of reviews.</p> */
+        /**
+         * Approve a review
+         * @description <p>Approves a <code>Review</code> object, closing it and removing it from the list of reviews.</p>
+         */
         post: operations["PostReviewsReviewApprove"];
         delete?: never;
         options?: never;
@@ -4740,7 +5932,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of SetupAttempts that associate with a provided SetupIntent.</p> */
+        /**
+         * List all SetupAttempts
+         * @description <p>Returns a list of SetupAttempts that associate with a provided SetupIntent.</p>
+         */
         get: operations["GetSetupAttempts"];
         put?: never;
         post?: never;
@@ -4757,13 +5952,19 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of SetupIntents.</p> */
+        /**
+         * List all SetupIntents
+         * @description <p>Returns a list of SetupIntents.</p>
+         */
         get: operations["GetSetupIntents"];
         put?: never;
-        /** @description <p>Creates a SetupIntent object.</p>
+        /**
+         * Create a SetupIntent
+         * @description <p>Creates a SetupIntent object.</p>
          *
          *     <p>After you create the SetupIntent, attach a payment method and <a href="/docs/api/setup_intents/confirm">confirm</a>
-         *     it to collect any required permissions to charge the payment method later.</p> */
+         *     it to collect any required permissions to charge the payment method later.</p>
+         */
         post: operations["PostSetupIntents"];
         delete?: never;
         options?: never;
@@ -4778,14 +5979,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a SetupIntent that has previously been created. </p>
+        /**
+         * Retrieve a SetupIntent
+         * @description <p>Retrieves the details of a SetupIntent that has previously been created. </p>
          *
          *     <p>Client-side retrieval using a publishable key is allowed when the <code>client_secret</code> is provided in the query string. </p>
          *
-         *     <p>When retrieved with a publishable key, only a subset of properties will be returned. Please refer to the <a href="#setup_intent_object">SetupIntent</a> object reference for more details.</p> */
+         *     <p>When retrieved with a publishable key, only a subset of properties will be returned. Please refer to the <a href="#setup_intent_object">SetupIntent</a> object reference for more details.</p>
+         */
         get: operations["GetSetupIntentsIntent"];
         put?: never;
-        /** @description <p>Updates a SetupIntent object.</p> */
+        /**
+         * Update a SetupIntent
+         * @description <p>Updates a SetupIntent object.</p>
+         */
         post: operations["PostSetupIntentsIntent"];
         delete?: never;
         options?: never;
@@ -4802,9 +6009,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>You can cancel a SetupIntent object when it’s in one of these statuses: <code>requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action</code>. </p>
+        /**
+         * Cancel a SetupIntent
+         * @description <p>You can cancel a SetupIntent object when it’s in one of these statuses: <code>requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action</code>. </p>
          *
-         *     <p>After you cancel it, setup is abandoned and any operations on the SetupIntent fail with an error. You can’t cancel the SetupIntent for a Checkout Session. <a href="/docs/api/checkout/sessions/expire">Expire the Checkout Session</a> instead.</p> */
+         *     <p>After you cancel it, setup is abandoned and any operations on the SetupIntent fail with an error. You can’t cancel the SetupIntent for a Checkout Session. <a href="/docs/api/checkout/sessions/expire">Expire the Checkout Session</a> instead.</p>
+         */
         post: operations["PostSetupIntentsIntentCancel"];
         delete?: never;
         options?: never;
@@ -4821,7 +6031,9 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Confirm that your customer intends to set up the current or
+        /**
+         * Confirm a SetupIntent
+         * @description <p>Confirm that your customer intends to set up the current or
          *     provided payment method. For example, you would confirm a SetupIntent
          *     when a customer hits the “Save” button on a payment method management
          *     page on your website.</p>
@@ -4834,7 +6046,8 @@ export interface paths {
          *     suggest additional actions via <code>next_action</code>. If setup fails,
          *     the SetupIntent will transition to the
          *     <code>requires_payment_method</code> status or the <code>canceled</code> status if the
-         *     confirmation limit is reached.</p> */
+         *     confirmation limit is reached.</p>
+         */
         post: operations["PostSetupIntentsIntentConfirm"];
         delete?: never;
         options?: never;
@@ -4851,7 +6064,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Verifies microdeposits on a SetupIntent object.</p> */
+        /**
+         * Verify microdeposits on a SetupIntent
+         * @description <p>Verifies microdeposits on a SetupIntent object.</p>
+         */
         post: operations["PostSetupIntentsIntentVerifyMicrodeposits"];
         delete?: never;
         options?: never;
@@ -4866,10 +6082,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your shipping rates.</p> */
+        /**
+         * List all shipping rates
+         * @description <p>Returns a list of your shipping rates.</p>
+         */
         get: operations["GetShippingRates"];
         put?: never;
-        /** @description <p>Creates a new shipping rate object.</p> */
+        /**
+         * Create a shipping rate
+         * @description <p>Creates a new shipping rate object.</p>
+         */
         post: operations["PostShippingRates"];
         delete?: never;
         options?: never;
@@ -4884,10 +6106,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns the shipping rate object with the given ID.</p> */
+        /**
+         * Retrieve a shipping rate
+         * @description <p>Returns the shipping rate object with the given ID.</p>
+         */
         get: operations["GetShippingRatesShippingRateToken"];
         put?: never;
-        /** @description <p>Updates an existing shipping rate object.</p> */
+        /**
+         * Update a shipping rate
+         * @description <p>Updates an existing shipping rate object.</p>
+         */
         post: operations["PostShippingRatesShippingRateToken"];
         delete?: never;
         options?: never;
@@ -4902,7 +6130,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of scheduled query runs.</p> */
+        /**
+         * List all scheduled query runs
+         * @description <p>Returns a list of scheduled query runs.</p>
+         */
         get: operations["GetSigmaScheduledQueryRuns"];
         put?: never;
         post?: never;
@@ -4919,7 +6150,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an scheduled query run.</p> */
+        /**
+         * Retrieve a scheduled query run
+         * @description <p>Retrieves the details of an scheduled query run.</p>
+         */
         get: operations["GetSigmaScheduledQueryRunsScheduledQueryRun"];
         put?: never;
         post?: never;
@@ -4938,7 +6172,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a new source object.</p> */
+        /**
+         * Shares a source
+         * @description <p>Creates a new source object.</p>
+         */
         post: operations["PostSources"];
         delete?: never;
         options?: never;
@@ -4953,12 +6190,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an existing source object. Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.</p> */
+        /**
+         * Retrieve a source
+         * @description <p>Retrieves an existing source object. Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.</p>
+         */
         get: operations["GetSourcesSource"];
         put?: never;
-        /** @description <p>Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+        /**
+         * Update a source
+         * @description <p>Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
          *
-         *     <p>This request accepts the <code>metadata</code> and <code>owner</code> as arguments. It is also possible to update type specific information for selected payment methods. Please refer to our <a href="/docs/sources">payment method guides</a> for more detail.</p> */
+         *     <p>This request accepts the <code>metadata</code> and <code>owner</code> as arguments. It is also possible to update type specific information for selected payment methods. Please refer to our <a href="/docs/sources">payment method guides</a> for more detail.</p>
+         */
         post: operations["PostSourcesSource"];
         delete?: never;
         options?: never;
@@ -4973,7 +6216,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a new Source MandateNotification.</p> */
+        /**
+         * Retrieve a Source MandateNotification
+         * @description <p>Retrieves a new Source MandateNotification.</p>
+         */
         get: operations["GetSourcesSourceMandateNotificationsMandateNotification"];
         put?: never;
         post?: never;
@@ -5007,7 +6253,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieve an existing source transaction object. Supply the unique source ID from a source creation request and the source transaction ID and Stripe will return the corresponding up-to-date source object information.</p> */
+        /**
+         * Retrieve a source transaction
+         * @description <p>Retrieve an existing source transaction object. Supply the unique source ID from a source creation request and the source transaction ID and Stripe will return the corresponding up-to-date source object information.</p>
+         */
         get: operations["GetSourcesSourceSourceTransactionsSourceTransaction"];
         put?: never;
         post?: never;
@@ -5041,10 +6290,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your subscription items for a given subscription.</p> */
+        /**
+         * List all subscription items
+         * @description <p>Returns a list of your subscription items for a given subscription.</p>
+         */
         get: operations["GetSubscriptionItems"];
         put?: never;
-        /** @description <p>Adds a new item to an existing subscription. No existing items will be changed or replaced.</p> */
+        /**
+         * Create a subscription item
+         * @description <p>Adds a new item to an existing subscription. No existing items will be changed or replaced.</p>
+         */
         post: operations["PostSubscriptionItems"];
         delete?: never;
         options?: never;
@@ -5059,12 +6314,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the subscription item with the given ID.</p> */
+        /**
+         * Retrieve a subscription item
+         * @description <p>Retrieves the subscription item with the given ID.</p>
+         */
         get: operations["GetSubscriptionItemsItem"];
         put?: never;
-        /** @description <p>Updates the plan or quantity of an item on a current subscription.</p> */
+        /**
+         * Update a subscription item
+         * @description <p>Updates the plan or quantity of an item on a current subscription.</p>
+         */
         post: operations["PostSubscriptionItemsItem"];
-        /** @description <p>Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.</p> */
+        /**
+         * Delete a subscription item
+         * @description <p>Deletes an item from the subscription. Removing a subscription item from a subscription will not cancel the subscription.</p>
+         */
         delete: operations["DeleteSubscriptionItemsItem"];
         options?: never;
         head?: never;
@@ -5078,9 +6342,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).</p>
+        /**
+         * List all subscription item period summaries
+         * @description <p>For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).</p>
          *
-         *     <p>The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.</p> */
+         *     <p>The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.</p>
+         */
         get: operations["GetSubscriptionItemsSubscriptionItemUsageRecordSummaries"];
         put?: never;
         post?: never;
@@ -5099,13 +6366,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a usage record for a specified subscription item and date, and fills it with a quantity.</p>
+        /**
+         * Create a usage record
+         * @description <p>Creates a usage record for a specified subscription item and date, and fills it with a quantity.</p>
          *
          *     <p>Usage records provide <code>quantity</code> information that Stripe uses to track how much a customer is using your service. With usage information and the pricing model set up by the <a href="https://stripe.com/docs/billing/subscriptions/metered-billing">metered billing</a> plan, Stripe helps you send accurate invoices to your customers.</p>
          *
          *     <p>The default calculation for usage is to add up all the <code>quantity</code> values of the usage records within a billing period. You can change this default behavior with the billing plan’s <code>aggregate_usage</code> <a href="/docs/api/plans/create#create_plan-aggregate_usage">parameter</a>. When there is more than one usage record with the same timestamp, Stripe adds the <code>quantity</code> values together. In most cases, this is the desired resolution, however, you can change this behavior with the <code>action</code> parameter.</p>
          *
-         *     <p>The default pricing model for metered billing is <a href="/docs/api/plans/object#plan_object-billing_scheme">per-unit pricing</a>. For finer granularity, you can configure metered billing to have a <a href="https://stripe.com/docs/billing/subscriptions/tiers">tiered pricing</a> model.</p> */
+         *     <p>The default pricing model for metered billing is <a href="/docs/api/plans/object#plan_object-billing_scheme">per-unit pricing</a>. For finer granularity, you can configure metered billing to have a <a href="https://stripe.com/docs/billing/subscriptions/tiers">tiered pricing</a> model.</p>
+         */
         post: operations["PostSubscriptionItemsSubscriptionItemUsageRecords"];
         delete?: never;
         options?: never;
@@ -5120,10 +6390,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the list of your subscription schedules.</p> */
+        /**
+         * List all schedules
+         * @description <p>Retrieves the list of your subscription schedules.</p>
+         */
         get: operations["GetSubscriptionSchedules"];
         put?: never;
-        /** @description <p>Creates a new subscription schedule object. Each customer can have up to 500 active or scheduled subscriptions.</p> */
+        /**
+         * Create a schedule
+         * @description <p>Creates a new subscription schedule object. Each customer can have up to 500 active or scheduled subscriptions.</p>
+         */
         post: operations["PostSubscriptionSchedules"];
         delete?: never;
         options?: never;
@@ -5138,10 +6414,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing subscription schedule. You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.</p> */
+        /**
+         * Retrieve a schedule
+         * @description <p>Retrieves the details of an existing subscription schedule. You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.</p>
+         */
         get: operations["GetSubscriptionSchedulesSchedule"];
         put?: never;
-        /** @description <p>Updates an existing subscription schedule.</p> */
+        /**
+         * Update a schedule
+         * @description <p>Updates an existing subscription schedule.</p>
+         */
         post: operations["PostSubscriptionSchedulesSchedule"];
         delete?: never;
         options?: never;
@@ -5158,7 +6440,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is <code>not_started</code> or <code>active</code>.</p> */
+        /**
+         * Cancel a schedule
+         * @description <p>Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription). A subscription schedule can only be canceled if its status is <code>not_started</code> or <code>active</code>.</p>
+         */
         post: operations["PostSubscriptionSchedulesScheduleCancel"];
         delete?: never;
         options?: never;
@@ -5175,7 +6460,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is <code>not_started</code> or <code>active</code>. If the subscription schedule is currently associated with a subscription, releasing it will remove its <code>subscription</code> property and set the subscription’s ID to the <code>released_subscription</code> property.</p> */
+        /**
+         * Release a schedule
+         * @description <p>Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is <code>not_started</code> or <code>active</code>. If the subscription schedule is currently associated with a subscription, releasing it will remove its <code>subscription</code> property and set the subscription’s ID to the <code>released_subscription</code> property.</p>
+         */
         post: operations["PostSubscriptionSchedulesScheduleRelease"];
         delete?: never;
         options?: never;
@@ -5190,16 +6478,22 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p> */
+        /**
+         * List subscriptions
+         * @description <p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p>
+         */
         get: operations["GetSubscriptions"];
         put?: never;
-        /** @description <p>Creates a new subscription on an existing customer. Each customer can have up to 500 active or scheduled subscriptions.</p>
+        /**
+         * Create a subscription
+         * @description <p>Creates a new subscription on an existing customer. Each customer can have up to 500 active or scheduled subscriptions.</p>
          *
          *     <p>When you create a subscription with <code>collection_method=charge_automatically</code>, the first invoice is finalized as part of the request.
          *     The <code>payment_behavior</code> parameter determines the exact behavior of the initial payment.</p>
          *
          *     <p>To start subscriptions where the first invoice always begins in a <code>draft</code> status, use <a href="/docs/billing/subscriptions/subscription-schedules#managing">subscription schedules</a> instead.
-         *     Schedules provide the flexibility to model more complex billing configurations that change over time.</p> */
+         *     Schedules provide the flexibility to model more complex billing configurations that change over time.</p>
+         */
         post: operations["PostSubscriptions"];
         delete?: never;
         options?: never;
@@ -5214,10 +6508,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Search for subscriptions you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
+        /**
+         * Search subscriptions
+         * @description <p>Search for subscriptions you’ve previously created using Stripe’s <a href="/docs/search#search-query-language">Search Query Language</a>.
          *     Don’t use search in read-after-write flows where strict consistency is necessary. Under normal operating
          *     conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
-         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p> */
+         *     to an hour behind during outages. Search functionality is not available to merchants in India.</p>
+         */
         get: operations["GetSubscriptionsSearch"];
         put?: never;
         post?: never;
@@ -5234,10 +6531,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the subscription with the given ID.</p> */
+        /**
+         * Retrieve a subscription
+         * @description <p>Retrieves the subscription with the given ID.</p>
+         */
         get: operations["GetSubscriptionsSubscriptionExposedId"];
         put?: never;
-        /** @description <p>Updates an existing subscription to match the specified parameters.
+        /**
+         * Update a subscription
+         * @description <p>Updates an existing subscription to match the specified parameters.
          *     When changing prices or quantities, we optionally prorate the price we charge next month to make up for any price changes.
          *     To preview how the proration is calculated, use the <a href="/docs/api/invoices/create_preview">create preview</a> endpoint.</p>
          *
@@ -5257,13 +6559,17 @@ export interface paths {
          *
          *     <p>If you don’t want to prorate, set the <code>proration_behavior</code> option to <code>none</code>. With this option, the customer is billed <currency>100</currency> on May 1 and <currency>200</currency> on June 1. Similarly, if you set <code>proration_behavior</code> to <code>none</code> when switching between different billing intervals (for example, from monthly to yearly), we don’t generate any credits for the old subscription’s unused time. We still reset the billing date and bill immediately for the new subscription.</p>
          *
-         *     <p>Updating the quantity on a subscription many times in an hour may result in <a href="/docs/rate-limits">rate limiting</a>. If you need to bill for a frequently changing quantity, consider integrating <a href="/docs/billing/subscriptions/usage-based">usage-based billing</a> instead.</p> */
+         *     <p>Updating the quantity on a subscription many times in an hour may result in <a href="/docs/rate-limits">rate limiting</a>. If you need to bill for a frequently changing quantity, consider integrating <a href="/docs/billing/subscriptions/usage-based">usage-based billing</a> instead.</p>
+         */
         post: operations["PostSubscriptionsSubscriptionExposedId"];
-        /** @description <p>Cancels a customer’s subscription immediately. The customer will not be charged again for the subscription.</p>
+        /**
+         * Cancel a subscription
+         * @description <p>Cancels a customer’s subscription immediately. The customer won’t be charged again for the subscription. After it’s canceled, you can no longer update the subscription or its <a href="/metadata">metadata</a>.</p>
          *
-         *     <p>Note, however, that any pending invoice items that you’ve created will still be charged for at the end of the period, unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel at the end of the period, any pending prorations will also be left in place and collected at the end of the period. But if the subscription is set to cancel immediately, pending prorations will be removed.</p>
+         *     <p>Any pending invoice items that you’ve created are still charged at the end of the period, unless manually <a href="#delete_invoiceitem">deleted</a>. If you’ve set the subscription to cancel at the end of the period, any pending prorations are also left in place and collected at the end of the period. But if the subscription is set to cancel immediately, pending prorations are removed.</p>
          *
-         *     <p>By default, upon subscription cancellation, Stripe will stop automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.</p> */
+         *     <p>By default, upon subscription cancellation, Stripe stops automatic collection of all finalized invoices for the customer. This is intended to prevent unexpected payment attempts after the customer has canceled a subscription. However, you can resume automatic collection of the invoices manually after subscription cancellation to have us proceed. Or, you could check for unpaid invoices before allowing the customer to cancel the subscription at all.</p>
+         */
         delete: operations["DeleteSubscriptionsSubscriptionExposedId"];
         options?: never;
         head?: never;
@@ -5280,7 +6586,10 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** @description <p>Removes the currently applied discount on a subscription.</p> */
+        /**
+         * Delete a subscription discount
+         * @description <p>Removes the currently applied discount on a subscription.</p>
+         */
         delete: operations["DeleteSubscriptionsSubscriptionExposedIdDiscount"];
         options?: never;
         head?: never;
@@ -5296,7 +6605,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become <code>active</code>, and if payment fails the subscription will be <code>past_due</code>. The resumption invoice will void automatically if not paid by the expiration date.</p> */
+        /**
+         * Resume a subscription
+         * @description <p>Initiates resumption of a paused subscription, optionally resetting the billing cycle anchor and creating prorations. If a resumption invoice is generated, it must be paid or marked uncollectible before the subscription will be unpaused. If payment succeeds the subscription will become <code>active</code>, and if payment fails the subscription will be <code>past_due</code>. The resumption invoice will void automatically if not paid by the expiration date.</p>
+         */
         post: operations["PostSubscriptionsSubscriptionResume"];
         delete?: never;
         options?: never;
@@ -5313,7 +6625,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Calculates tax based on the input and returns a Tax <code>Calculation</code> object.</p> */
+        /**
+         * Create a Tax Calculation
+         * @description <p>Calculates tax based on the input and returns a Tax <code>Calculation</code> object.</p>
+         */
         post: operations["PostTaxCalculations"];
         delete?: never;
         options?: never;
@@ -5328,7 +6643,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Tax <code>Calculation</code> object, if the calculation hasn’t expired.</p> */
+        /**
+         * Retrieve a Tax Calculation
+         * @description <p>Retrieves a Tax <code>Calculation</code> object, if the calculation hasn’t expired.</p>
+         */
         get: operations["GetTaxCalculationsCalculation"];
         put?: never;
         post?: never;
@@ -5345,7 +6663,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the line items of a tax calculation as a collection, if the calculation hasn’t expired.</p> */
+        /**
+         * Retrieve a calculation's line items
+         * @description <p>Retrieves the line items of a tax calculation as a collection, if the calculation hasn’t expired.</p>
+         */
         get: operations["GetTaxCalculationsCalculationLineItems"];
         put?: never;
         post?: never;
@@ -5362,10 +6683,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of Tax <code>Registration</code> objects.</p> */
+        /**
+         * List registrations
+         * @description <p>Returns a list of Tax <code>Registration</code> objects.</p>
+         */
         get: operations["GetTaxRegistrations"];
         put?: never;
-        /** @description <p>Creates a new Tax <code>Registration</code> object.</p> */
+        /**
+         * Create a registration
+         * @description <p>Creates a new Tax <code>Registration</code> object.</p>
+         */
         post: operations["PostTaxRegistrations"];
         delete?: never;
         options?: never;
@@ -5380,12 +6707,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a Tax <code>Registration</code> object.</p> */
+        /**
+         * Retrieve a registration
+         * @description <p>Returns a Tax <code>Registration</code> object.</p>
+         */
         get: operations["GetTaxRegistrationsId"];
         put?: never;
-        /** @description <p>Updates an existing Tax <code>Registration</code> object.</p>
+        /**
+         * Update a registration
+         * @description <p>Updates an existing Tax <code>Registration</code> object.</p>
          *
-         *     <p>A registration cannot be deleted after it has been created. If you wish to end a registration you may do so by setting <code>expires_at</code>.</p> */
+         *     <p>A registration cannot be deleted after it has been created. If you wish to end a registration you may do so by setting <code>expires_at</code>.</p>
+         */
         post: operations["PostTaxRegistrationsId"];
         delete?: never;
         options?: never;
@@ -5400,10 +6733,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves Tax <code>Settings</code> for a merchant.</p> */
+        /**
+         * Retrieve settings
+         * @description <p>Retrieves Tax <code>Settings</code> for a merchant.</p>
+         */
         get: operations["GetTaxSettings"];
         put?: never;
-        /** @description <p>Updates Tax <code>Settings</code> parameters used in tax calculations. All parameters are editable but none can be removed once set.</p> */
+        /**
+         * Update settings
+         * @description <p>Updates Tax <code>Settings</code> parameters used in tax calculations. All parameters are editable but none can be removed once set.</p>
+         */
         post: operations["PostTaxSettings"];
         delete?: never;
         options?: never;
@@ -5420,7 +6759,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a Tax Transaction from a calculation, if that calculation hasn’t expired. Calculations expire after 90 days.</p> */
+        /**
+         * Create a transaction from a calculation
+         * @description <p>Creates a Tax Transaction from a calculation, if that calculation hasn’t expired. Calculations expire after 90 days.</p>
+         */
         post: operations["PostTaxTransactionsCreateFromCalculation"];
         delete?: never;
         options?: never;
@@ -5437,7 +6779,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Partially or fully reverses a previously created <code>Transaction</code>.</p> */
+        /**
+         * Create a reversal transaction
+         * @description <p>Partially or fully reverses a previously created <code>Transaction</code>.</p>
+         */
         post: operations["PostTaxTransactionsCreateReversal"];
         delete?: never;
         options?: never;
@@ -5452,7 +6797,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a Tax <code>Transaction</code> object.</p> */
+        /**
+         * Retrieve a transaction
+         * @description <p>Retrieves a Tax <code>Transaction</code> object.</p>
+         */
         get: operations["GetTaxTransactionsTransaction"];
         put?: never;
         post?: never;
@@ -5469,7 +6817,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the line items of a committed standalone transaction as a collection.</p> */
+        /**
+         * Retrieve a transaction's line items
+         * @description <p>Retrieves the line items of a committed standalone transaction as a collection.</p>
+         */
         get: operations["GetTaxTransactionsTransactionLineItems"];
         put?: never;
         post?: never;
@@ -5486,7 +6837,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>A list of <a href="https://stripe.com/docs/tax/tax-categories">all tax codes available</a> to add to Products in order to allow specific tax calculations.</p> */
+        /**
+         * List all tax codes
+         * @description <p>A list of <a href="https://stripe.com/docs/tax/tax-categories">all tax codes available</a> to add to Products in order to allow specific tax calculations.</p>
+         */
         get: operations["GetTaxCodes"];
         put?: never;
         post?: never;
@@ -5503,7 +6857,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing tax code. Supply the unique tax code ID and Stripe will return the corresponding tax code information.</p> */
+        /**
+         * Retrieve a tax code
+         * @description <p>Retrieves the details of an existing tax code. Supply the unique tax code ID and Stripe will return the corresponding tax code information.</p>
+         */
         get: operations["GetTaxCodesId"];
         put?: never;
         post?: never;
@@ -5520,10 +6877,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of tax IDs.</p> */
+        /**
+         * List all tax IDs
+         * @description <p>Returns a list of tax IDs.</p>
+         */
         get: operations["GetTaxIds"];
         put?: never;
-        /** @description <p>Creates a new account or customer <code>tax_id</code> object.</p> */
+        /**
+         * Create a tax ID
+         * @description <p>Creates a new account or customer <code>tax_id</code> object.</p>
+         */
         post: operations["PostTaxIds"];
         delete?: never;
         options?: never;
@@ -5538,11 +6901,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves an account or customer <code>tax_id</code> object.</p> */
+        /**
+         * Retrieve a tax ID
+         * @description <p>Retrieves an account or customer <code>tax_id</code> object.</p>
+         */
         get: operations["GetTaxIdsId"];
         put?: never;
         post?: never;
-        /** @description <p>Deletes an existing account or customer <code>tax_id</code> object.</p> */
+        /**
+         * Delete a tax ID
+         * @description <p>Deletes an existing account or customer <code>tax_id</code> object.</p>
+         */
         delete: operations["DeleteTaxIdsId"];
         options?: never;
         head?: never;
@@ -5556,10 +6925,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.</p> */
+        /**
+         * List all tax rates
+         * @description <p>Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.</p>
+         */
         get: operations["GetTaxRates"];
         put?: never;
-        /** @description <p>Creates a new tax rate.</p> */
+        /**
+         * Create a tax rate
+         * @description <p>Creates a new tax rate.</p>
+         */
         post: operations["PostTaxRates"];
         delete?: never;
         options?: never;
@@ -5574,10 +6949,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a tax rate with the given ID</p> */
+        /**
+         * Retrieve a tax rate
+         * @description <p>Retrieves a tax rate with the given ID</p>
+         */
         get: operations["GetTaxRatesTaxRate"];
         put?: never;
-        /** @description <p>Updates an existing tax rate.</p> */
+        /**
+         * Update a tax rate
+         * @description <p>Updates an existing tax rate.</p>
+         */
         post: operations["PostTaxRatesTaxRate"];
         delete?: never;
         options?: never;
@@ -5592,10 +6973,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>Configuration</code> objects.</p> */
+        /**
+         * List all Configurations
+         * @description <p>Returns a list of <code>Configuration</code> objects.</p>
+         */
         get: operations["GetTerminalConfigurations"];
         put?: never;
-        /** @description <p>Creates a new <code>Configuration</code> object.</p> */
+        /**
+         * Create a Configuration
+         * @description <p>Creates a new <code>Configuration</code> object.</p>
+         */
         post: operations["PostTerminalConfigurations"];
         delete?: never;
         options?: never;
@@ -5610,12 +6997,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>Configuration</code> object.</p> */
+        /**
+         * Retrieve a Configuration
+         * @description <p>Retrieves a <code>Configuration</code> object.</p>
+         */
         get: operations["GetTerminalConfigurationsConfiguration"];
         put?: never;
-        /** @description <p>Updates a new <code>Configuration</code> object.</p> */
+        /**
+         * Update a Configuration
+         * @description <p>Updates a new <code>Configuration</code> object.</p>
+         */
         post: operations["PostTerminalConfigurationsConfiguration"];
-        /** @description <p>Deletes a <code>Configuration</code> object.</p> */
+        /**
+         * Delete a Configuration
+         * @description <p>Deletes a <code>Configuration</code> object.</p>
+         */
         delete: operations["DeleteTerminalConfigurationsConfiguration"];
         options?: never;
         head?: never;
@@ -5631,7 +7027,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server. On your backend, add an endpoint that creates and returns a connection token.</p> */
+        /**
+         * Create a Connection Token
+         * @description <p>To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server. On your backend, add an endpoint that creates and returns a connection token.</p>
+         */
         post: operations["PostTerminalConnectionTokens"];
         delete?: never;
         options?: never;
@@ -5646,11 +7045,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>Location</code> objects.</p> */
+        /**
+         * List all Locations
+         * @description <p>Returns a list of <code>Location</code> objects.</p>
+         */
         get: operations["GetTerminalLocations"];
         put?: never;
-        /** @description <p>Creates a new <code>Location</code> object.
-         *     For further details, including which address fields are required in each country, see the <a href="/docs/terminal/fleet/locations">Manage locations</a> guide.</p> */
+        /**
+         * Create a Location
+         * @description <p>Creates a new <code>Location</code> object.
+         *     For further details, including which address fields are required in each country, see the <a href="/docs/terminal/fleet/locations">Manage locations</a> guide.</p>
+         */
         post: operations["PostTerminalLocations"];
         delete?: never;
         options?: never;
@@ -5665,12 +7070,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>Location</code> object.</p> */
+        /**
+         * Retrieve a Location
+         * @description <p>Retrieves a <code>Location</code> object.</p>
+         */
         get: operations["GetTerminalLocationsLocation"];
         put?: never;
-        /** @description <p>Updates a <code>Location</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a Location
+         * @description <p>Updates a <code>Location</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostTerminalLocationsLocation"];
-        /** @description <p>Deletes a <code>Location</code> object.</p> */
+        /**
+         * Delete a Location
+         * @description <p>Deletes a <code>Location</code> object.</p>
+         */
         delete: operations["DeleteTerminalLocationsLocation"];
         options?: never;
         head?: never;
@@ -5684,10 +7098,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of <code>Reader</code> objects.</p> */
+        /**
+         * List all Readers
+         * @description <p>Returns a list of <code>Reader</code> objects.</p>
+         */
         get: operations["GetTerminalReaders"];
         put?: never;
-        /** @description <p>Creates a new <code>Reader</code> object.</p> */
+        /**
+         * Create a Reader
+         * @description <p>Creates a new <code>Reader</code> object.</p>
+         */
         post: operations["PostTerminalReaders"];
         delete?: never;
         options?: never;
@@ -5702,12 +7122,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a <code>Reader</code> object.</p> */
+        /**
+         * Retrieve a Reader
+         * @description <p>Retrieves a <code>Reader</code> object.</p>
+         */
         get: operations["GetTerminalReadersReader"];
         put?: never;
-        /** @description <p>Updates a <code>Reader</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p> */
+        /**
+         * Update a Reader
+         * @description <p>Updates a <code>Reader</code> object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+         */
         post: operations["PostTerminalReadersReader"];
-        /** @description <p>Deletes a <code>Reader</code> object.</p> */
+        /**
+         * Delete a Reader
+         * @description <p>Deletes a <code>Reader</code> object.</p>
+         */
         delete: operations["DeleteTerminalReadersReader"];
         options?: never;
         head?: never;
@@ -5723,7 +7152,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels the current reader action.</p> */
+        /**
+         * Cancel the current reader action
+         * @description <p>Cancels the current reader action.</p>
+         */
         post: operations["PostTerminalReadersReaderCancelAction"];
         delete?: never;
         options?: never;
@@ -5740,7 +7172,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Initiates a payment flow on a Reader.</p> */
+        /**
+         * Hand-off a PaymentIntent to a Reader
+         * @description <p>Initiates a payment flow on a Reader.</p>
+         */
         post: operations["PostTerminalReadersReaderProcessPaymentIntent"];
         delete?: never;
         options?: never;
@@ -5757,7 +7192,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Initiates a setup intent flow on a Reader.</p> */
+        /**
+         * Hand-off a SetupIntent to a Reader
+         * @description <p>Initiates a setup intent flow on a Reader.</p>
+         */
         post: operations["PostTerminalReadersReaderProcessSetupIntent"];
         delete?: never;
         options?: never;
@@ -5774,7 +7212,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Initiates a refund on a Reader</p> */
+        /**
+         * Refund a Charge or a PaymentIntent in-person
+         * @description <p>Initiates a refund on a Reader</p>
+         */
         post: operations["PostTerminalReadersReaderRefundPayment"];
         delete?: never;
         options?: never;
@@ -5791,7 +7232,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Sets reader display to show cart details.</p> */
+        /**
+         * Set reader display
+         * @description <p>Sets reader display to show cart details.</p>
+         */
         post: operations["PostTerminalReadersReaderSetReaderDisplay"];
         delete?: never;
         options?: never;
@@ -5808,7 +7252,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a test mode Confirmation Token server side for your integration tests.</p> */
+        /**
+         * Create a test Confirmation Token
+         * @description <p>Creates a test mode Confirmation Token server side for your integration tests.</p>
+         */
         post: operations["PostTestHelpersConfirmationTokens"];
         delete?: never;
         options?: never;
@@ -5825,7 +7272,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Create an incoming testmode bank transfer</p> */
+        /**
+         * Fund a test mode cash balance
+         * @description <p>Create an incoming testmode bank transfer</p>
+         */
         post: operations["PostTestHelpersCustomersCustomerFundCashBalance"];
         delete?: never;
         options?: never;
@@ -5842,7 +7292,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Create a test-mode authorization.</p> */
+        /**
+         * Create a test-mode authorization
+         * @description <p>Create a test-mode authorization.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizations"];
         delete?: never;
         options?: never;
@@ -5859,7 +7312,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Capture a test-mode authorization.</p> */
+        /**
+         * Capture a test-mode authorization
+         * @description <p>Capture a test-mode authorization.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationCapture"];
         delete?: never;
         options?: never;
@@ -5876,7 +7332,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Expire a test-mode Authorization.</p> */
+        /**
+         * Expire a test-mode authorization
+         * @description <p>Expire a test-mode Authorization.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationExpire"];
         delete?: never;
         options?: never;
@@ -5893,7 +7352,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Finalize the amount on an Authorization prior to capture, when the initial authorization was for an estimated amount.</p> */
+        /**
+         * Finalize a test-mode authorization's amount
+         * @description <p>Finalize the amount on an Authorization prior to capture, when the initial authorization was for an estimated amount.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationFinalizeAmount"];
         delete?: never;
         options?: never;
@@ -5910,7 +7372,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Increment a test-mode Authorization.</p> */
+        /**
+         * Increment a test-mode authorization
+         * @description <p>Increment a test-mode Authorization.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationIncrement"];
         delete?: never;
         options?: never;
@@ -5927,7 +7392,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Reverse a test-mode Authorization.</p> */
+        /**
+         * Reverse a test-mode authorization
+         * @description <p>Reverse a test-mode Authorization.</p>
+         */
         post: operations["PostTestHelpersIssuingAuthorizationsAuthorizationReverse"];
         delete?: never;
         options?: never;
@@ -5944,7 +7412,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>delivered</code>.</p> */
+        /**
+         * Deliver a testmode card
+         * @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>delivered</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingCardsCardShippingDeliver"];
         delete?: never;
         options?: never;
@@ -5961,7 +7432,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>failure</code>.</p> */
+        /**
+         * Fail a testmode card
+         * @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>failure</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingCardsCardShippingFail"];
         delete?: never;
         options?: never;
@@ -5978,7 +7452,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>returned</code>.</p> */
+        /**
+         * Return a testmode card
+         * @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>returned</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingCardsCardShippingReturn"];
         delete?: never;
         options?: never;
@@ -5995,8 +7472,31 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>shipped</code>.</p> */
+        /**
+         * Ship a testmode card
+         * @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>shipped</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingCardsCardShippingShip"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/test_helpers/issuing/cards/{card}/shipping/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit a testmode card
+         * @description <p>Updates the shipping status of the specified Issuing <code>Card</code> object to <code>submitted</code>. This method requires Stripe Version ‘2024-09-30.acacia’ or later.</p>
+         */
+        post: operations["PostTestHelpersIssuingCardsCardShippingSubmit"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6012,7 +7512,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>active</code>.</p> */
+        /**
+         * Activate a testmode personalization design
+         * @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>active</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignActivate"];
         delete?: never;
         options?: never;
@@ -6029,7 +7532,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>inactive</code>.</p> */
+        /**
+         * Deactivate a testmode personalization design
+         * @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>inactive</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignDeactivate"];
         delete?: never;
         options?: never;
@@ -6046,7 +7552,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>rejected</code>.</p> */
+        /**
+         * Reject a testmode personalization design
+         * @description <p>Updates the <code>status</code> of the specified testmode personalization design object to <code>rejected</code>.</p>
+         */
         post: operations["PostTestHelpersIssuingPersonalizationDesignsPersonalizationDesignReject"];
         delete?: never;
         options?: never;
@@ -6063,7 +7572,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Allows the user to create an Issuing settlement.</p> */
+        /**
+         * Create a test-mode settleemnt
+         * @description <p>Allows the user to create an Issuing settlement.</p>
+         */
         post: operations["PostTestHelpersIssuingSettlements"];
         delete?: never;
         options?: never;
@@ -6080,7 +7592,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Allows the user to capture an arbitrary amount, also known as a forced capture.</p> */
+        /**
+         * Create a test-mode force capture
+         * @description <p>Allows the user to capture an arbitrary amount, also known as a forced capture.</p>
+         */
         post: operations["PostTestHelpersIssuingTransactionsCreateForceCapture"];
         delete?: never;
         options?: never;
@@ -6097,7 +7612,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Allows the user to refund an arbitrary amount, also known as a unlinked refund.</p> */
+        /**
+         * Create a test-mode unlinked refund
+         * @description <p>Allows the user to refund an arbitrary amount, also known as a unlinked refund.</p>
+         */
         post: operations["PostTestHelpersIssuingTransactionsCreateUnlinkedRefund"];
         delete?: never;
         options?: never;
@@ -6114,7 +7632,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Refund a test-mode Transaction.</p> */
+        /**
+         * Refund a test-mode transaction
+         * @description <p>Refund a test-mode Transaction.</p>
+         */
         post: operations["PostTestHelpersIssuingTransactionsTransactionRefund"];
         delete?: never;
         options?: never;
@@ -6131,7 +7652,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Expire a refund with a status of <code>requires_action</code>.</p> */
+        /**
+         * Expire a pending refund.
+         * @description <p>Expire a refund with a status of <code>requires_action</code>.</p>
+         */
         post: operations["PostTestHelpersRefundsRefundExpire"];
         delete?: never;
         options?: never;
@@ -6148,7 +7672,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.</p> */
+        /**
+         * Simulate presenting a payment method
+         * @description <p>Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction.</p>
+         */
         post: operations["PostTestHelpersTerminalReadersReaderPresentPaymentMethod"];
         delete?: never;
         options?: never;
@@ -6163,10 +7690,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your test clocks.</p> */
+        /**
+         * List all test clocks
+         * @description <p>Returns a list of your test clocks.</p>
+         */
         get: operations["GetTestHelpersTestClocks"];
         put?: never;
-        /** @description <p>Creates a new test clock that can be attached to new customers and quotes.</p> */
+        /**
+         * Create a test clock
+         * @description <p>Creates a new test clock that can be attached to new customers and quotes.</p>
+         */
         post: operations["PostTestHelpersTestClocks"];
         delete?: never;
         options?: never;
@@ -6181,11 +7714,17 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a test clock.</p> */
+        /**
+         * Retrieve a test clock
+         * @description <p>Retrieves a test clock.</p>
+         */
         get: operations["GetTestHelpersTestClocksTestClock"];
         put?: never;
         post?: never;
-        /** @description <p>Deletes a test clock.</p> */
+        /**
+         * Delete a test clock
+         * @description <p>Deletes a test clock.</p>
+         */
         delete: operations["DeleteTestHelpersTestClocksTestClock"];
         options?: never;
         head?: never;
@@ -6201,7 +7740,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to <code>Ready</code>.</p> */
+        /**
+         * Advance a test clock
+         * @description <p>Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to <code>Ready</code>.</p>
+         */
         post: operations["PostTestHelpersTestClocksTestClockAdvance"];
         delete?: never;
         options?: never;
@@ -6218,7 +7760,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created InboundTransfer to the <code>failed</code> status. The InboundTransfer must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Fail an InboundTransfer
+         * @description <p>Transitions a test mode created InboundTransfer to the <code>failed</code> status. The InboundTransfer must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryInboundTransfersIdFail"];
         delete?: never;
         options?: never;
@@ -6235,7 +7780,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.</p> */
+        /**
+         * Test mode: Return an InboundTransfer
+         * @description <p>Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryInboundTransfersIdReturn"];
         delete?: never;
         options?: never;
@@ -6252,7 +7800,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The InboundTransfer must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Succeed an InboundTransfer
+         * @description <p>Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The InboundTransfer must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryInboundTransfersIdSucceed"];
         delete?: never;
         options?: never;
@@ -6269,7 +7820,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates a test mode created OutboundPayment with tracking details. The OutboundPayment must not be cancelable, and cannot be in the <code>canceled</code> or <code>failed</code> states.</p> */
+        /**
+         * Test mode: Update an OutboundPayment
+         * @description <p>Updates a test mode created OutboundPayment with tracking details. The OutboundPayment must not be cancelable, and cannot be in the <code>canceled</code> or <code>failed</code> states.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundPaymentsId"];
         delete?: never;
         options?: never;
@@ -6286,7 +7840,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundPayment to the <code>failed</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Fail an OutboundPayment
+         * @description <p>Transitions a test mode created OutboundPayment to the <code>failed</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundPaymentsIdFail"];
         delete?: never;
         options?: never;
@@ -6303,7 +7860,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundPayment to the <code>posted</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Post an OutboundPayment
+         * @description <p>Transitions a test mode created OutboundPayment to the <code>posted</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundPaymentsIdPost"];
         delete?: never;
         options?: never;
@@ -6320,7 +7880,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundPayment to the <code>returned</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Return an OutboundPayment
+         * @description <p>Transitions a test mode created OutboundPayment to the <code>returned</code> status. The OutboundPayment must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundPaymentsIdReturn"];
         delete?: never;
         options?: never;
@@ -6337,7 +7900,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the <code>canceled</code> or <code>failed</code> states.</p> */
+        /**
+         * Test mode: Update an OutboundTransfer
+         * @description <p>Updates a test mode created OutboundTransfer with tracking details. The OutboundTransfer must not be cancelable, and cannot be in the <code>canceled</code> or <code>failed</code> states.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundTransfersOutboundTransfer"];
         delete?: never;
         options?: never;
@@ -6354,7 +7920,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Fail an OutboundTransfer
+         * @description <p>Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundTransfersOutboundTransferFail"];
         delete?: never;
         options?: never;
@@ -6371,7 +7940,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Post an OutboundTransfer
+         * @description <p>Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundTransfersOutboundTransferPost"];
         delete?: never;
         options?: never;
@@ -6388,7 +7960,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p> */
+        /**
+         * Test mode: Return an OutboundTransfer
+         * @description <p>Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The OutboundTransfer must already be in the <code>processing</code> state.</p>
+         */
         post: operations["PostTestHelpersTreasuryOutboundTransfersOutboundTransferReturn"];
         delete?: never;
         options?: never;
@@ -6405,7 +7980,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live mode, you can’t directly create ReceivedCredits initiated by third parties.</p> */
+        /**
+         * Test mode: Create a ReceivedCredit
+         * @description <p>Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live mode, you can’t directly create ReceivedCredits initiated by third parties.</p>
+         */
         post: operations["PostTestHelpersTreasuryReceivedCredits"];
         delete?: never;
         options?: never;
@@ -6422,7 +8000,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live mode, you can’t directly create ReceivedDebits initiated by third parties.</p> */
+        /**
+         * Test mode: Create a ReceivedDebit
+         * @description <p>Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live mode, you can’t directly create ReceivedDebits initiated by third parties.</p>
+         */
         post: operations["PostTestHelpersTreasuryReceivedDebits"];
         delete?: never;
         options?: never;
@@ -6439,8 +8020,11 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Creates a single-use token that represents a bank account’s details.
-         *     You can use this token with any API method in place of a bank account dictionary. You can only use this token once. To do so, attach it to a <a href="#accounts">connected account</a> where <a href="/api/accounts/object#account_object-controller-requirement_collection">controller.requirement_collection</a> is <code>application</code>, which includes Custom accounts.</p> */
+        /**
+         * Create a CVC update token
+         * @description <p>Creates a single-use token that represents a bank account’s details.
+         *     You can use this token with any v1 API method in place of a bank account dictionary. You can only use this token once. To do so, attach it to a <a href="#accounts">connected account</a> where <a href="/api/accounts/object#account_object-controller-requirement_collection">controller.requirement_collection</a> is <code>application</code>, which includes Custom accounts.</p>
+         */
         post: operations["PostTokens"];
         delete?: never;
         options?: never;
@@ -6455,7 +8039,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the token with the given ID.</p> */
+        /**
+         * Retrieve a token
+         * @description <p>Retrieves the token with the given ID.</p>
+         */
         get: operations["GetTokensToken"];
         put?: never;
         post?: never;
@@ -6472,10 +8059,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of top-ups.</p> */
+        /**
+         * List all top-ups
+         * @description <p>Returns a list of top-ups.</p>
+         */
         get: operations["GetTopups"];
         put?: never;
-        /** @description <p>Top up the balance of an account</p> */
+        /**
+         * Create a top-up
+         * @description <p>Top up the balance of an account</p>
+         */
         post: operations["PostTopups"];
         delete?: never;
         options?: never;
@@ -6490,10 +8083,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a top-up that has previously been created. Supply the unique top-up ID that was returned from your previous request, and Stripe will return the corresponding top-up information.</p> */
+        /**
+         * Retrieve a top-up
+         * @description <p>Retrieves the details of a top-up that has previously been created. Supply the unique top-up ID that was returned from your previous request, and Stripe will return the corresponding top-up information.</p>
+         */
         get: operations["GetTopupsTopup"];
         put?: never;
-        /** @description <p>Updates the metadata of a top-up. Other top-up details are not editable by design.</p> */
+        /**
+         * Update a top-up
+         * @description <p>Updates the metadata of a top-up. Other top-up details are not editable by design.</p>
+         */
         post: operations["PostTopupsTopup"];
         delete?: never;
         options?: never;
@@ -6510,7 +8109,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels a top-up. Only pending top-ups can be canceled.</p> */
+        /**
+         * Cancel a top-up
+         * @description <p>Cancels a top-up. Only pending top-ups can be canceled.</p>
+         */
         post: operations["PostTopupsTopupCancel"];
         delete?: never;
         options?: never;
@@ -6525,10 +8127,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.</p> */
+        /**
+         * List all transfers
+         * @description <p>Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.</p>
+         */
         get: operations["GetTransfers"];
         put?: never;
-        /** @description <p>To send funds from your Stripe account to a connected account, you create a new transfer object. Your <a href="#balance">Stripe balance</a> must be able to cover the transfer amount, or you’ll receive an “Insufficient Funds” error.</p> */
+        /**
+         * Create a transfer
+         * @description <p>To send funds from your Stripe account to a connected account, you create a new transfer object. Your <a href="#balance">Stripe balance</a> must be able to cover the transfer amount, or you’ll receive an “Insufficient Funds” error.</p>
+         */
         post: operations["PostTransfers"];
         delete?: never;
         options?: never;
@@ -6543,14 +8151,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional reversals.</p> */
+        /**
+         * List all reversals
+         * @description <p>You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional reversals.</p>
+         */
         get: operations["GetTransfersIdReversals"];
         put?: never;
-        /** @description <p>When you create a new reversal, you must specify a transfer to create it on.</p>
+        /**
+         * Create a transfer reversal
+         * @description <p>When you create a new reversal, you must specify a transfer to create it on.</p>
          *
          *     <p>When reversing transfers, you can optionally reverse part of the transfer. You can do so as many times as you wish until the entire transfer has been reversed.</p>
          *
-         *     <p>Once entirely reversed, a transfer can’t be reversed again. This method will return an error when called on an already-reversed transfer, or when trying to reverse more money than is left on a transfer.</p> */
+         *     <p>Once entirely reversed, a transfer can’t be reversed again. This method will return an error when called on an already-reversed transfer, or when trying to reverse more money than is left on a transfer.</p>
+         */
         post: operations["PostTransfersIdReversals"];
         delete?: never;
         options?: never;
@@ -6565,12 +8179,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing transfer. Supply the unique transfer ID from either a transfer creation request or the transfer list, and Stripe will return the corresponding transfer information.</p> */
+        /**
+         * Retrieve a transfer
+         * @description <p>Retrieves the details of an existing transfer. Supply the unique transfer ID from either a transfer creation request or the transfer list, and Stripe will return the corresponding transfer information.</p>
+         */
         get: operations["GetTransfersTransfer"];
         put?: never;
-        /** @description <p>Updates the specified transfer by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+        /**
+         * Update a transfer
+         * @description <p>Updates the specified transfer by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
          *
-         *     <p>This request accepts only metadata as an argument.</p> */
+         *     <p>This request accepts only metadata as an argument.</p>
+         */
         post: operations["PostTransfersTransfer"];
         delete?: never;
         options?: never;
@@ -6585,12 +8205,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.</p> */
+        /**
+         * Retrieve a reversal
+         * @description <p>By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.</p>
+         */
         get: operations["GetTransfersTransferReversalsId"];
         put?: never;
-        /** @description <p>Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
+        /**
+         * Update a reversal
+         * @description <p>Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.</p>
          *
-         *     <p>This request only accepts metadata and description as arguments.</p> */
+         *     <p>This request only accepts metadata and description as arguments.</p>
+         */
         post: operations["PostTransfersTransferReversalsId"];
         delete?: never;
         options?: never;
@@ -6605,10 +8231,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of CreditReversals.</p> */
+        /**
+         * List all CreditReversals
+         * @description <p>Returns a list of CreditReversals.</p>
+         */
         get: operations["GetTreasuryCreditReversals"];
         put?: never;
-        /** @description <p>Reverses a ReceivedCredit and creates a CreditReversal object.</p> */
+        /**
+         * Create a CreditReversal
+         * @description <p>Reverses a ReceivedCredit and creates a CreditReversal object.</p>
+         */
         post: operations["PostTreasuryCreditReversals"];
         delete?: never;
         options?: never;
@@ -6623,7 +8255,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID from either the CreditReversal creation request or CreditReversal list</p> */
+        /**
+         * Retrieve a CreditReversal
+         * @description <p>Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID from either the CreditReversal creation request or CreditReversal list</p>
+         */
         get: operations["GetTreasuryCreditReversalsCreditReversal"];
         put?: never;
         post?: never;
@@ -6640,10 +8275,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of DebitReversals.</p> */
+        /**
+         * List all DebitReversals
+         * @description <p>Returns a list of DebitReversals.</p>
+         */
         get: operations["GetTreasuryDebitReversals"];
         put?: never;
-        /** @description <p>Reverses a ReceivedDebit and creates a DebitReversal object.</p> */
+        /**
+         * Create a DebitReversal
+         * @description <p>Reverses a ReceivedDebit and creates a DebitReversal object.</p>
+         */
         post: operations["PostTreasuryDebitReversals"];
         delete?: never;
         options?: never;
@@ -6658,7 +8299,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a DebitReversal object.</p> */
+        /**
+         * Retrieve a DebitReversal
+         * @description <p>Retrieves a DebitReversal object.</p>
+         */
         get: operations["GetTreasuryDebitReversalsDebitReversal"];
         put?: never;
         post?: never;
@@ -6675,10 +8319,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of FinancialAccounts.</p> */
+        /**
+         * List all FinancialAccounts
+         * @description <p>Returns a list of FinancialAccounts.</p>
+         */
         get: operations["GetTreasuryFinancialAccounts"];
         put?: never;
-        /** @description <p>Creates a new FinancialAccount. For now, each connected account can only have one FinancialAccount.</p> */
+        /**
+         * Create a FinancialAccount
+         * @description <p>Creates a new FinancialAccount. For now, each connected account can only have one FinancialAccount.</p>
+         */
         post: operations["PostTreasuryFinancialAccounts"];
         delete?: never;
         options?: never;
@@ -6693,10 +8343,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of a FinancialAccount.</p> */
+        /**
+         * Retrieve a FinancialAccount
+         * @description <p>Retrieves the details of a FinancialAccount.</p>
+         */
         get: operations["GetTreasuryFinancialAccountsFinancialAccount"];
         put?: never;
-        /** @description <p>Updates the details of a FinancialAccount.</p> */
+        /**
+         * Update a FinancialAccount
+         * @description <p>Updates the details of a FinancialAccount.</p>
+         */
         post: operations["PostTreasuryFinancialAccountsFinancialAccount"];
         delete?: never;
         options?: never;
@@ -6711,10 +8367,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves Features information associated with the FinancialAccount.</p> */
+        /**
+         * Retrieve FinancialAccount Features
+         * @description <p>Retrieves Features information associated with the FinancialAccount.</p>
+         */
         get: operations["GetTreasuryFinancialAccountsFinancialAccountFeatures"];
         put?: never;
-        /** @description <p>Updates the Features associated with a FinancialAccount.</p> */
+        /**
+         * Update FinancialAccount Features
+         * @description <p>Updates the Features associated with a FinancialAccount.</p>
+         */
         post: operations["PostTreasuryFinancialAccountsFinancialAccountFeatures"];
         delete?: never;
         options?: never;
@@ -6729,10 +8391,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of InboundTransfers sent from the specified FinancialAccount.</p> */
+        /**
+         * List all InboundTransfers
+         * @description <p>Returns a list of InboundTransfers sent from the specified FinancialAccount.</p>
+         */
         get: operations["GetTreasuryInboundTransfers"];
         put?: never;
-        /** @description <p>Creates an InboundTransfer.</p> */
+        /**
+         * Create an InboundTransfer
+         * @description <p>Creates an InboundTransfer.</p>
+         */
         post: operations["PostTreasuryInboundTransfers"];
         delete?: never;
         options?: never;
@@ -6747,7 +8415,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing InboundTransfer.</p> */
+        /**
+         * Retrieve an InboundTransfer
+         * @description <p>Retrieves the details of an existing InboundTransfer.</p>
+         */
         get: operations["GetTreasuryInboundTransfersId"];
         put?: never;
         post?: never;
@@ -6766,7 +8437,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancels an InboundTransfer.</p> */
+        /**
+         * Cancel an InboundTransfer
+         * @description <p>Cancels an InboundTransfer.</p>
+         */
         post: operations["PostTreasuryInboundTransfersInboundTransferCancel"];
         delete?: never;
         options?: never;
@@ -6781,10 +8455,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of OutboundPayments sent from the specified FinancialAccount.</p> */
+        /**
+         * List all OutboundPayments
+         * @description <p>Returns a list of OutboundPayments sent from the specified FinancialAccount.</p>
+         */
         get: operations["GetTreasuryOutboundPayments"];
         put?: never;
-        /** @description <p>Creates an OutboundPayment.</p> */
+        /**
+         * Create an OutboundPayment
+         * @description <p>Creates an OutboundPayment.</p>
+         */
         post: operations["PostTreasuryOutboundPayments"];
         delete?: never;
         options?: never;
@@ -6799,7 +8479,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID from either the OutboundPayment creation request or OutboundPayment list.</p> */
+        /**
+         * Retrieve an OutboundPayment
+         * @description <p>Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID from either the OutboundPayment creation request or OutboundPayment list.</p>
+         */
         get: operations["GetTreasuryOutboundPaymentsId"];
         put?: never;
         post?: never;
@@ -6818,7 +8501,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>Cancel an OutboundPayment.</p> */
+        /**
+         * Cancel an OutboundPayment
+         * @description <p>Cancel an OutboundPayment.</p>
+         */
         post: operations["PostTreasuryOutboundPaymentsIdCancel"];
         delete?: never;
         options?: never;
@@ -6833,10 +8519,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of OutboundTransfers sent from the specified FinancialAccount.</p> */
+        /**
+         * List all OutboundTransfers
+         * @description <p>Returns a list of OutboundTransfers sent from the specified FinancialAccount.</p>
+         */
         get: operations["GetTreasuryOutboundTransfers"];
         put?: never;
-        /** @description <p>Creates an OutboundTransfer.</p> */
+        /**
+         * Create an OutboundTransfer
+         * @description <p>Creates an OutboundTransfer.</p>
+         */
         post: operations["PostTreasuryOutboundTransfers"];
         delete?: never;
         options?: never;
@@ -6851,7 +8543,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID from either the OutboundTransfer creation request or OutboundTransfer list.</p> */
+        /**
+         * Retrieve an OutboundTransfer
+         * @description <p>Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID from either the OutboundTransfer creation request or OutboundTransfer list.</p>
+         */
         get: operations["GetTreasuryOutboundTransfersOutboundTransfer"];
         put?: never;
         post?: never;
@@ -6870,7 +8565,10 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** @description <p>An OutboundTransfer can be canceled if the funds have not yet been paid out.</p> */
+        /**
+         * Cancel an OutboundTransfer
+         * @description <p>An OutboundTransfer can be canceled if the funds have not yet been paid out.</p>
+         */
         post: operations["PostTreasuryOutboundTransfersOutboundTransferCancel"];
         delete?: never;
         options?: never;
@@ -6885,7 +8583,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of ReceivedCredits.</p> */
+        /**
+         * List all ReceivedCredits
+         * @description <p>Returns a list of ReceivedCredits.</p>
+         */
         get: operations["GetTreasuryReceivedCredits"];
         put?: never;
         post?: never;
@@ -6902,7 +8603,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID from the ReceivedCredit list.</p> */
+        /**
+         * Retrieve a ReceivedCredit
+         * @description <p>Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID from the ReceivedCredit list.</p>
+         */
         get: operations["GetTreasuryReceivedCreditsId"];
         put?: never;
         post?: never;
@@ -6919,7 +8623,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of ReceivedDebits.</p> */
+        /**
+         * List all ReceivedDebits
+         * @description <p>Returns a list of ReceivedDebits.</p>
+         */
         get: operations["GetTreasuryReceivedDebits"];
         put?: never;
         post?: never;
@@ -6936,7 +8643,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from the ReceivedDebit list</p> */
+        /**
+         * Retrieve a ReceivedDebit
+         * @description <p>Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from the ReceivedDebit list</p>
+         */
         get: operations["GetTreasuryReceivedDebitsId"];
         put?: never;
         post?: never;
@@ -6953,7 +8663,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a list of TransactionEntry objects.</p> */
+        /**
+         * List all TransactionEntries
+         * @description <p>Retrieves a list of TransactionEntry objects.</p>
+         */
         get: operations["GetTreasuryTransactionEntries"];
         put?: never;
         post?: never;
@@ -6970,7 +8683,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a TransactionEntry object.</p> */
+        /**
+         * Retrieve a TransactionEntry
+         * @description <p>Retrieves a TransactionEntry object.</p>
+         */
         get: operations["GetTreasuryTransactionEntriesId"];
         put?: never;
         post?: never;
@@ -6987,7 +8703,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves a list of Transaction objects.</p> */
+        /**
+         * List all Transactions
+         * @description <p>Retrieves a list of Transaction objects.</p>
+         */
         get: operations["GetTreasuryTransactions"];
         put?: never;
         post?: never;
@@ -7004,7 +8723,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the details of an existing Transaction.</p> */
+        /**
+         * Retrieve a Transaction
+         * @description <p>Retrieves the details of an existing Transaction.</p>
+         */
         get: operations["GetTreasuryTransactionsId"];
         put?: never;
         post?: never;
@@ -7021,10 +8743,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Returns a list of your webhook endpoints.</p> */
+        /**
+         * List all webhook endpoints
+         * @description <p>Returns a list of your webhook endpoints.</p>
+         */
         get: operations["GetWebhookEndpoints"];
         put?: never;
-        /** @description <p>A webhook endpoint must have a <code>url</code> and a list of <code>enabled_events</code>. You may optionally specify the Boolean <code>connect</code> parameter. If set to true, then a Connect webhook endpoint that notifies the specified <code>url</code> about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified <code>url</code> only about events from your account is created. You can also create webhook endpoints in the <a href="https://dashboard.stripe.com/account/webhooks">webhooks settings</a> section of the Dashboard.</p> */
+        /**
+         * Create a webhook endpoint
+         * @description <p>A webhook endpoint must have a <code>url</code> and a list of <code>enabled_events</code>. You may optionally specify the Boolean <code>connect</code> parameter. If set to true, then a Connect webhook endpoint that notifies the specified <code>url</code> about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified <code>url</code> only about events from your account is created. You can also create webhook endpoints in the <a href="https://dashboard.stripe.com/account/webhooks">webhooks settings</a> section of the Dashboard.</p>
+         */
         post: operations["PostWebhookEndpoints"];
         delete?: never;
         options?: never;
@@ -7039,12 +8767,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** @description <p>Retrieves the webhook endpoint with the given ID.</p> */
+        /**
+         * Retrieve a webhook endpoint
+         * @description <p>Retrieves the webhook endpoint with the given ID.</p>
+         */
         get: operations["GetWebhookEndpointsWebhookEndpoint"];
         put?: never;
-        /** @description <p>Updates the webhook endpoint. You may edit the <code>url</code>, the list of <code>enabled_events</code>, and the status of your endpoint.</p> */
+        /**
+         * Update a webhook endpoint
+         * @description <p>Updates the webhook endpoint. You may edit the <code>url</code>, the list of <code>enabled_events</code>, and the status of your endpoint.</p>
+         */
         post: operations["PostWebhookEndpointsWebhookEndpoint"];
-        /** @description <p>You can also delete webhook endpoints via the <a href="https://dashboard.stripe.com/account/webhooks">webhook endpoint management</a> page of the Stripe dashboard.</p> */
+        /**
+         * Delete a webhook endpoint
+         * @description <p>You can also delete webhook endpoints via the <a href="https://dashboard.stripe.com/account/webhooks">webhook endpoint management</a> page of the Stripe dashboard.</p>
+         */
         delete: operations["DeleteWebhookEndpointsWebhookEndpoint"];
         options?: never;
         head?: never;
@@ -7079,7 +8816,7 @@ export interface components {
              */
             business_type?: "company" | "government_entity" | "individual" | "non_profit" | null;
             capabilities?: components["schemas"]["account_capabilities"];
-            /** @description Whether the account can create live charges. */
+            /** @description Whether the account can process charges. */
             charges_enabled?: boolean;
             company?: components["schemas"]["legal_entity_company"];
             controller?: components["schemas"]["account_unification_account_controller"];
@@ -7114,6 +8851,8 @@ export interface components {
                 url: string;
             };
             future_requirements?: components["schemas"]["account_future_requirements"];
+            /** @description The groups associated with the account. */
+            groups?: components["schemas"]["account_group_membership"] | null;
             /** @description Unique identifier for the object. */
             id: string;
             individual?: components["schemas"]["person"];
@@ -7126,7 +8865,7 @@ export interface components {
              * @enum {string}
              */
             object: "account";
-            /** @description Whether Stripe can send payouts to this account. */
+            /** @description Whether the funds in this account can be paid out. */
             payouts_enabled?: boolean;
             requirements?: components["schemas"]["account_requirements"];
             /** @description Options for customizing how the account functions within Stripe. */
@@ -7206,6 +8945,11 @@ export interface components {
              * @enum {string}
              */
             afterpay_clearpay_payments?: "active" | "inactive" | "pending";
+            /**
+             * @description The status of the Alma capability of the account, or whether the account can directly process Alma payments.
+             * @enum {string}
+             */
+            alma_payments?: "active" | "inactive" | "pending";
             /**
              * @description The status of the AmazonPay capability of the account, or whether the account can directly process AmazonPay payments.
              * @enum {string}
@@ -7307,6 +9051,11 @@ export interface components {
              */
             jp_bank_transfer_payments?: "active" | "inactive" | "pending";
             /**
+             * @description The status of the KakaoPay capability of the account, or whether the account can directly process KakaoPay payments.
+             * @enum {string}
+             */
+            kakao_pay_payments?: "active" | "inactive" | "pending";
+            /**
              * @description The status of the Klarna payments capability of the account, or whether the account can directly process Klarna charges.
              * @enum {string}
              */
@@ -7316,6 +9065,11 @@ export interface components {
              * @enum {string}
              */
             konbini_payments?: "active" | "inactive" | "pending";
+            /**
+             * @description The status of the KrCard capability of the account, or whether the account can directly process KrCard payments.
+             * @enum {string}
+             */
+            kr_card_payments?: "active" | "inactive" | "pending";
             /**
              * @description The status of the legacy payments capability of the account.
              * @enum {string}
@@ -7342,6 +9096,11 @@ export interface components {
              */
             mx_bank_transfer_payments?: "active" | "inactive" | "pending";
             /**
+             * @description The status of the NaverPay capability of the account, or whether the account can directly process NaverPay payments.
+             * @enum {string}
+             */
+            naver_pay_payments?: "active" | "inactive" | "pending";
+            /**
              * @description The status of the OXXO payments capability of the account, or whether the account can directly process OXXO charges.
              * @enum {string}
              */
@@ -7351,6 +9110,11 @@ export interface components {
              * @enum {string}
              */
             p24_payments?: "active" | "inactive" | "pending";
+            /**
+             * @description The status of the Payco capability of the account, or whether the account can directly process Payco payments.
+             * @enum {string}
+             */
+            payco_payments?: "active" | "inactive" | "pending";
             /**
              * @description The status of the paynow payments capability of the account, or whether the account can directly process paynow charges.
              * @enum {string}
@@ -7366,6 +9130,11 @@ export interface components {
              * @enum {string}
              */
             revolut_pay_payments?: "active" | "inactive" | "pending";
+            /**
+             * @description The status of the SamsungPay capability of the account, or whether the account can directly process SamsungPay payments.
+             * @enum {string}
+             */
+            samsung_pay_payments?: "active" | "inactive" | "pending";
             /**
              * @description The status of the SEPA customer_balance payments (EUR currency) capability of the account, or whether the account can directly process SEPA customer_balance charges.
              * @enum {string}
@@ -7526,6 +9295,11 @@ export interface components {
             past_due?: string[] | null;
             /** @description Fields that might become required depending on the results of verification or review. It's an empty array unless an asynchronous verification is pending. If verification fails, these fields move to `eventually_due` or `currently_due`. Fields might appear in `eventually_due` or `currently_due` and in `pending_verification` if verification fails but another verification is still pending. */
             pending_verification?: string[] | null;
+        };
+        /** AccountGroupMembership */
+        account_group_membership: {
+            /** @description The group the account is in to determine their payments pricing, and null if the account is on customized pricing. [See the Platform pricing tool documentation](https://stripe.com/docs/connect/platform-pricing-tools) for details. */
+            payments_pricing?: string | null;
         };
         /** AccountInvoicesSettings */
         account_invoices_settings: {
@@ -8250,8 +10024,6 @@ export interface components {
              * @enum {string}
              */
             alert_type: "usage_threshold";
-            /** @description Limits the scope of the alert to a specific [customer](https://stripe.com/docs/api/customers). */
-            filter?: components["schemas"]["thresholds_resource_alert_filter"] | null;
             /** @description Unique identifier for the object. */
             id: string;
             /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
@@ -8269,11 +10041,128 @@ export interface components {
             /** @description Title of the alert. */
             title: string;
             /** @description Encapsulates configuration of the alert to monitor usage on a specific [Billing Meter](https://stripe.com/docs/api/billing/meter). */
-            usage_threshold_config?: components["schemas"]["thresholds_resource_usage_threshold_config"] | null;
+            usage_threshold?: components["schemas"]["thresholds_resource_usage_threshold_config"] | null;
+        };
+        /**
+         * CreditBalanceSummary
+         * @description Indicates the billing credit balance for billing credits granted to a customer.
+         */
+        "billing.credit_balance_summary": {
+            /** @description The billing credit balances. One entry per credit grant currency. If a customer only has credit grants in a single currency, then this will have a single balance entry. */
+            balances: components["schemas"]["credit_balance"][];
+            /** @description The customer the balance is for. */
+            customer: string | components["schemas"]["customer"] | components["schemas"]["deleted_customer"];
+            /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+            livemode: boolean;
+            /**
+             * @description String representing the object's type. Objects of the same type share the same value.
+             * @enum {string}
+             */
+            object: "billing.credit_balance_summary";
+        };
+        /**
+         * CreditBalanceTransaction
+         * @description A credit balance transaction is a resource representing a transaction (either a credit or a debit) against an existing credit grant.
+         */
+        "billing.credit_balance_transaction": {
+            /**
+             * Format: unix-time
+             * @description Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+            /** @description Credit details for this credit balance transaction. Only present if type is `credit`. */
+            credit?: components["schemas"]["billing_credit_grants_resource_balance_credit"] | null;
+            /** @description The credit grant associated with this credit balance transaction. */
+            credit_grant: string | components["schemas"]["billing.credit_grant"];
+            /** @description Debit details for this credit balance transaction. Only present if type is `debit`. */
+            debit?: components["schemas"]["billing_credit_grants_resource_balance_debit"] | null;
+            /**
+             * Format: unix-time
+             * @description The effective time of this credit balance transaction.
+             */
+            effective_at: number;
+            /** @description Unique identifier for the object. */
+            id: string;
+            /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+            livemode: boolean;
+            /**
+             * @description String representing the object's type. Objects of the same type share the same value.
+             * @enum {string}
+             */
+            object: "billing.credit_balance_transaction";
+            /** @description ID of the test clock this credit balance transaction belongs to. */
+            test_clock?: (string | components["schemas"]["test_helpers.test_clock"]) | null;
+            /**
+             * @description The type of credit balance transaction (credit or debit).
+             * @enum {string|null}
+             */
+            type?: "credit" | "debit" | null;
+        };
+        /**
+         * CreditGrant
+         * @description A credit grant is an API resource that documents the allocation of some billing credits to a customer.
+         *
+         *     Related guide: [Billing credits](https://docs.stripe.com/billing/subscriptions/usage-based/billing-credits)
+         *     end
+         */
+        "billing.credit_grant": {
+            amount: components["schemas"]["billing_credit_grants_resource_amount"];
+            applicability_config: components["schemas"]["billing_credit_grants_resource_applicability_config"];
+            /**
+             * @description The category of this credit grant. This is for tracking purposes and will not be displayed to the customer.
+             * @enum {string}
+             */
+            category: "paid" | "promotional";
+            /**
+             * Format: unix-time
+             * @description Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
+            created: number;
+            /** @description ID of the customer to whom the billing credits are granted. */
+            customer: string | components["schemas"]["customer"] | components["schemas"]["deleted_customer"];
+            /**
+             * Format: unix-time
+             * @description The time when the billing credits become effective i.e when they are eligible to be used.
+             */
+            effective_at?: number | null;
+            /**
+             * Format: unix-time
+             * @description The time when the billing credits will expire. If not present, the billing credits will never expire.
+             */
+            expires_at?: number | null;
+            /** @description Unique identifier for the object. */
+            id: string;
+            /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+            livemode: boolean;
+            /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+            metadata: {
+                [key: string]: string;
+            };
+            /** @description A descriptive name shown in dashboard. */
+            name?: string | null;
+            /**
+             * @description String representing the object's type. Objects of the same type share the same value.
+             * @enum {string}
+             */
+            object: "billing.credit_grant";
+            /** @description ID of the test clock this credit grant belongs to. */
+            test_clock?: (string | components["schemas"]["test_helpers.test_clock"]) | null;
+            /**
+             * Format: unix-time
+             * @description Time at which the object was last updated. Measured in seconds since the Unix epoch.
+             */
+            updated: number;
+            /**
+             * Format: unix-time
+             * @description The time when this credit grant was voided. If not present, the credit grant hasn't been voided.
+             */
+            voided_at?: number | null;
         };
         /**
          * BillingMeter
          * @description A billing meter is a resource that allows you to track usage of a particular event. For example, you might create a billing meter to track the number of API calls made by a particular user. You can then attach the billing meter to a price and attach the price to a subscription to charge the user for the number of API calls they make.
+         *
+         *     Related guide: [Usage based billing](https://docs.stripe.com/billing/subscriptions/usage-based)
          */
         "billing.meter": {
             /**
@@ -8414,6 +10303,62 @@ export interface components {
         /** BillingClocksResourceStatusDetailsStatusDetails */
         billing_clocks_resource_status_details_status_details: {
             advancing?: components["schemas"]["billing_clocks_resource_status_details_advancing_status_details"];
+        };
+        /** BillingCreditGrantsResourceAmount */
+        billing_credit_grants_resource_amount: {
+            /** @description The monetary amount. */
+            monetary?: components["schemas"]["billing_credit_grants_resource_monetary_amount"] | null;
+            /**
+             * @description The type of this amount. We currently only support `monetary` billing credits.
+             * @enum {string}
+             */
+            type: "monetary";
+        };
+        /** BillingCreditGrantsResourceApplicabilityConfig */
+        billing_credit_grants_resource_applicability_config: {
+            scope: components["schemas"]["billing_credit_grants_resource_scope"];
+        };
+        /** BillingCreditGrantsResourceBalanceCredit */
+        billing_credit_grants_resource_balance_credit: {
+            amount: components["schemas"]["billing_credit_grants_resource_amount"];
+            /**
+             * @description The type of credit transaction.
+             * @enum {string}
+             */
+            type: "credits_granted";
+        };
+        /** BillingCreditGrantsResourceBalanceCreditsApplied */
+        billing_credit_grants_resource_balance_credits_applied: {
+            /** @description The invoice to which the billing credits were applied. */
+            invoice: string | components["schemas"]["invoice"];
+            /** @description The invoice line item to which the billing credits were applied. */
+            invoice_line_item: string;
+        };
+        /** BillingCreditGrantsResourceBalanceDebit */
+        billing_credit_grants_resource_balance_debit: {
+            amount: components["schemas"]["billing_credit_grants_resource_amount"];
+            /** @description Details of how the billing credits were applied to an invoice. Only present if `type` is `credits_applied`. */
+            credits_applied?: components["schemas"]["billing_credit_grants_resource_balance_credits_applied"] | null;
+            /**
+             * @description The type of debit transaction.
+             * @enum {string}
+             */
+            type: "credits_applied" | "credits_expired" | "credits_voided";
+        };
+        /** BillingCreditGrantsResourceMonetaryAmount */
+        billing_credit_grants_resource_monetary_amount: {
+            /** @description Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
+            currency: string;
+            /** @description A positive integer representing the amount. */
+            value: number;
+        };
+        /** BillingCreditGrantsResourceScope */
+        billing_credit_grants_resource_scope: {
+            /**
+             * @description The price type to which credit grants can apply to. We currently only support `metered` price type. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them.
+             * @enum {string}
+             */
+            price_type: "metered";
         };
         /** billing_details */
         billing_details: {
@@ -8593,7 +10538,7 @@ export interface components {
             requested_at?: number | null;
             requirements?: components["schemas"]["account_capability_requirements"];
             /**
-             * @description The status of the capability. Can be `active`, `inactive`, `pending`, or `unrequested`.
+             * @description The status of the capability.
              * @enum {string}
              */
             status: "active" | "disabled" | "inactive" | "pending" | "unrequested";
@@ -9366,6 +11311,25 @@ export interface components {
              */
             setup_future_usage?: "none";
         };
+        /** CheckoutKakaoPayPaymentMethodOptions */
+        checkout_kakao_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+            /**
+             * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
+             *
+             *     If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+             *
+             *     If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+             *
+             *     When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](/strong-customer-authentication).
+             * @enum {string}
+             */
+            setup_future_usage?: "none" | "off_session";
+        };
         /** CheckoutKlarnaPaymentMethodOptions */
         checkout_klarna_payment_method_options: {
             /**
@@ -9395,6 +11359,25 @@ export interface components {
              * @enum {string}
              */
             setup_future_usage?: "none";
+        };
+        /** CheckoutKrCardPaymentMethodOptions */
+        checkout_kr_card_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+            /**
+             * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
+             *
+             *     If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+             *
+             *     If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+             *
+             *     When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](/strong-customer-authentication).
+             * @enum {string}
+             */
+            setup_future_usage?: "none" | "off_session";
         };
         /** CheckoutLinkPaymentMethodOptions */
         checkout_link_payment_method_options: {
@@ -9438,6 +11421,14 @@ export interface components {
              */
             setup_future_usage?: "none";
         };
+        /** CheckoutNaverPayPaymentMethodOptions */
+        checkout_naver_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+        };
         /** CheckoutOxxoPaymentMethodOptions */
         checkout_oxxo_payment_method_options: {
             /** @description The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time. */
@@ -9467,6 +11458,14 @@ export interface components {
              * @enum {string}
              */
             setup_future_usage?: "none";
+        };
+        /** CheckoutPaycoPaymentMethodOptions */
+        checkout_payco_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
         };
         /** CheckoutPaynowPaymentMethodOptions */
         checkout_paynow_payment_method_options: {
@@ -9524,6 +11523,14 @@ export interface components {
              */
             setup_future_usage?: "none" | "off_session";
         };
+        /** CheckoutSamsungPayPaymentMethodOptions */
+        checkout_samsung_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+        };
         /** CheckoutSepaDebitPaymentMethodOptions */
         checkout_sepa_debit_payment_method_options: {
             /**
@@ -9557,17 +11564,22 @@ export interface components {
             giropay?: components["schemas"]["checkout_giropay_payment_method_options"];
             grabpay?: components["schemas"]["checkout_grab_pay_payment_method_options"];
             ideal?: components["schemas"]["checkout_ideal_payment_method_options"];
+            kakao_pay?: components["schemas"]["checkout_kakao_pay_payment_method_options"];
             klarna?: components["schemas"]["checkout_klarna_payment_method_options"];
             konbini?: components["schemas"]["checkout_konbini_payment_method_options"];
+            kr_card?: components["schemas"]["checkout_kr_card_payment_method_options"];
             link?: components["schemas"]["checkout_link_payment_method_options"];
             mobilepay?: components["schemas"]["checkout_mobilepay_payment_method_options"];
             multibanco?: components["schemas"]["checkout_multibanco_payment_method_options"];
+            naver_pay?: components["schemas"]["checkout_naver_pay_payment_method_options"];
             oxxo?: components["schemas"]["checkout_oxxo_payment_method_options"];
             p24?: components["schemas"]["checkout_p24_payment_method_options"];
+            payco?: components["schemas"]["checkout_payco_payment_method_options"];
             paynow?: components["schemas"]["checkout_paynow_payment_method_options"];
             paypal?: components["schemas"]["checkout_paypal_payment_method_options"];
             pix?: components["schemas"]["checkout_pix_payment_method_options"];
             revolut_pay?: components["schemas"]["checkout_revolut_pay_payment_method_options"];
+            samsung_pay?: components["schemas"]["checkout_samsung_pay_payment_method_options"];
             sepa_debit?: components["schemas"]["checkout_sepa_debit_payment_method_options"];
             sofort?: components["schemas"]["checkout_sofort_payment_method_options"];
             swish?: components["schemas"]["checkout_swish_payment_method_options"];
@@ -9914,6 +11926,7 @@ export interface components {
              * @enum {string}
              */
             allow_redisplay?: "always" | "limited" | "unspecified";
+            alma?: components["schemas"]["payment_method_alma"];
             amazon_pay?: components["schemas"]["payment_method_amazon_pay"];
             au_becs_debit?: components["schemas"]["payment_method_au_becs_debit"];
             bacs_debit?: components["schemas"]["payment_method_bacs_debit"];
@@ -9933,18 +11946,23 @@ export interface components {
             grabpay?: components["schemas"]["payment_method_grabpay"];
             ideal?: components["schemas"]["payment_method_ideal"];
             interac_present?: components["schemas"]["payment_method_interac_present"];
+            kakao_pay?: components["schemas"]["payment_method_kakao_pay"];
             klarna?: components["schemas"]["payment_method_klarna"];
             konbini?: components["schemas"]["payment_method_konbini"];
+            kr_card?: components["schemas"]["payment_method_kr_card"];
             link?: components["schemas"]["payment_method_link"];
             mobilepay?: components["schemas"]["payment_method_mobilepay"];
             multibanco?: components["schemas"]["payment_method_multibanco"];
+            naver_pay?: components["schemas"]["payment_method_naver_pay"];
             oxxo?: components["schemas"]["payment_method_oxxo"];
             p24?: components["schemas"]["payment_method_p24"];
+            payco?: components["schemas"]["payment_method_payco"];
             paynow?: components["schemas"]["payment_method_paynow"];
             paypal?: components["schemas"]["payment_method_paypal"];
             pix?: components["schemas"]["payment_method_pix"];
             promptpay?: components["schemas"]["payment_method_promptpay"];
             revolut_pay?: components["schemas"]["payment_method_revolut_pay"];
+            samsung_pay?: components["schemas"]["payment_method_samsung_pay"];
             sepa_debit?: components["schemas"]["payment_method_sepa_debit"];
             sofort?: components["schemas"]["payment_method_sofort"];
             swish?: components["schemas"]["payment_method_swish"];
@@ -9953,7 +11971,7 @@ export interface components {
              * @description The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
              * @enum {string}
              */
-            type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "card_present" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "interac_present" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+            type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "card_present" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "interac_present" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
             us_bank_account?: components["schemas"]["payment_method_us_bank_account"];
             wechat_pay?: components["schemas"]["payment_method_wechat_pay"];
             zip?: components["schemas"]["payment_method_zip"];
@@ -10002,7 +12020,9 @@ export interface components {
         };
         /** ConnectEmbeddedAccountFeaturesClaim */
         connect_embedded_account_features_claim: {
-            /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for custom accounts (or accounts where the platform is compliance owner). Otherwise, bank account collection is determined by compliance requirements. */
+            /** @description Disables Stripe user authentication for this embedded component. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. The default value for this feature is `false` when `external_account_collection` is enabled and `true` otherwise. */
+            disable_stripe_user_authentication?: boolean;
+            /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. Otherwise, bank account collection is determined by compliance requirements. The default value for this feature is `true`. */
             external_account_collection: boolean;
         };
         /** ConnectEmbeddedAccountSessionCreateComponents */
@@ -10052,9 +12072,11 @@ export interface components {
         };
         /** ConnectEmbeddedPayoutsFeatures */
         connect_embedded_payouts_features: {
+            /** @description Disables Stripe user authentication for this embedded component. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. The default value for this feature is `false` when `external_account_collection` is enabled and `true` otherwise. */
+            disable_stripe_user_authentication?: boolean;
             /** @description Whether to allow payout schedule to be changed. Default `true` when Stripe owns Loss Liability, default `false` otherwise. */
             edit_payout_schedule: boolean;
-            /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for custom accounts (or accounts where the platform is compliance owner). Otherwise, bank account collection is determined by compliance requirements. */
+            /** @description Whether to allow platforms to control bank account collection for their connected accounts. This feature can only be false for accounts where you’re responsible for collecting updated information when requirements are due or change, like custom accounts. Otherwise, bank account collection is determined by compliance requirements. The default value for this feature is `true`. */
             external_account_collection: boolean;
             /** @description Whether to allow creation of instant payouts. Default `true` when Stripe owns Loss Liability, default `false` otherwise. */
             instant_payouts: boolean;
@@ -10171,6 +12193,11 @@ export interface components {
             /** @description Amount (in the `currency` specified) that will be taken off the subtotal of any invoices for this customer. */
             amount_off: number;
         };
+        /** CreditBalance */
+        credit_balance: {
+            available_balance: components["schemas"]["billing_credit_grants_resource_amount"];
+            ledger_balance: components["schemas"]["billing_credit_grants_resource_amount"];
+        };
         /**
          * CreditNote
          * @description Issue a credit note to adjust an invoice's amount after the invoice is finalized.
@@ -10242,6 +12269,8 @@ export interface components {
             out_of_band_amount?: number | null;
             /** @description The link to download the PDF of the credit note. */
             pdf: string;
+            /** @description The pretax credit amounts (ex: discount, credit grants, etc) for all line items. */
+            pretax_credit_amounts?: components["schemas"]["credit_notes_pretax_credit_amount"][];
             /**
              * @description Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory`
              * @enum {string|null}
@@ -10303,6 +12332,8 @@ export interface components {
              * @enum {string}
              */
             object: "credit_note_line_item";
+            /** @description The pretax credit amounts (ex: discount, credit grants, etc) for this line item. */
+            pretax_credit_amounts?: components["schemas"]["credit_notes_pretax_credit_amount"][];
             /** @description The number of units of product being credited. */
             quantity?: number | null;
             /** @description The amount of tax calculated per tax rate for this line item */
@@ -10343,6 +12374,20 @@ export interface components {
             /** @description The amount on which tax is calculated, in cents (or local equivalent). */
             taxable_amount?: number | null;
         };
+        /** CreditNotesPretaxCreditAmount */
+        credit_notes_pretax_credit_amount: {
+            /** @description The amount, in cents (or local equivalent), of the pretax credit amount. */
+            amount: number;
+            /** @description The credit balance transaction that was applied to get this pretax credit amount. */
+            credit_balance_transaction?: string | components["schemas"]["billing.credit_balance_transaction"];
+            /** @description The discount that was applied to get this pretax credit amount. */
+            discount?: string | components["schemas"]["discount"] | components["schemas"]["deleted_discount"];
+            /**
+             * @description Type of the pretax credit amount referenced.
+             * @enum {string}
+             */
+            type: "credit_balance_transaction" | "discount";
+        };
         /** CurrencyOption */
         currency_option: {
             /** @description When set, provides configuration for the amount to be adjusted by the customer during Checkout Sessions and Payment Links. */
@@ -10373,9 +12418,8 @@ export interface components {
         };
         /**
          * Customer
-         * @description This object represents a customer of your business. Use it to create recurring charges and track payments that belong to the same customer.
-         *
-         *     Related guide: [Save a card during payment](https://stripe.com/docs/payments/save-during-payment)
+         * @description This object represents a customer of your business. Use it to [create recurring charges](https://stripe.com/docs/invoicing/customer), [save payment](https://stripe.com/docs/payments/save-during-payment) and contact information,
+         *     and track payments that belong to the same customer.
          */
         customer: {
             /** @description The customer's address. */
@@ -11297,6 +13341,8 @@ export interface components {
             created: number;
             /** @description Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). */
             currency: string;
+            /** @description List of eligibility types that are included in `enhanced_evidence`. */
+            enhanced_eligibility_types: "visa_compelling_evidence_3"[];
             evidence: components["schemas"]["dispute_evidence"];
             evidence_details: components["schemas"]["dispute_evidence_details"];
             /** @description Unique identifier for the object. */
@@ -11324,6 +13370,31 @@ export interface components {
              * @enum {string}
              */
             status: "lost" | "needs_response" | "under_review" | "warning_closed" | "warning_needs_response" | "warning_under_review" | "won";
+        };
+        /** DisputeEnhancedEligibility */
+        dispute_enhanced_eligibility: {
+            visa_compelling_evidence_3?: components["schemas"]["dispute_enhanced_eligibility_visa_compelling_evidence3"];
+        };
+        /** DisputeEnhancedEligibilityVisaCompellingEvidence3 */
+        dispute_enhanced_eligibility_visa_compelling_evidence3: {
+            /** @description List of actions required to qualify dispute for Visa Compelling Evidence 3.0 evidence submission. */
+            required_actions: ("missing_customer_identifiers" | "missing_disputed_transaction_description" | "missing_merchandise_or_services" | "missing_prior_undisputed_transaction_description" | "missing_prior_undisputed_transactions")[];
+            /**
+             * @description Visa Compelling Evidence 3.0 eligibility status.
+             * @enum {string}
+             */
+            status: "not_qualified" | "qualified" | "requires_action";
+        };
+        /** DisputeEnhancedEvidence */
+        dispute_enhanced_evidence: {
+            visa_compelling_evidence_3?: components["schemas"]["dispute_enhanced_evidence_visa_compelling_evidence3"];
+        };
+        /** DisputeEnhancedEvidenceVisaCompellingEvidence3 */
+        dispute_enhanced_evidence_visa_compelling_evidence3: {
+            /** @description Disputed transaction details for Visa Compelling Evidence 3.0 evidence submission. */
+            disputed_transaction?: components["schemas"]["dispute_visa_compelling_evidence3_disputed_transaction"] | null;
+            /** @description List of exactly two prior undisputed transaction objects for Visa Compelling Evidence 3.0 evidence submission. */
+            prior_undisputed_transactions: components["schemas"]["dispute_visa_compelling_evidence3_prior_undisputed_transaction"][];
         };
         /** DisputeEvidence */
         dispute_evidence: {
@@ -11353,6 +13424,7 @@ export interface components {
             duplicate_charge_explanation?: string | null;
             /** @description The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge. */
             duplicate_charge_id?: string | null;
+            enhanced_evidence: components["schemas"]["dispute_enhanced_evidence"];
             /** @description A description of the product or service that was sold. */
             product_description?: string | null;
             /** @description (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent to the customer notifying them of the charge. */
@@ -11389,6 +13461,7 @@ export interface components {
              * @description Date by which evidence must be submitted in order to successfully challenge dispute. Will be 0 if the customer's bank or credit card company doesn't allow a response for this particular dispute.
              */
             due_by?: number | null;
+            enhanced_eligibility: components["schemas"]["dispute_enhanced_eligibility"];
             /** @description Whether evidence has been staged for this dispute. */
             has_evidence: boolean;
             /** @description Whether the last evidence submission was submitted past the due date. Defaults to `false` if no evidence submissions have occurred. If `true`, then delivery of the latest evidence is *not* guaranteed. */
@@ -11439,6 +13512,62 @@ export interface components {
             case_id?: string | null;
             /** @description The reason for the dispute as defined by PayPal */
             reason_code?: string | null;
+        };
+        /** DisputeTransactionShippingAddress */
+        dispute_transaction_shipping_address: {
+            /** @description City, district, suburb, town, or village. */
+            city?: string | null;
+            /** @description Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
+            country?: string | null;
+            /** @description Address line 1 (e.g., street, PO Box, or company name). */
+            line1?: string | null;
+            /** @description Address line 2 (e.g., apartment, suite, unit, or building). */
+            line2?: string | null;
+            /** @description ZIP or postal code. */
+            postal_code?: string | null;
+            /** @description State, county, province, or region. */
+            state?: string | null;
+        };
+        /** DisputeVisaCompellingEvidence3DisputedTransaction */
+        dispute_visa_compelling_evidence3_disputed_transaction: {
+            /** @description User Account ID used to log into business platform. Must be recognizable by the user. */
+            customer_account_id?: string | null;
+            /** @description Unique identifier of the cardholder’s device derived from a combination of at least two hardware and software attributes. Must be at least 20 characters. */
+            customer_device_fingerprint?: string | null;
+            /** @description Unique identifier of the cardholder’s device such as a device serial number (e.g., International Mobile Equipment Identity [IMEI]). Must be at least 15 characters. */
+            customer_device_id?: string | null;
+            /** @description The email address of the customer. */
+            customer_email_address?: string | null;
+            /** @description The IP address that the customer used when making the purchase. */
+            customer_purchase_ip?: string | null;
+            /**
+             * @description Categorization of disputed payment.
+             * @enum {string|null}
+             */
+            merchandise_or_services?: "merchandise" | "services" | null;
+            /** @description A description of the product or service that was sold. */
+            product_description?: string | null;
+            /** @description The address to which a physical product was shipped. All fields are required for Visa Compelling Evidence 3.0 evidence submission. */
+            shipping_address?: components["schemas"]["dispute_transaction_shipping_address"] | null;
+        };
+        /** DisputeVisaCompellingEvidence3PriorUndisputedTransaction */
+        dispute_visa_compelling_evidence3_prior_undisputed_transaction: {
+            /** @description Stripe charge ID for the Visa Compelling Evidence 3.0 eligible prior charge. */
+            charge: string;
+            /** @description User Account ID used to log into business platform. Must be recognizable by the user. */
+            customer_account_id?: string | null;
+            /** @description Unique identifier of the cardholder’s device derived from a combination of at least two hardware and software attributes. Must be at least 20 characters. */
+            customer_device_fingerprint?: string | null;
+            /** @description Unique identifier of the cardholder’s device such as a device serial number (e.g., International Mobile Equipment Identity [IMEI]). Must be at least 15 characters. */
+            customer_device_id?: string | null;
+            /** @description The email address of the customer. */
+            customer_email_address?: string | null;
+            /** @description The IP address that the customer used when making the purchase. */
+            customer_purchase_ip?: string | null;
+            /** @description A description of the product or service that was sold. */
+            product_description?: string | null;
+            /** @description The address to which a physical product was shipped. All fields are required for Visa Compelling Evidence 3.0 evidence submission. */
+            shipping_address?: components["schemas"]["dispute_transaction_shipping_address"] | null;
         };
         /** EmailSent */
         email_sent: {
@@ -12103,6 +14232,10 @@ export interface components {
             id: string;
             /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
             livemode: boolean;
+            /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
+            metadata?: {
+                [key: string]: string;
+            } | null;
             /**
              * @description String representing the object's type. Objects of the same type share the same value.
              * @enum {string}
@@ -12984,6 +15117,8 @@ export interface components {
             total_discount_amounts?: components["schemas"]["discounts_resource_discount_amount"][] | null;
             /** @description The integer amount in cents (or local equivalent) representing the total amount of the invoice including all discounts but excluding all tax. */
             total_excluding_tax?: number | null;
+            /** @description Contains pretax credit amounts (ex: discount, credit grants, etc) that apply to this invoice. This is a combined list of total_pretax_credit_amounts across all invoice line items. */
+            total_pretax_credit_amounts?: components["schemas"]["invoices_resource_pretax_credit_amount"][] | null;
             /** @description The aggregate amounts calculated per tax rate for all line items. */
             total_tax_amounts: components["schemas"]["invoice_tax_amount"][];
             /** @description The account (if any) the payment will be attributed to for tax reporting, and where funds from the payment will be transferred to for the invoice. */
@@ -13333,7 +15468,7 @@ export interface components {
             /** @description Payment-method-specific configuration to provide to the invoice’s PaymentIntent. */
             payment_method_options?: components["schemas"]["invoices_payment_method_options"] | null;
             /** @description The list of payment method types (e.g. card) to provide to the invoice’s PaymentIntent. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice). */
-            payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | null;
+            payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | null;
         };
         /** InvoicesResourceFromInvoice */
         invoices_resource_from_invoice: {
@@ -13356,10 +15491,10 @@ export interface components {
         /** InvoicesResourceInvoiceTaxID */
         invoices_resource_invoice_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value?: string | null;
         };
@@ -13374,6 +15509,20 @@ export interface components {
         invoices_resource_line_items_proration_details: {
             /** @description For a credit proration `line_item`, the original debit line_items to which the credit proration applies. */
             credited_items?: components["schemas"]["invoices_resource_line_items_credited_items"] | null;
+        };
+        /** InvoicesResourcePretaxCreditAmount */
+        invoices_resource_pretax_credit_amount: {
+            /** @description The amount, in cents (or local equivalent), of the pretax credit amount. */
+            amount: number;
+            /** @description The credit balance transaction that was applied to get this pretax credit amount. */
+            credit_balance_transaction?: (string | components["schemas"]["billing.credit_balance_transaction"]) | null;
+            /** @description The discount that was applied to get this pretax credit amount. */
+            discount?: string | components["schemas"]["discount"] | components["schemas"]["deleted_discount"];
+            /**
+             * @description Type of the pretax credit amount referenced.
+             * @enum {string}
+             */
+            type: "credit_balance_transaction" | "discount";
         };
         /** InvoicesResourceShippingCost */
         invoices_resource_shipping_cost: {
@@ -15018,6 +17167,8 @@ export interface components {
              */
             object: "line_item";
             period: components["schemas"]["invoice_line_item_period"];
+            /** @description Contains pretax credit amounts (ex: discount, credit grants, etc) that apply to this line item. */
+            pretax_credit_amounts?: components["schemas"]["invoices_resource_pretax_credit_amount"][] | null;
             /** @description The price of the line item. */
             price?: components["schemas"]["price"] | null;
             /** @description Whether this is a proration. */
@@ -15168,6 +17319,10 @@ export interface components {
         };
         /** mandate_cashapp */
         mandate_cashapp: Record<string, never>;
+        /** mandate_kakao_pay */
+        mandate_kakao_pay: Record<string, never>;
+        /** mandate_kr_card */
+        mandate_kr_card: Record<string, never>;
         /** mandate_link */
         mandate_link: Record<string, never>;
         /** mandate_multi_use */
@@ -15180,6 +17335,8 @@ export interface components {
             bacs_debit?: components["schemas"]["mandate_bacs_debit"];
             card?: components["schemas"]["card_mandate_payment_method_details"];
             cashapp?: components["schemas"]["mandate_cashapp"];
+            kakao_pay?: components["schemas"]["mandate_kakao_pay"];
+            kr_card?: components["schemas"]["mandate_kr_card"];
             link?: components["schemas"]["mandate_link"];
             paypal?: components["schemas"]["mandate_paypal"];
             revolut_pay?: components["schemas"]["mandate_revolut_pay"];
@@ -15438,6 +17595,25 @@ export interface components {
              */
             type: "apple_pay" | "google_pay" | "samsung_pay" | "unknown";
         };
+        /** PaymentFlowsPrivatePaymentMethodsKakaoPayPaymentMethodOptions */
+        payment_flows_private_payment_methods_kakao_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+            /**
+             * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
+             *
+             *     If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+             *
+             *     If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+             *
+             *     When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](/strong-customer-authentication).
+             * @enum {string}
+             */
+            setup_future_usage?: "none" | "off_session";
+        };
         /** PaymentFlowsPrivatePaymentMethodsKlarnaDOB */
         payment_flows_private_payment_methods_klarna_dob: {
             /** @description The day of birth, between 1 and 31. */
@@ -15446,6 +17622,30 @@ export interface components {
             month?: number | null;
             /** @description The four-digit year of birth. */
             year?: number | null;
+        };
+        /** PaymentFlowsPrivatePaymentMethodsNaverPayPaymentMethodOptions */
+        payment_flows_private_payment_methods_naver_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+        };
+        /** PaymentFlowsPrivatePaymentMethodsPaycoPaymentMethodOptions */
+        payment_flows_private_payment_methods_payco_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+        };
+        /** PaymentFlowsPrivatePaymentMethodsSamsungPayPaymentMethodOptions */
+        payment_flows_private_payment_methods_samsung_pay_payment_method_options: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
         };
         /** PaymentFlowsPrivatePaymentMethodsUsBankAccountLinkedAccountOptionsFilters */
         payment_flows_private_payment_methods_us_bank_account_linked_account_options_filters: {
@@ -15877,6 +18077,7 @@ export interface components {
             affirm?: components["schemas"]["payment_method_options_affirm"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             afterpay_clearpay?: components["schemas"]["payment_method_options_afterpay_clearpay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             alipay?: components["schemas"]["payment_method_options_alipay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            alma?: components["schemas"]["payment_method_options_alma"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             amazon_pay?: components["schemas"]["payment_method_options_amazon_pay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             au_becs_debit?: components["schemas"]["payment_intent_payment_method_options_au_becs_debit"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             bacs_debit?: components["schemas"]["payment_intent_payment_method_options_bacs_debit"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
@@ -15893,18 +18094,23 @@ export interface components {
             grabpay?: components["schemas"]["payment_method_options_grabpay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             ideal?: components["schemas"]["payment_method_options_ideal"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             interac_present?: components["schemas"]["payment_method_options_interac_present"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            kakao_pay?: components["schemas"]["payment_flows_private_payment_methods_kakao_pay_payment_method_options"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             klarna?: components["schemas"]["payment_method_options_klarna"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             konbini?: components["schemas"]["payment_method_options_konbini"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            kr_card?: components["schemas"]["payment_method_options_kr_card"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             link?: components["schemas"]["payment_intent_payment_method_options_link"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             mobilepay?: components["schemas"]["payment_intent_payment_method_options_mobilepay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             multibanco?: components["schemas"]["payment_method_options_multibanco"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            naver_pay?: components["schemas"]["payment_flows_private_payment_methods_naver_pay_payment_method_options"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             oxxo?: components["schemas"]["payment_method_options_oxxo"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             p24?: components["schemas"]["payment_method_options_p24"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            payco?: components["schemas"]["payment_flows_private_payment_methods_payco_payment_method_options"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             paynow?: components["schemas"]["payment_method_options_paynow"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             paypal?: components["schemas"]["payment_method_options_paypal"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             pix?: components["schemas"]["payment_method_options_pix"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             promptpay?: components["schemas"]["payment_method_options_promptpay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             revolut_pay?: components["schemas"]["payment_method_options_revolut_pay"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
+            samsung_pay?: components["schemas"]["payment_flows_private_payment_methods_samsung_pay_payment_method_options"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             sepa_debit?: components["schemas"]["payment_intent_payment_method_options_sepa_debit"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             sofort?: components["schemas"]["payment_method_options_sofort"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
             swish?: components["schemas"]["payment_intent_payment_method_options_swish"] | components["schemas"]["payment_intent_type_specific_payment_method_options_client"];
@@ -16298,7 +18504,7 @@ export interface components {
              */
             payment_method_collection: "always" | "if_required";
             /** @description The list of payment method types that customers can use. When `null`, Stripe will dynamically show relevant payment methods you've enabled in your [payment method settings](https://dashboard.stripe.com/settings/payment_methods). */
-            payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[] | null;
+            payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "alma" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[] | null;
             phone_number_collection: components["schemas"]["payment_links_resource_phone_number_collection"];
             /** @description Settings that restrict the usage of a payment link. */
             restrictions?: components["schemas"]["payment_links_resource_restrictions"] | null;
@@ -16568,6 +18774,7 @@ export interface components {
              * @enum {string}
              */
             allow_redisplay?: "always" | "limited" | "unspecified";
+            alma?: components["schemas"]["payment_method_alma"];
             amazon_pay?: components["schemas"]["payment_method_amazon_pay"];
             au_becs_debit?: components["schemas"]["payment_method_au_becs_debit"];
             bacs_debit?: components["schemas"]["payment_method_bacs_debit"];
@@ -16594,8 +18801,10 @@ export interface components {
             id: string;
             ideal?: components["schemas"]["payment_method_ideal"];
             interac_present?: components["schemas"]["payment_method_interac_present"];
+            kakao_pay?: components["schemas"]["payment_method_kakao_pay"];
             klarna?: components["schemas"]["payment_method_klarna"];
             konbini?: components["schemas"]["payment_method_konbini"];
+            kr_card?: components["schemas"]["payment_method_kr_card"];
             link?: components["schemas"]["payment_method_link"];
             /** @description Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
             livemode: boolean;
@@ -16605,6 +18814,7 @@ export interface components {
             } | null;
             mobilepay?: components["schemas"]["payment_method_mobilepay"];
             multibanco?: components["schemas"]["payment_method_multibanco"];
+            naver_pay?: components["schemas"]["payment_method_naver_pay"];
             /**
              * @description String representing the object's type. Objects of the same type share the same value.
              * @enum {string}
@@ -16612,12 +18822,14 @@ export interface components {
             object: "payment_method";
             oxxo?: components["schemas"]["payment_method_oxxo"];
             p24?: components["schemas"]["payment_method_p24"];
+            payco?: components["schemas"]["payment_method_payco"];
             paynow?: components["schemas"]["payment_method_paynow"];
             paypal?: components["schemas"]["payment_method_paypal"];
             pix?: components["schemas"]["payment_method_pix"];
             promptpay?: components["schemas"]["payment_method_promptpay"];
             radar_options?: components["schemas"]["radar_radar_options"];
             revolut_pay?: components["schemas"]["payment_method_revolut_pay"];
+            samsung_pay?: components["schemas"]["payment_method_samsung_pay"];
             sepa_debit?: components["schemas"]["payment_method_sepa_debit"];
             sofort?: components["schemas"]["payment_method_sofort"];
             swish?: components["schemas"]["payment_method_swish"];
@@ -16626,7 +18838,7 @@ export interface components {
              * @description The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
              * @enum {string}
              */
-            type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "card_present" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "interac_present" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+            type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "card_present" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "interac_present" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
             us_bank_account?: components["schemas"]["payment_method_us_bank_account"];
             wechat_pay?: components["schemas"]["payment_method_wechat_pay"];
             zip?: components["schemas"]["payment_method_zip"];
@@ -16648,6 +18860,8 @@ export interface components {
         payment_method_affirm: Record<string, never>;
         /** payment_method_afterpay_clearpay */
         payment_method_afterpay_clearpay: Record<string, never>;
+        /** payment_method_alma */
+        payment_method_alma: Record<string, never>;
         /** payment_method_amazon_pay */
         payment_method_amazon_pay: Record<string, never>;
         /** payment_method_au_becs_debit */
@@ -16880,6 +19094,7 @@ export interface components {
             affirm?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
             afterpay_clearpay?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
             alipay?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
+            alma?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
             amazon_pay?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
             apple_pay?: components["schemas"]["payment_method_config_resource_payment_method_properties"];
             /** @description For child configs, the Connect application associated with the configuration. */
@@ -16944,6 +19159,7 @@ export interface components {
             affirm?: components["schemas"]["payment_method_details_affirm"];
             afterpay_clearpay?: components["schemas"]["payment_method_details_afterpay_clearpay"];
             alipay?: components["schemas"]["payment_flows_private_payment_methods_alipay_details"];
+            alma?: components["schemas"]["payment_method_details_alma"];
             amazon_pay?: components["schemas"]["payment_method_details_amazon_pay"];
             au_becs_debit?: components["schemas"]["payment_method_details_au_becs_debit"];
             bacs_debit?: components["schemas"]["payment_method_details_bacs_debit"];
@@ -16960,18 +19176,23 @@ export interface components {
             grabpay?: components["schemas"]["payment_method_details_grabpay"];
             ideal?: components["schemas"]["payment_method_details_ideal"];
             interac_present?: components["schemas"]["payment_method_details_interac_present"];
+            kakao_pay?: components["schemas"]["payment_method_details_kakao_pay"];
             klarna?: components["schemas"]["payment_method_details_klarna"];
             konbini?: components["schemas"]["payment_method_details_konbini"];
+            kr_card?: components["schemas"]["payment_method_details_kr_card"];
             link?: components["schemas"]["payment_method_details_link"];
             mobilepay?: components["schemas"]["payment_method_details_mobilepay"];
             multibanco?: components["schemas"]["payment_method_details_multibanco"];
+            naver_pay?: components["schemas"]["payment_method_details_naver_pay"];
             oxxo?: components["schemas"]["payment_method_details_oxxo"];
             p24?: components["schemas"]["payment_method_details_p24"];
+            payco?: components["schemas"]["payment_method_details_payco"];
             paynow?: components["schemas"]["payment_method_details_paynow"];
             paypal?: components["schemas"]["payment_method_details_paypal"];
             pix?: components["schemas"]["payment_method_details_pix"];
             promptpay?: components["schemas"]["payment_method_details_promptpay"];
             revolut_pay?: components["schemas"]["payment_method_details_revolut_pay"];
+            samsung_pay?: components["schemas"]["payment_method_details_samsung_pay"];
             sepa_debit?: components["schemas"]["payment_method_details_sepa_debit"];
             sofort?: components["schemas"]["payment_method_details_sofort"];
             stripe_account?: components["schemas"]["payment_method_details_stripe_account"];
@@ -17042,6 +19263,8 @@ export interface components {
             /** @description Order identifier shown to the merchant in Afterpay’s online portal. */
             reference?: string | null;
         };
+        /** payment_method_details_alma */
+        payment_method_details_alma: Record<string, never>;
         /** payment_method_details_amazon_pay */
         payment_method_details_amazon_pay: Record<string, never>;
         /** payment_method_details_au_becs_debit */
@@ -17464,6 +19687,11 @@ export interface components {
             /** @description An indication of various EMV functions performed during the transaction. */
             transaction_status_information?: string | null;
         };
+        /** payment_method_details_kakao_pay */
+        payment_method_details_kakao_pay: {
+            /** @description A unique identifier for the buyer as determined by the local payment processor. */
+            buyer_id?: string | null;
+        };
         /** payment_method_details_klarna */
         payment_method_details_klarna: {
             /** @description The payer details for this transaction. */
@@ -17488,6 +19716,18 @@ export interface components {
              */
             chain?: "familymart" | "lawson" | "ministop" | "seicomart" | null;
         };
+        /** payment_method_details_kr_card */
+        payment_method_details_kr_card: {
+            /**
+             * @description The local credit or debit card brand.
+             * @enum {string|null}
+             */
+            brand?: "bc" | "citi" | "hana" | "hyundai" | "jeju" | "jeonbuk" | "kakaobank" | "kbank" | "kdbbank" | "kookmin" | "kwangju" | "lotte" | "mg" | "nh" | "post" | "samsung" | "savingsbank" | "shinhan" | "shinhyup" | "suhyup" | "tossbank" | "woori" | null;
+            /** @description A unique identifier for the buyer as determined by the local payment processor. */
+            buyer_id?: string | null;
+            /** @description The last four digits of the card. This may not be present for American Express cards. */
+            last4?: string | null;
+        };
         /** payment_method_details_link */
         payment_method_details_link: {
             /** @description Two-letter ISO code representing the funding source country beneath the Link payment.
@@ -17505,6 +19745,11 @@ export interface components {
             entity?: string | null;
             /** @description Reference number associated with this Multibanco payment. */
             reference?: string | null;
+        };
+        /** payment_method_details_naver_pay */
+        payment_method_details_naver_pay: {
+            /** @description A unique identifier for the buyer as determined by the local payment processor. */
+            buyer_id?: string | null;
         };
         /** payment_method_details_oxxo */
         payment_method_details_oxxo: {
@@ -17524,6 +19769,11 @@ export interface components {
              *     (if supported) at the time of authorization or settlement. They cannot be set or mutated.
              *     Przelewy24 rarely provides this information so the attribute is usually empty. */
             verified_name?: string | null;
+        };
+        /** payment_method_details_payco */
+        payment_method_details_payco: {
+            /** @description A unique identifier for the buyer as determined by the local payment processor. */
+            buyer_id?: string | null;
         };
         /** payment_method_details_paynow */
         payment_method_details_paynow: {
@@ -17557,6 +19807,11 @@ export interface components {
         };
         /** payment_method_details_revolut_pay */
         payment_method_details_revolut_pay: Record<string, never>;
+        /** payment_method_details_samsung_pay */
+        payment_method_details_samsung_pay: {
+            /** @description A unique identifier for the buyer as determined by the local payment processor. */
+            buyer_id?: string | null;
+        };
         /** payment_method_details_sepa_debit */
         payment_method_details_sepa_debit: {
             /** @description Bank code of bank associated with the bank account. */
@@ -17655,6 +19910,7 @@ export interface components {
          *     Related guide: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
          */
         payment_method_domain: {
+            amazon_pay: components["schemas"]["payment_method_domain_resource_payment_method_status"];
             apple_pay: components["schemas"]["payment_method_domain_resource_payment_method_status"];
             /**
              * Format: unix-time
@@ -17765,6 +20021,8 @@ export interface components {
              */
             read_method?: "contact_emv" | "contactless_emv" | "contactless_magstripe_mode" | "magnetic_stripe_fallback" | "magnetic_stripe_track2" | null;
         };
+        /** payment_method_kakao_pay */
+        payment_method_kakao_pay: Record<string, never>;
         /** payment_method_klarna */
         payment_method_klarna: {
             /** @description The customer's date of birth, if provided. */
@@ -17772,6 +20030,16 @@ export interface components {
         };
         /** payment_method_konbini */
         payment_method_konbini: Record<string, never>;
+        /** payment_method_kr_card */
+        payment_method_kr_card: {
+            /**
+             * @description The local credit or debit card brand.
+             * @enum {string|null}
+             */
+            brand?: "bc" | "citi" | "hana" | "hyundai" | "jeju" | "jeonbuk" | "kakaobank" | "kbank" | "kdbbank" | "kookmin" | "kwangju" | "lotte" | "mg" | "nh" | "post" | "samsung" | "savingsbank" | "shinhan" | "shinhyup" | "suhyup" | "tossbank" | "woori" | null;
+            /** @description The last four digits of the card. This may not be present for American Express cards. */
+            last4?: string | null;
+        };
         /** payment_method_link */
         payment_method_link: {
             /** @description Account owner's email address. */
@@ -17781,6 +20049,14 @@ export interface components {
         payment_method_mobilepay: Record<string, never>;
         /** payment_method_multibanco */
         payment_method_multibanco: Record<string, never>;
+        /** payment_method_naver_pay */
+        payment_method_naver_pay: {
+            /**
+             * @description Whether to fund this transaction with Naver Pay points or a card.
+             * @enum {string}
+             */
+            funding: "card" | "points";
+        };
         /** payment_method_options_affirm */
         payment_method_options_affirm: {
             /**
@@ -17837,6 +20113,14 @@ export interface components {
              * @enum {string}
              */
             setup_future_usage?: "none" | "off_session";
+        };
+        /** payment_method_options_alma */
+        payment_method_options_alma: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
         };
         /** payment_method_options_amazon_pay */
         payment_method_options_amazon_pay: {
@@ -18114,6 +20398,25 @@ export interface components {
              */
             setup_future_usage?: "none";
         };
+        /** payment_method_options_kr_card */
+        payment_method_options_kr_card: {
+            /**
+             * @description Controls when the funds will be captured from the customer's account.
+             * @enum {string}
+             */
+            capture_method?: "manual";
+            /**
+             * @description Indicates that you intend to make future payments with this PaymentIntent's payment method.
+             *
+             *     If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+             *
+             *     If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+             *
+             *     When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](/strong-customer-authentication).
+             * @enum {string}
+             */
+            setup_future_usage?: "none" | "off_session";
+        };
         /** payment_method_options_multibanco */
         payment_method_options_multibanco: {
             /**
@@ -18332,6 +20635,8 @@ export interface components {
              */
             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank" | null;
         };
+        /** payment_method_payco */
+        payment_method_payco: Record<string, never>;
         /** payment_method_paynow */
         payment_method_paynow: Record<string, never>;
         /** payment_method_paypal */
@@ -18348,6 +20653,8 @@ export interface components {
         payment_method_promptpay: Record<string, never>;
         /** payment_method_revolut_pay */
         payment_method_revolut_pay: Record<string, never>;
+        /** payment_method_samsung_pay */
+        payment_method_samsung_pay: Record<string, never>;
         /** payment_method_sepa_debit */
         payment_method_sepa_debit: {
             /** @description Bank code of bank associated with the bank account. */
@@ -18681,10 +20988,10 @@ export interface components {
         /** PaymentPagesCheckoutSessionTaxID */
         payment_pages_checkout_session_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value?: string | null;
         };
@@ -18852,7 +21159,7 @@ export interface components {
             /** @description A list of alternate names or aliases that the person is known by. */
             full_name_aliases?: string[];
             future_requirements?: components["schemas"]["person_future_requirements"] | null;
-            /** @description The person's gender (International regulations require either "male" or "female"). */
+            /** @description The person's gender. */
             gender?: string | null;
             /** @description Unique identifier for the object. */
             id: string;
@@ -19201,6 +21508,19 @@ export interface components {
             /** @description Whether the feature is enabled. */
             enabled: boolean;
         };
+        /** PortalResourceScheduleUpdateAtPeriodEnd */
+        portal_resource_schedule_update_at_period_end: {
+            /** @description List of conditions. When any condition is true, an update will be scheduled at the end of the current period. */
+            conditions: components["schemas"]["portal_resource_schedule_update_at_period_end_condition"][];
+        };
+        /** PortalResourceScheduleUpdateAtPeriodEndCondition */
+        portal_resource_schedule_update_at_period_end_condition: {
+            /**
+             * @description The type of condition.
+             * @enum {string}
+             */
+            type: "decreasing_item_amount" | "shortening_interval";
+        };
         /** PortalSubscriptionCancel */
         portal_subscription_cancel: {
             cancellation_reason: components["schemas"]["portal_subscription_cancellation_reason"];
@@ -19237,6 +21557,7 @@ export interface components {
              * @enum {string}
              */
             proration_behavior: "always_invoice" | "create_prorations" | "none";
+            schedule_at_period_end?: components["schemas"]["portal_resource_schedule_update_at_period_end"];
         };
         /** PortalSubscriptionUpdateProduct */
         portal_subscription_update_product: {
@@ -19432,7 +21753,7 @@ export interface components {
         promotion_code: {
             /** @description Whether the promotion code is currently active. A promotion code is only active if the coupon is also valid. */
             active: boolean;
-            /** @description The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for each customer. */
+            /** @description The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for each customer. Valid characters are lower case letters (a-z), upper case letters (A-Z), and digits (0-9). */
             code: string;
             coupon: components["schemas"]["coupon"];
             /**
@@ -19953,6 +22274,7 @@ export interface components {
             affirm?: components["schemas"]["destination_details_unimplemented"];
             afterpay_clearpay?: components["schemas"]["destination_details_unimplemented"];
             alipay?: components["schemas"]["destination_details_unimplemented"];
+            alma?: components["schemas"]["destination_details_unimplemented"];
             amazon_pay?: components["schemas"]["destination_details_unimplemented"];
             au_bank_transfer?: components["schemas"]["destination_details_unimplemented"];
             blik?: components["schemas"]["refund_destination_details_generic"];
@@ -20006,8 +22328,7 @@ export interface components {
         };
         /** RefundNextAction */
         refund_next_action: {
-            /** @description Contains the refund details. */
-            display_details?: components["schemas"]["refund_next_action_display_details"] | null;
+            display_details?: components["schemas"]["refund_next_action_display_details"];
             /** @description Type of the next action to perform. */
             type: string;
         };
@@ -20308,7 +22629,9 @@ export interface components {
             card_present?: components["schemas"]["setup_attempt_payment_method_details_card_present"];
             cashapp?: components["schemas"]["setup_attempt_payment_method_details_cashapp"];
             ideal?: components["schemas"]["setup_attempt_payment_method_details_ideal"];
+            kakao_pay?: components["schemas"]["setup_attempt_payment_method_details_kakao_pay"];
             klarna?: components["schemas"]["setup_attempt_payment_method_details_klarna"];
+            kr_card?: components["schemas"]["setup_attempt_payment_method_details_kr_card"];
             link?: components["schemas"]["setup_attempt_payment_method_details_link"];
             paypal?: components["schemas"]["setup_attempt_payment_method_details_paypal"];
             revolut_pay?: components["schemas"]["setup_attempt_payment_method_details_revolut_pay"];
@@ -20429,8 +22752,12 @@ export interface components {
              *     (if supported) at the time of authorization or settlement. They cannot be set or mutated. */
             verified_name?: string | null;
         };
+        /** setup_attempt_payment_method_details_kakao_pay */
+        setup_attempt_payment_method_details_kakao_pay: Record<string, never>;
         /** setup_attempt_payment_method_details_klarna */
         setup_attempt_payment_method_details_klarna: Record<string, never>;
+        /** setup_attempt_payment_method_details_kr_card */
+        setup_attempt_payment_method_details_kr_card: Record<string, never>;
         /** setup_attempt_payment_method_details_link */
         setup_attempt_payment_method_details_link: Record<string, never>;
         /** setup_attempt_payment_method_details_paypal */
@@ -21852,7 +24179,7 @@ export interface components {
             /** @description Payment-method-specific configuration to provide to invoices created by the subscription. */
             payment_method_options?: components["schemas"]["subscriptions_resource_payment_method_options"] | null;
             /** @description The list of payment method types to provide to every invoice created by the subscription. If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice). */
-            payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | null;
+            payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | null;
             /**
              * @description Configure whether Stripe updates `subscription.default_payment_method` when payment succeeds. Defaults to `off`.
              * @enum {string|null}
@@ -22061,7 +24388,7 @@ export interface components {
              */
             object: "tax.settings";
             /**
-             * @description The `active` status indicates you have all required settings to calculate tax. A status can transition out of `active` when new required settings are introduced.
+             * @description The status of the Tax `Settings`.
              * @enum {string}
              */
             status: "active" | "pending";
@@ -22260,10 +24587,10 @@ export interface components {
             /** @description The account or customer the tax ID belongs to. */
             owner?: components["schemas"]["tax_i_ds_owner"] | null;
             /**
-             * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+             * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description Value of the tax ID. */
             value: string;
             /** @description Tax ID verification information. */
@@ -22289,14 +24616,17 @@ export interface components {
             be?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             bg?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             bh?: components["schemas"]["tax_product_registrations_resource_country_options_default"];
+            by?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             ca?: components["schemas"]["tax_product_registrations_resource_country_options_canada"];
             ch?: components["schemas"]["tax_product_registrations_resource_country_options_default"];
             cl?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             co?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
+            cr?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             cy?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             cz?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             de?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             dk?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
+            ec?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             ee?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             eg?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             es?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
@@ -22318,6 +24648,8 @@ export interface components {
             lt?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             lu?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             lv?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
+            ma?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
+            md?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             mt?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             mx?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             my?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
@@ -22329,6 +24661,8 @@ export interface components {
             pl?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             pt?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             ro?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
+            rs?: components["schemas"]["tax_product_registrations_resource_country_options_default"];
+            ru?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             sa?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             se?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             sg?: components["schemas"]["tax_product_registrations_resource_country_options_default"];
@@ -22336,7 +24670,9 @@ export interface components {
             sk?: components["schemas"]["tax_product_registrations_resource_country_options_europe"];
             th?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             tr?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
+            tz?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             us?: components["schemas"]["tax_product_registrations_resource_country_options_united_states"];
+            uz?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             vn?: components["schemas"]["tax_product_registrations_resource_country_options_simplified"];
             za?: components["schemas"]["tax_product_registrations_resource_country_options_default"];
         };
@@ -22398,7 +24734,7 @@ export interface components {
              * @description Type of registration in the US.
              * @enum {string}
              */
-            type: "local_amusement_tax" | "local_lease_tax" | "state_communications_tax" | "state_sales_tax";
+            type: "local_amusement_tax" | "local_lease_tax" | "state_communications_tax" | "state_retail_delivery_fee" | "state_sales_tax";
         };
         /** TaxProductRegistrationsResourceCountryOptionsUsLocalAmusementTax */
         tax_product_registrations_resource_country_options_us_local_amusement_tax: {
@@ -22447,10 +24783,10 @@ export interface components {
         /** TaxProductResourceCustomerDetailsResourceTaxId */
         tax_product_resource_customer_details_resource_tax_id: {
             /**
-             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, or `unknown`
+             * @description The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, or `unknown`
              * @enum {string}
              */
-            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "unknown" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
             /** @description The value of the tax ID. */
             value: string;
         };
@@ -22498,7 +24834,7 @@ export interface components {
              * @description The tax type, such as `vat` or `sales_tax`.
              * @enum {string}
              */
-            tax_type: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+            tax_type: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
         };
         /** TaxProductResourcePostalAddress */
         tax_product_resource_postal_address: {
@@ -22556,15 +24892,22 @@ export interface components {
         tax_product_resource_tax_rate_details: {
             /** @description Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
             country?: string | null;
+            /** @description The amount of the tax rate when the `rate_type` is `flat_amount`. Tax rates with `rate_type` `percentage` can vary based on the transaction, resulting in this field being `null`. This field exposes the amount and currency of the flat tax rate. */
+            flat_amount?: components["schemas"]["tax_rate_flat_amount"] | null;
             /** @description The tax rate percentage as a string. For example, 8.5% is represented as `"8.5"`. */
             percentage_decimal: string;
+            /**
+             * @description Indicates the type of tax rate applied to the taxable amount. This value can be `null` when no tax applies to the location.
+             * @enum {string|null}
+             */
+            rate_type?: "flat_amount" | "percentage" | null;
             /** @description State, county, province, or region. */
             state?: string | null;
             /**
              * @description The tax type, such as `vat` or `sales_tax`.
              * @enum {string|null}
              */
-            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat" | null;
+            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat" | null;
         };
         /** TaxProductResourceTaxSettingsDefaults */
         tax_product_resource_tax_settings_defaults: {
@@ -22642,6 +24985,8 @@ export interface components {
              *     this percentage reflects the rate actually used to calculate tax based on the product's taxability
              *     and whether the user is registered to collect taxes in the corresponding jurisdiction. */
             effective_percentage?: number | null;
+            /** @description The amount of the tax rate when the `rate_type` is `flat_amount`. Tax rates with `rate_type` `percentage` can vary based on the transaction, resulting in this field being `null`. This field exposes the amount and currency of the flat tax rate. */
+            flat_amount?: components["schemas"]["tax_rate_flat_amount"] | null;
             /** @description Unique identifier for the object. */
             id: string;
             /** @description This specifies if the tax rate is inclusive or exclusive. */
@@ -22666,13 +25011,28 @@ export interface components {
             object: "tax_rate";
             /** @description Tax rate percentage out of 100. For tax calculations with automatic_tax[enabled]=true, this percentage includes the statutory tax rate of non-taxable jurisdictions. */
             percentage: number;
+            /**
+             * @description Indicates the type of tax rate applied to the taxable amount. This value can be `null` when no tax applies to the location.
+             * @enum {string|null}
+             */
+            rate_type?: "flat_amount" | "percentage" | null;
             /** @description [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix. For example, "NY" for New York, United States. */
             state?: string | null;
             /**
              * @description The high-level tax type, such as `vat` or `sales_tax`.
              * @enum {string|null}
              */
-            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat" | null;
+            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat" | null;
+        };
+        /**
+         * TaxRateFlatAmount
+         * @description The amount of the tax rate when the `rate_type`` is `flat_amount`. Tax rates with `rate_type` `percentage` can vary based on the transaction, resulting in this field being `null`. This field exposes the amount and currency of the flat tax rate.
+         */
+        tax_rate_flat_amount: {
+            /** @description Amount of the tax when the `rate_type` is `flat_amount`. This positive integer represents how much to charge in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99). */
+            amount: number;
+            /** @description Three-letter ISO currency code, in lowercase. */
+            currency: string;
         };
         /**
          * TerminalConfigurationConfiguration
@@ -22824,6 +25184,7 @@ export interface components {
             myr?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
             nok?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
             nzd?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
+            pln?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
             sek?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
             sgd?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
             usd?: components["schemas"]["terminal_configuration_configuration_resource_currency_specific_config"];
@@ -23095,16 +25456,20 @@ export interface components {
             /** @description Whether 3D Secure is supported on this card. */
             supported: boolean;
         };
-        /** ThresholdsResourceAlertFilter */
-        thresholds_resource_alert_filter: {
+        /** ThresholdsResourceUsageAlertFilter */
+        thresholds_resource_usage_alert_filter: {
             /** @description Limit the scope of the alert to this customer ID */
             customer?: (string | components["schemas"]["customer"]) | null;
+            /** @enum {string} */
+            type: "customer";
         };
         /**
          * ThresholdsResourceUsageThresholdConfig
          * @description The usage threshold alert configuration enables setting up alerts for when a certain usage threshold on a specific meter is crossed.
          */
         thresholds_resource_usage_threshold_config: {
+            /** @description The filters allow limiting the scope of this usage alert. You can only specify up to one filter at this time. */
+            filters?: components["schemas"]["thresholds_resource_usage_alert_filter"][] | null;
             /** @description The value at which this alert will trigger. */
             gte: number;
             /** @description The [Billing Meter](/api/billing/meter) ID whose usage is monitored. */
@@ -23513,7 +25878,7 @@ export interface components {
             /** @description The array of paths to restricted Features in the Features hash. */
             restricted_features?: ("card_issuing" | "deposit_insurance" | "financial_addresses.aba" | "financial_addresses.aba.forwarding" | "inbound_transfers.ach" | "intra_stripe_flows" | "outbound_payments.ach" | "outbound_payments.us_domestic_wire" | "outbound_transfers.ach" | "outbound_transfers.us_domestic_wire" | "remote_deposit_capture")[];
             /**
-             * @description The enum specifying what state the account is in.
+             * @description Status of this FinancialAccount.
              * @enum {string}
              */
             status: "closed" | "open";
@@ -23746,7 +26111,7 @@ export interface components {
              * @description Reason for the failure. A ReceivedCredit might fail because the receiving FinancialAccount is closed or frozen.
              * @enum {string|null}
              */
-            failure_code?: "account_closed" | "account_frozen" | "other" | null;
+            failure_code?: "account_closed" | "account_frozen" | "international_transaction" | "other" | null;
             /** @description The FinancialAccount that received the funds. */
             financial_account?: string | null;
             /** @description A [hosted transaction receipt](https://stripe.com/docs/treasury/moving-money/regulatory-receipts) URL that is provided when money movement is considered regulated under Stripe's money transmission licenses. */
@@ -24455,7 +26820,10 @@ export interface components {
              */
             timestamp: number;
         };
-        /** UsageRecordSummary */
+        /**
+         * UsageRecordSummary
+         * @description A usage record summary represents an aggregated view of how much usage was accrued for a subscription item within a subscription billing period.
+         */
         usage_record_summary: {
             /** @description Unique identifier for the object. */
             id: string;
@@ -24655,6 +27023,7 @@ export interface operations {
                             enabled: boolean;
                             /** account_features_param */
                             features?: {
+                                disable_stripe_user_authentication?: boolean;
                                 external_account_collection?: boolean;
                             };
                         };
@@ -24663,6 +27032,7 @@ export interface operations {
                             enabled: boolean;
                             /** account_features_param */
                             features?: {
+                                disable_stripe_user_authentication?: boolean;
                                 external_account_collection?: boolean;
                             };
                         };
@@ -24671,6 +27041,7 @@ export interface operations {
                             enabled: boolean;
                             /** payouts_features_param */
                             features?: {
+                                disable_stripe_user_authentication?: boolean;
                                 edit_payout_schedule?: boolean;
                                 external_account_collection?: boolean;
                                 instant_payouts?: boolean;
@@ -24688,6 +27059,7 @@ export interface operations {
                             enabled: boolean;
                             /** account_features_param */
                             features?: {
+                                disable_stripe_user_authentication?: boolean;
                                 external_account_collection?: boolean;
                             };
                         };
@@ -24718,6 +27090,7 @@ export interface operations {
                             enabled: boolean;
                             /** payouts_features_param */
                             features?: {
+                                disable_stripe_user_authentication?: boolean;
                                 edit_payout_schedule?: boolean;
                                 external_account_collection?: boolean;
                                 instant_payouts?: boolean;
@@ -24926,6 +27299,10 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        alma_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         amazon_pay_payments?: {
                             requested?: boolean;
                         };
@@ -25006,11 +27383,19 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        kakao_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         klarna_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
                         konbini_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        kr_card_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25034,11 +27419,19 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        naver_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         oxxo_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
                         p24_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        payco_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25051,6 +27444,10 @@ export interface operations {
                         };
                         /** capability_param */
                         revolut_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        samsung_pay_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25234,6 +27631,13 @@ export interface operations {
                     expand?: string[];
                     /** @description A card or bank account to attach to the account for receiving [payouts](/connect/bank-debit-card-payouts) (you won’t be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](/js), or a dictionary, as documented in the `external_account` parameter for [bank account](/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the [bank account](/api#account_create_bank_account) or [card creation](/api#account_create_card) APIs. After you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts. */
                     external_account?: string;
+                    /**
+                     * account_groups_specs
+                     * @description A hash of account group type to tokens. These are account groups this account should be added to
+                     */
+                    groups?: {
+                        payments_pricing?: string | "";
+                    };
                     /**
                      * individual_specs
                      * @description Information about the person represented by the account. This field is null unless `business_type` is set to `individual`. Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
@@ -25551,6 +27955,10 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        alma_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         amazon_pay_payments?: {
                             requested?: boolean;
                         };
@@ -25631,11 +28039,19 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        kakao_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         klarna_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
                         konbini_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        kr_card_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25659,11 +28075,19 @@ export interface operations {
                             requested?: boolean;
                         };
                         /** capability_param */
+                        naver_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
                         oxxo_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
                         p24_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        payco_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25676,6 +28100,10 @@ export interface operations {
                         };
                         /** capability_param */
                         revolut_pay_payments?: {
+                            requested?: boolean;
+                        };
+                        /** capability_param */
+                        samsung_pay_payments?: {
                             requested?: boolean;
                         };
                         /** capability_param */
@@ -25834,6 +28262,13 @@ export interface operations {
                     expand?: string[];
                     /** @description A card or bank account to attach to the account for receiving [payouts](/connect/bank-debit-card-payouts) (you won’t be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](/js), or a dictionary, as documented in the `external_account` parameter for [bank account](/api#account_create_bank_account) creation. <br><br>By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the [bank account](/api#account_create_bank_account) or [card creation](/api#account_create_card) APIs. After you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts. */
                     external_account?: string;
+                    /**
+                     * account_groups_specs
+                     * @description A hash of account group type to tokens. These are account groups this account should be added to
+                     */
+                    groups?: {
+                        payments_pricing?: string | "";
+                    };
                     /**
                      * individual_specs
                      * @description Information about the person represented by the account. This field is null unless `business_type` is set to `individual`. Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
@@ -28848,22 +31283,18 @@ export interface operations {
                     alert_type: "usage_threshold";
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
-                    /**
-                     * alert_filter
-                     * @description Filters to limit the scope of an alert.
-                     */
-                    filter?: {
-                        customer?: string;
-                        subscription?: string;
-                        subscription_item?: string;
-                    };
                     /** @description The title of the alert. */
                     title: string;
                     /**
                      * usage_threshold_config
                      * @description The configuration of the usage threshold.
                      */
-                    usage_threshold_config?: {
+                    usage_threshold?: {
+                        filters?: {
+                            customer?: string;
+                            /** @enum {string} */
+                            type: "customer";
+                        }[];
                         gte: number;
                         meter?: string;
                         /** @enum {string} */
@@ -29032,6 +31463,451 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["billing.alert"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    GetBillingCreditBalanceSummary: {
+        parameters: {
+            query: {
+                /** @description The customer for which to fetch credit balance summary. */
+                customer: string;
+                /** @description Specifies which fields in the response should be expanded. */
+                expand?: string[];
+                /** @description The filter criteria for the credit balance summary. */
+                filter: {
+                    /** scope_param */
+                    applicability_scope?: {
+                        /** @enum {string} */
+                        price_type: "metered";
+                    };
+                    credit_grant?: string;
+                    /** @enum {string} */
+                    type: "applicability_scope" | "credit_grant";
+                };
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_balance_summary"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    GetBillingCreditBalanceTransactions: {
+        parameters: {
+            query: {
+                /** @description The credit grant for which to fetch credit balance transactions. */
+                credit_grant?: string;
+                /** @description The customer for which to fetch credit balance transactions. */
+                customer: string;
+                /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
+                ending_before?: string;
+                /** @description Specifies which fields in the response should be expanded. */
+                expand?: string[];
+                /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
+                limit?: number;
+                /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
+                starting_after?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["billing.credit_balance_transaction"][];
+                        /** @description True if this list has another page of items after this one that can be fetched. */
+                        has_more: boolean;
+                        /**
+                         * @description String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+                         * @enum {string}
+                         */
+                        object: "list";
+                        /** @description The URL where this list can be accessed. */
+                        url: string;
+                    };
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    GetBillingCreditBalanceTransactionsId: {
+        parameters: {
+            query?: {
+                /** @description Specifies which fields in the response should be expanded. */
+                expand?: string[];
+            };
+            header?: never;
+            path: {
+                /** @description Unique identifier for the object. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_balance_transaction"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    GetBillingCreditGrants: {
+        parameters: {
+            query?: {
+                /** @description Only return credit grants for this customer. */
+                customer?: string;
+                /** @description A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. */
+                ending_before?: string;
+                /** @description Specifies which fields in the response should be expanded. */
+                expand?: string[];
+                /** @description A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. */
+                limit?: number;
+                /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
+                starting_after?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["billing.credit_grant"][];
+                        /** @description True if this list has another page of items after this one that can be fetched. */
+                        has_more: boolean;
+                        /**
+                         * @description String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+                         * @enum {string}
+                         */
+                        object: "list";
+                        /** @description The URL where this list can be accessed. */
+                        url: string;
+                    };
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostBillingCreditGrants: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /**
+                     * amount_param
+                     * @description Amount of this credit grant.
+                     */
+                    amount: {
+                        /** monetary_amount_param */
+                        monetary?: {
+                            currency: string;
+                            value: number;
+                        };
+                        /** @enum {string} */
+                        type: "monetary";
+                    };
+                    /**
+                     * applicability_config_param
+                     * @description Configuration specifying what this credit grant applies to.
+                     */
+                    applicability_config: {
+                        /** scope_param */
+                        scope: {
+                            /** @enum {string} */
+                            price_type: "metered";
+                        };
+                    };
+                    /**
+                     * @description The category of this credit grant.
+                     * @enum {string}
+                     */
+                    category: "paid" | "promotional";
+                    /** @description ID of the customer to whom the billing credits should be granted. */
+                    customer: string;
+                    /**
+                     * Format: unix-time
+                     * @description The time when the billing credits become effective i.e when they are eligible to be used. Defaults to the current timestamp if not specified.
+                     */
+                    effective_at?: number;
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
+                    /**
+                     * Format: unix-time
+                     * @description The time when the billing credits will expire. If not specified, the billing credits will never expire.
+                     */
+                    expires_at?: number;
+                    /** @description Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object (ex: cost basis) in a structured format. */
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                    /** @description A descriptive name shown in dashboard. */
+                    name?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_grant"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    GetBillingCreditGrantsId: {
+        parameters: {
+            query?: {
+                /** @description Specifies which fields in the response should be expanded. */
+                expand?: string[];
+            };
+            header?: never;
+            path: {
+                /** @description Unique identifier for the object. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_grant"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostBillingCreditGrantsId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unique identifier for the object. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
+                    /** @description The time when the billing credits created by this credit grant will expire. If set to empty, the billing credits will never expire. */
+                    expires_at?: number | "";
+                    /** @description Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object (ex: cost basis) in a structured format. */
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_grant"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostBillingCreditGrantsIdExpire: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unique identifier for the object. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_grant"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostBillingCreditGrantsIdVoid: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Unique identifier for the object. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["billing.credit_grant"];
                 };
             };
             /** @description Error response. */
@@ -29561,7 +32437,7 @@ export interface operations {
                      * business_profile_create_param
                      * @description The business information shown to customers in the portal.
                      */
-                    business_profile: {
+                    business_profile?: {
                         headline?: string | "";
                         privacy_policy_url?: string;
                         terms_of_service_url?: string;
@@ -29603,14 +32479,21 @@ export interface operations {
                         };
                         /** subscription_update_creation_param */
                         subscription_update?: {
-                            default_allowed_updates: ("price" | "promotion_code" | "quantity")[] | "";
+                            default_allowed_updates?: ("price" | "promotion_code" | "quantity")[] | "";
                             enabled: boolean;
-                            products: {
+                            products?: {
                                 prices: string[];
                                 product: string;
                             }[] | "";
                             /** @enum {string} */
                             proration_behavior?: "always_invoice" | "create_prorations" | "none";
+                            /** schedule_update_at_period_end_creating_param */
+                            schedule_at_period_end?: {
+                                conditions?: {
+                                    /** @enum {string} */
+                                    type: "decreasing_item_amount" | "shortening_interval";
+                                }[];
+                            };
                         };
                     };
                     /**
@@ -29754,6 +32637,13 @@ export interface operations {
                             }[] | "";
                             /** @enum {string} */
                             proration_behavior?: "always_invoice" | "create_prorations" | "none";
+                            /** schedule_update_at_period_end_updating_param */
+                            schedule_at_period_end?: {
+                                conditions?: {
+                                    /** @enum {string} */
+                                    type: "decreasing_item_amount" | "shortening_interval";
+                                }[] | "";
+                            };
                         };
                     };
                     /**
@@ -30379,6 +33269,49 @@ export interface operations {
                         duplicate_charge_documentation?: string;
                         duplicate_charge_explanation?: string;
                         duplicate_charge_id?: string;
+                        enhanced_evidence?: {
+                            /** visa_compelling_evidence3 */
+                            visa_compelling_evidence_3?: {
+                                /** visa_compelling_evidence3_disputed_transaction */
+                                disputed_transaction?: {
+                                    customer_account_id?: string | "";
+                                    customer_device_fingerprint?: string | "";
+                                    customer_device_id?: string | "";
+                                    customer_email_address?: string | "";
+                                    customer_purchase_ip?: string | "";
+                                    /** @enum {string} */
+                                    merchandise_or_services?: "merchandise" | "services";
+                                    product_description?: string | "";
+                                    /** shipping_address */
+                                    shipping_address?: {
+                                        city?: string | "";
+                                        country?: string | "";
+                                        line1?: string | "";
+                                        line2?: string | "";
+                                        postal_code?: string | "";
+                                        state?: string | "";
+                                    };
+                                };
+                                prior_undisputed_transactions?: {
+                                    charge: string;
+                                    customer_account_id?: string | "";
+                                    customer_device_fingerprint?: string | "";
+                                    customer_device_id?: string | "";
+                                    customer_email_address?: string | "";
+                                    customer_purchase_ip?: string | "";
+                                    product_description?: string | "";
+                                    /** shipping_address */
+                                    shipping_address?: {
+                                        city?: string | "";
+                                        country?: string | "";
+                                        line1?: string | "";
+                                        line2?: string | "";
+                                        postal_code?: string | "";
+                                        state?: string | "";
+                                    };
+                                }[];
+                            };
+                        } | "";
                         product_description?: string;
                         receipt?: string;
                         refund_policy?: string;
@@ -31243,6 +34176,11 @@ export interface operations {
                             setup_future_usage?: "none";
                         };
                         /** payment_method_options_param */
+                        kakao_pay?: {
+                            /** @enum {string} */
+                            setup_future_usage?: "none" | "off_session";
+                        };
+                        /** payment_method_options_param */
                         klarna?: {
                             /** @enum {string} */
                             setup_future_usage?: "none";
@@ -31252,6 +34190,11 @@ export interface operations {
                             expires_after_days?: number;
                             /** @enum {string} */
                             setup_future_usage?: "none";
+                        };
+                        /** payment_method_options_param */
+                        kr_card?: {
+                            /** @enum {string} */
+                            setup_future_usage?: "none" | "off_session";
                         };
                         /** payment_method_options_param */
                         link?: {
@@ -31269,6 +34212,11 @@ export interface operations {
                             setup_future_usage?: "none";
                         };
                         /** payment_method_options_param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            setup_future_usage?: "none" | "off_session";
+                        };
+                        /** payment_method_options_param */
                         oxxo?: {
                             expires_after_days?: number;
                             /** @enum {string} */
@@ -31280,6 +34228,8 @@ export interface operations {
                             setup_future_usage?: "none";
                             tos_shown_and_accepted?: boolean;
                         };
+                        /** payment_method_options_param */
+                        payco?: Record<string, never>;
                         /** payment_method_options_param */
                         paynow?: {
                             /** @enum {string} */
@@ -31305,6 +34255,8 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none" | "off_session";
                         };
+                        /** payment_method_options_param */
+                        samsung_pay?: Record<string, never>;
                         /** payment_method_options_param */
                         sepa_debit?: {
                             /** @enum {string} */
@@ -31351,7 +34303,7 @@ export interface operations {
                      *     If multiple payment methods are passed, Checkout will dynamically reorder them to
                      *     prioritize the most relevant payment methods based on the customer's location and
                      *     other characteristics. */
-                    payment_method_types?: ("acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[];
+                    payment_method_types?: ("acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[];
                     /**
                      * phone_number_collection_params
                      * @description Controls phone number collection settings for the session.
@@ -33239,7 +36191,7 @@ export interface operations {
                     promotion_code?: string;
                     /** @description The customer's shipping information. Appears on invoices emailed to this customer. */
                     shipping?: {
-                        /** optional_fields_address */
+                        /** optional_fields_customer_address */
                         address: {
                             city?: string;
                             country?: string;
@@ -33253,7 +36205,7 @@ export interface operations {
                     } | "";
                     source?: string;
                     /**
-                     * tax_param
+                     * shared_tax_create_param
                      * @description Tax details about the customer.
                      */
                     tax?: {
@@ -33269,7 +36221,7 @@ export interface operations {
                     /** @description The customer's tax IDs. */
                     tax_id_data?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                     /** @description ID of the test clock to attach to the customer. */
@@ -33509,7 +36461,7 @@ export interface operations {
                     promotion_code?: string;
                     /** @description The customer's shipping information. Appears on invoices emailed to this customer. */
                     shipping?: {
-                        /** optional_fields_address */
+                        /** optional_fields_customer_address */
                         address: {
                             city?: string;
                             country?: string;
@@ -33523,13 +36475,13 @@ export interface operations {
                     } | "";
                     source?: string;
                     /**
-                     * tax_param
+                     * shared_tax_update_param
                      * @description Tax details about the customer.
                      */
                     tax?: {
                         ip_address?: string | "";
                         /** @enum {string} */
-                        validate_location?: "deferred" | "immediately";
+                        validate_location?: "auto" | "deferred" | "immediately";
                     };
                     /**
                      * @description The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
@@ -34735,7 +37687,7 @@ export interface operations {
                 /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
                 starting_after?: string;
                 /** @description An optional filter on the list, based on the object `type` field. Without the filter, the list includes all current and future payment method types. If your integration expects only one type of payment method in the response, make sure to provide a type value in the request. */
-                type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
             };
             header?: never;
             path: {
@@ -35434,7 +38386,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                         /** @enum {string} */
                         save_default_payment_method?: "off" | "on_subscription";
                     };
@@ -35767,7 +38719,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                         /** @enum {string} */
                         save_default_payment_method?: "off" | "on_subscription";
                     };
@@ -36022,10 +38974,10 @@ export interface operations {
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /**
-                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`
+                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
                      * @enum {string}
                      */
-                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                     /** @description Value of the tax ID. */
                     value: string;
                 };
@@ -36259,6 +39211,49 @@ export interface operations {
                         duplicate_charge_documentation?: string;
                         duplicate_charge_explanation?: string;
                         duplicate_charge_id?: string;
+                        enhanced_evidence?: {
+                            /** visa_compelling_evidence3 */
+                            visa_compelling_evidence_3?: {
+                                /** visa_compelling_evidence3_disputed_transaction */
+                                disputed_transaction?: {
+                                    customer_account_id?: string | "";
+                                    customer_device_fingerprint?: string | "";
+                                    customer_device_id?: string | "";
+                                    customer_email_address?: string | "";
+                                    customer_purchase_ip?: string | "";
+                                    /** @enum {string} */
+                                    merchandise_or_services?: "merchandise" | "services";
+                                    product_description?: string | "";
+                                    /** shipping_address */
+                                    shipping_address?: {
+                                        city?: string | "";
+                                        country?: string | "";
+                                        line1?: string | "";
+                                        line2?: string | "";
+                                        postal_code?: string | "";
+                                        state?: string | "";
+                                    };
+                                };
+                                prior_undisputed_transactions?: {
+                                    charge: string;
+                                    customer_account_id?: string | "";
+                                    customer_device_fingerprint?: string | "";
+                                    customer_device_id?: string | "";
+                                    customer_email_address?: string | "";
+                                    customer_purchase_ip?: string | "";
+                                    product_description?: string | "";
+                                    /** shipping_address */
+                                    shipping_address?: {
+                                        city?: string | "";
+                                        country?: string | "";
+                                        line1?: string | "";
+                                        line2?: string | "";
+                                        postal_code?: string | "";
+                                        state?: string | "";
+                                    };
+                                }[];
+                            };
+                        } | "";
                         product_description?: string;
                         receipt?: string;
                         refund_policy?: string;
@@ -37845,6 +40840,10 @@ export interface operations {
                 "application/x-www-form-urlencoded": {
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
+                    /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
+                    metadata?: {
+                        [key: string]: string;
+                    };
                     /** @description The PaymentMethod to insert into the forwarded request. Forwarding previously consumed PaymentMethods is allowed. */
                     payment_method: string;
                     /** @description The field kinds to be replaced in the forwarded request. */
@@ -38960,6 +41959,11 @@ export interface operations {
                         };
                     };
                     /**
+                     * Format: unix-time
+                     * @description The time when this invoice should be scheduled to finalize. The invoice will be finalized at this time if it is still in draft state.
+                     */
+                    automatically_finalizes_at?: number;
+                    /**
                      * @description Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to `charge_automatically`.
                      * @enum {string}
                      */
@@ -39092,7 +42096,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                     };
                     /**
                      * @description How to handle pending invoice items on invoice creation. Defaults to `exclude` if the parameter is omitted.
@@ -39256,7 +42260,7 @@ export interface operations {
                             state?: string;
                         } | "";
                         shipping?: {
-                            /** optional_fields_address */
+                            /** optional_fields_customer_address */
                             address: {
                                 city?: string;
                                 country?: string;
@@ -39276,7 +42280,7 @@ export interface operations {
                         tax_exempt?: "" | "exempt" | "none" | "reverse";
                         tax_ids?: {
                             /** @enum {string} */
-                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                             value: string;
                         }[];
                     };
@@ -39632,7 +42636,7 @@ export interface operations {
                         state?: string;
                     } | "";
                     shipping?: {
-                        /** optional_fields_address */
+                        /** optional_fields_customer_address */
                         address: {
                             city?: string;
                             country?: string;
@@ -39652,7 +42656,7 @@ export interface operations {
                     tax_exempt?: "" | "exempt" | "none" | "reverse";
                     tax_ids?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                 };
@@ -40005,7 +43009,7 @@ export interface operations {
                         state?: string;
                     } | "";
                     shipping?: {
-                        /** optional_fields_address */
+                        /** optional_fields_customer_address */
                         address: {
                             city?: string;
                             country?: string;
@@ -40025,7 +43029,7 @@ export interface operations {
                     tax_exempt?: "" | "exempt" | "none" | "reverse";
                     tax_ids?: {
                         /** @enum {string} */
-                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                        type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                         value: string;
                     }[];
                 };
@@ -40436,6 +43440,11 @@ export interface operations {
                         };
                     };
                     /**
+                     * Format: unix-time
+                     * @description The time when this invoice should be scheduled to finalize. The invoice will be finalized at this time if it is still in draft state. To turn off automatic finalization, set `auto_advance` to false.
+                     */
+                    automatically_finalizes_at?: number;
+                    /**
                      * @description Either `charge_automatically` or `send_invoice`. This field can be updated only on `draft` invoices.
                      * @enum {string}
                      */
@@ -40552,7 +43561,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                     };
                     /**
                      * rendering_param
@@ -40765,7 +43774,7 @@ export interface operations {
                                 percentage: number;
                                 state?: string;
                                 /** @enum {string} */
-                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
                             };
                             taxable_amount: number;
                         }[] | "";
@@ -40974,7 +43983,7 @@ export interface operations {
                             percentage: number;
                             state?: string;
                             /** @enum {string} */
-                            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+                            tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
                         };
                         taxable_amount: number;
                     }[] | "";
@@ -41253,7 +44262,7 @@ export interface operations {
                                 percentage: number;
                                 state?: string;
                                 /** @enum {string} */
-                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+                                tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
                             };
                             taxable_amount: number;
                         }[] | "";
@@ -42024,7 +45033,7 @@ export interface operations {
                      * @enum {string}
                      */
                     replacement_reason?: "damaged" | "expired" | "lost" | "stolen";
-                    /** @description The second line to print on the card. */
+                    /** @description The second line to print on the card. Max length: 24 characters. */
                     second_line?: string | "";
                     /**
                      * shipping_specs
@@ -43871,6 +46880,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -43930,6 +46941,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -43941,6 +46954,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -43950,12 +46965,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -43971,6 +46993,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -43984,7 +47008,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -44037,6 +47061,10 @@ export interface operations {
                         alipay?: {
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        alma?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         amazon_pay?: {
                             /** @enum {string} */
@@ -44195,6 +47223,12 @@ export interface operations {
                             setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         interac_present?: Record<string, never> | "";
+                        kakao_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
                         klarna?: {
                             /** @enum {string} */
                             capture_method?: "" | "manual";
@@ -44210,6 +47244,12 @@ export interface operations {
                             product_description?: string | "";
                             /** @enum {string} */
                             setup_future_usage?: "none";
+                        } | "";
+                        kr_card?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         link?: {
                             /** @enum {string} */
@@ -44227,6 +47267,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                         } | "";
+                        naver_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                        } | "";
                         oxxo?: {
                             expires_after_days?: number;
                             /** @enum {string} */
@@ -44236,6 +47280,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                             tos_shown_and_accepted?: boolean;
+                        } | "";
+                        payco?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         paynow?: {
                             /** @enum {string} */
@@ -44267,6 +47315,10 @@ export interface operations {
                             capture_method?: "" | "manual";
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        samsung_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         sepa_debit?: {
                             /** payment_method_options_mandate_options_param */
@@ -44571,6 +47623,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -44630,6 +47684,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -44641,6 +47697,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -44650,12 +47708,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -44671,6 +47736,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -44684,7 +47751,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -44737,6 +47804,10 @@ export interface operations {
                         alipay?: {
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        alma?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         amazon_pay?: {
                             /** @enum {string} */
@@ -44895,6 +47966,12 @@ export interface operations {
                             setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         interac_present?: Record<string, never> | "";
+                        kakao_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
                         klarna?: {
                             /** @enum {string} */
                             capture_method?: "" | "manual";
@@ -44910,6 +47987,12 @@ export interface operations {
                             product_description?: string | "";
                             /** @enum {string} */
                             setup_future_usage?: "none";
+                        } | "";
+                        kr_card?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         link?: {
                             /** @enum {string} */
@@ -44927,6 +48010,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                         } | "";
+                        naver_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                        } | "";
                         oxxo?: {
                             expires_after_days?: number;
                             /** @enum {string} */
@@ -44936,6 +48023,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                             tos_shown_and_accepted?: boolean;
+                        } | "";
+                        payco?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         paynow?: {
                             /** @enum {string} */
@@ -44967,6 +48058,10 @@ export interface operations {
                             capture_method?: "" | "manual";
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        samsung_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         sepa_debit?: {
                             /** payment_method_options_mandate_options_param */
@@ -45112,11 +48207,9 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/x-www-form-urlencoded": {
-                    /** @description Amount that you intend to apply to this PaymentIntent from the customer’s cash balance.
+                    /** @description Amount that you intend to apply to this PaymentIntent from the customer’s cash balance. If the PaymentIntent was created by an Invoice, the full amount of the PaymentIntent is applied regardless of this parameter.
                      *
-                     *     A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (for example, 100 cents to charge 1 USD or 100 to charge 100 JPY, a zero-decimal currency).
-                     *
-                     *     The maximum amount is the amount of the PaymentIntent.
+                     *     A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (for example, 100 cents to charge 1 USD or 100 to charge 100 JPY, a zero-decimal currency). The maximum amount is the amount of the PaymentIntent.
                      *
                      *     When you omit the amount, it defaults to the remaining amount requested on the PaymentIntent. */
                     amount?: number;
@@ -45335,6 +48428,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -45394,6 +48489,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -45405,6 +48502,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -45414,12 +48513,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -45435,6 +48541,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -45448,7 +48556,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -45501,6 +48609,10 @@ export interface operations {
                         alipay?: {
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        alma?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         amazon_pay?: {
                             /** @enum {string} */
@@ -45659,6 +48771,12 @@ export interface operations {
                             setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         interac_present?: Record<string, never> | "";
+                        kakao_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
                         klarna?: {
                             /** @enum {string} */
                             capture_method?: "" | "manual";
@@ -45674,6 +48792,12 @@ export interface operations {
                             product_description?: string | "";
                             /** @enum {string} */
                             setup_future_usage?: "none";
+                        } | "";
+                        kr_card?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                            /** @enum {string} */
+                            setup_future_usage?: "" | "none" | "off_session";
                         } | "";
                         link?: {
                             /** @enum {string} */
@@ -45691,6 +48815,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                         } | "";
+                        naver_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
+                        } | "";
                         oxxo?: {
                             expires_after_days?: number;
                             /** @enum {string} */
@@ -45700,6 +48828,10 @@ export interface operations {
                             /** @enum {string} */
                             setup_future_usage?: "none";
                             tos_shown_and_accepted?: boolean;
+                        } | "";
+                        payco?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         paynow?: {
                             /** @enum {string} */
@@ -45731,6 +48863,10 @@ export interface operations {
                             capture_method?: "" | "manual";
                             /** @enum {string} */
                             setup_future_usage?: "" | "none" | "off_session";
+                        } | "";
+                        samsung_pay?: {
+                            /** @enum {string} */
+                            capture_method?: "" | "manual";
                         } | "";
                         sepa_debit?: {
                             /** payment_method_options_mandate_options_param */
@@ -46217,7 +49353,7 @@ export interface operations {
                      */
                     payment_method_collection?: "always" | "if_required";
                     /** @description The list of payment method types that customers can use. If no value is passed, Stripe will dynamically show relevant payment methods from your [payment method settings](https://dashboard.stripe.com/settings/payment_methods) (20+ payment methods [supported](https://stripe.com/docs/payments/payment-methods/integration-options#payment-method-product-support)). */
-                    payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[];
+                    payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "alma" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[];
                     /**
                      * phone_number_collection_params
                      * @description Controls phone number collection settings during checkout.
@@ -46535,7 +49671,7 @@ export interface operations {
                      */
                     payment_method_collection?: "always" | "if_required";
                     /** @description The list of payment method types that customers can use. Pass an empty string to enable dynamic payment methods that use your [payment method settings](https://dashboard.stripe.com/settings/payment_methods). */
-                    payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[] | "";
+                    payment_method_types?: ("affirm" | "afterpay_clearpay" | "alipay" | "alma" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip")[] | "";
                     /** @description Settings that restrict the usage of a payment link. */
                     restrictions?: {
                         /** completed_sessions_params */
@@ -46764,6 +49900,17 @@ export interface operations {
                      * @description Alipay is a digital wallet in China that has more than a billion active users worldwide. Alipay users can pay on the web or on a mobile device using login credentials or their Alipay app. Alipay has a low dispute rate and reduces fraud by authenticating payments using the customer's login credentials. Check this [page](https://stripe.com/docs/payments/alipay) for more details.
                      */
                     alipay?: {
+                        /** display_preference_param */
+                        display_preference?: {
+                            /** @enum {string} */
+                            preference?: "none" | "off" | "on";
+                        };
+                    };
+                    /**
+                     * payment_method_param
+                     * @description Alma is a Buy Now, Pay Later payment method that offers customers the ability to pay in 2, 3, or 4 installments.
+                     */
+                    alma?: {
                         /** display_preference_param */
                         display_preference?: {
                             /** @enum {string} */
@@ -47152,7 +50299,7 @@ export interface operations {
                     };
                     /**
                      * payment_method_param
-                     * @description Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha. Check this [page](https://stripe.com/docs/payments/ach-debit) for more details.
+                     * @description Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha. Check this [page](https://stripe.com/docs/payments/ach-direct-debit) for more details.
                      */
                     us_bank_account?: {
                         /** display_preference_param */
@@ -47297,6 +50444,17 @@ export interface operations {
                      * @description Alipay is a digital wallet in China that has more than a billion active users worldwide. Alipay users can pay on the web or on a mobile device using login credentials or their Alipay app. Alipay has a low dispute rate and reduces fraud by authenticating payments using the customer's login credentials. Check this [page](https://stripe.com/docs/payments/alipay) for more details.
                      */
                     alipay?: {
+                        /** display_preference_param */
+                        display_preference?: {
+                            /** @enum {string} */
+                            preference?: "none" | "off" | "on";
+                        };
+                    };
+                    /**
+                     * payment_method_param
+                     * @description Alma is a Buy Now, Pay Later payment method that offers customers the ability to pay in 2, 3, or 4 installments.
+                     */
+                    alma?: {
                         /** display_preference_param */
                         display_preference?: {
                             /** @enum {string} */
@@ -47683,7 +50841,7 @@ export interface operations {
                     };
                     /**
                      * payment_method_param
-                     * @description Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha. Check this [page](https://stripe.com/docs/payments/ach-debit) for more details.
+                     * @description Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha. Check this [page](https://stripe.com/docs/payments/ach-direct-debit) for more details.
                      */
                     us_bank_account?: {
                         /** display_preference_param */
@@ -47965,7 +51123,7 @@ export interface operations {
                 /** @description A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. */
                 starting_after?: string;
                 /** @description An optional filter on the list, based on the object `type` field. Without the filter, the list includes all current and future payment method types. If your integration expects only one type of payment method in the response, make sure to provide a type value in the request. */
-                type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
             };
             header?: never;
             path?: never;
@@ -48047,6 +51205,11 @@ export interface operations {
                      * @enum {string}
                      */
                     allow_redisplay?: "always" | "limited" | "unspecified";
+                    /**
+                     * param
+                     * @description If this is a Alma PaymentMethod, this hash contains details about the Alma payment method.
+                     */
+                    alma?: Record<string, never>;
                     /**
                      * param
                      * @description If this is a AmazonPay PaymentMethod, this hash contains details about the AmazonPay payment method.
@@ -48171,6 +51334,11 @@ export interface operations {
                     interac_present?: Record<string, never>;
                     /**
                      * param
+                     * @description If this is a `kakao_pay` PaymentMethod, this hash contains details about the Kakao Pay payment method.
+                     */
+                    kakao_pay?: Record<string, never>;
+                    /**
+                     * param
                      * @description If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
                      */
                     klarna?: {
@@ -48186,6 +51354,11 @@ export interface operations {
                      * @description If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
                      */
                     konbini?: Record<string, never>;
+                    /**
+                     * param
+                     * @description If this is a `kr_card` PaymentMethod, this hash contains details about the Korean Card payment method.
+                     */
+                    kr_card?: Record<string, never>;
                     /**
                      * param
                      * @description If this is an `Link` PaymentMethod, this hash contains details about the Link payment method.
@@ -48207,6 +51380,14 @@ export interface operations {
                     multibanco?: Record<string, never>;
                     /**
                      * param
+                     * @description If this is a `naver_pay` PaymentMethod, this hash contains details about the Naver Pay payment method.
+                     */
+                    naver_pay?: {
+                        /** @enum {string} */
+                        funding?: "card" | "points";
+                    };
+                    /**
+                     * param
                      * @description If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
                      */
                     oxxo?: Record<string, never>;
@@ -48218,6 +51399,11 @@ export interface operations {
                         /** @enum {string} */
                         bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                     };
+                    /**
+                     * param
+                     * @description If this is a `payco` PaymentMethod, this hash contains details about the PAYCO payment method.
+                     */
+                    payco?: Record<string, never>;
                     /** @description The PaymentMethod to share. */
                     payment_method?: string;
                     /**
@@ -48254,6 +51440,11 @@ export interface operations {
                     revolut_pay?: Record<string, never>;
                     /**
                      * param
+                     * @description If this is a `samsung_pay` PaymentMethod, this hash contains details about the SamsungPay payment method.
+                     */
+                    samsung_pay?: Record<string, never>;
+                    /**
+                     * param
                      * @description If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
                      */
                     sepa_debit?: {
@@ -48281,7 +51472,7 @@ export interface operations {
                      * @description The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
                      * @enum {string}
                      */
-                    type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                    type?: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                     /**
                      * payment_method_param
                      * @description If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -48425,6 +51616,14 @@ export interface operations {
                     metadata?: {
                         [key: string]: string;
                     } | "";
+                    /**
+                     * param
+                     * @description If this is a `naver_pay` PaymentMethod, this hash contains details about the Naver Pay payment method.
+                     */
+                    naver_pay?: {
+                        /** @enum {string} */
+                        funding?: "card" | "points";
+                    };
                     /**
                      * update_param
                      * @description If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -49656,6 +52855,13 @@ export interface operations {
                                 unit_amount_decimal?: string;
                             };
                         };
+                        /** custom_unit_amount */
+                        custom_unit_amount?: {
+                            enabled: boolean;
+                            maximum?: number;
+                            minimum?: number;
+                            preset?: number;
+                        };
                         /** recurring_adhoc */
                         recurring?: {
                             /** @enum {string} */
@@ -50188,7 +53394,9 @@ export interface operations {
                 "application/x-www-form-urlencoded": {
                     /** @description Whether the promotion code is currently active. */
                     active?: boolean;
-                    /** @description The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for a specific customer. If left blank, we will generate one automatically. */
+                    /** @description The customer-facing code. Regardless of case, this code must be unique across all active promotion codes for a specific customer. Valid characters are lower case letters (a-z), upper case letters (A-Z), and digits (0-9).
+                     *
+                     *     If left blank, we will generate one automatically. */
                     code?: string;
                     /** @description The coupon for this promotion code. */
                     coupon: string;
@@ -52358,6 +55566,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -52417,6 +55627,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -52428,6 +55640,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -52437,12 +55651,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -52458,6 +55679,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -52471,7 +55694,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -52740,6 +55963,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -52799,6 +56024,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -52810,6 +56037,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -52819,12 +56048,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -52840,6 +56076,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -52853,7 +56091,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -53121,6 +56359,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -53180,6 +56420,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -53191,6 +56433,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -53200,12 +56444,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -53221,6 +56472,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -53234,7 +56487,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -55659,7 +58912,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                         /** @enum {string} */
                         save_default_payment_method?: "off" | "on_subscription";
                     };
@@ -56048,7 +59301,7 @@ export interface operations {
                                 verification_method?: "automatic" | "instant" | "microdeposits";
                             } | "";
                         };
-                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "konbini" | "link" | "multibanco" | "p24" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
+                        payment_method_types?: ("ach_credit_transfer" | "ach_debit" | "acss_debit" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "boleto" | "card" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "jp_credit_transfer" | "kakao_pay" | "konbini" | "kr_card" | "link" | "multibanco" | "naver_pay" | "p24" | "payco" | "paynow" | "paypal" | "promptpay" | "revolut_pay" | "sepa_credit_transfer" | "sepa_debit" | "sofort" | "swish" | "us_bank_account" | "wechat_pay")[] | "";
                         /** @enum {string} */
                         save_default_payment_method?: "off" | "on_subscription";
                     };
@@ -56137,7 +59390,7 @@ export interface operations {
                     };
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
-                    /** @description Will generate a final invoice that invoices for any un-invoiced metered usage and new/pending proration invoice items. Defaults to `true`. */
+                    /** @description Will generate a final invoice that invoices for any un-invoiced metered usage and new/pending proration invoice items. Defaults to `false`. */
                     invoice_now?: boolean;
                     /** @description Will generate a proration invoice item that credits remaining unused time until the subscription period end. Defaults to `false`. */
                     prorate?: boolean;
@@ -56213,7 +59466,7 @@ export interface operations {
             content: {
                 "application/x-www-form-urlencoded": {
                     /**
-                     * @description Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time (in UTC). Setting the value to `unchanged` advances the subscription's billing cycle anchor to the period that surrounds the current time. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+                     * @description The billing cycle anchor that applies when the subscription is resumed. Either `now` or `unchanged`. The default is `now`. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
                      * @enum {string}
                      */
                     billing_cycle_anchor?: "now" | "unchanged";
@@ -56286,7 +59539,7 @@ export interface operations {
                         ip_address?: string;
                         tax_ids?: {
                             /** @enum {string} */
-                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                            type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                             value: string;
                         }[];
                         /** @enum {string} */
@@ -56569,6 +59822,11 @@ export interface operations {
                             /** @enum {string} */
                             type: "standard";
                         };
+                        /** simplified */
+                        by?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
                         /** canada */
                         ca?: {
                             /** province_standard */
@@ -56590,6 +59848,11 @@ export interface operations {
                         };
                         /** simplified */
                         co?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
+                        /** simplified */
+                        cr?: {
                             /** @enum {string} */
                             type: "simplified";
                         };
@@ -56632,6 +59895,11 @@ export interface operations {
                             };
                             /** @enum {string} */
                             type: "ioss" | "oss_non_union" | "oss_union" | "standard";
+                        };
+                        /** simplified */
+                        ec?: {
+                            /** @enum {string} */
+                            type: "simplified";
                         };
                         /** europe */
                         ee?: {
@@ -56798,6 +60066,16 @@ export interface operations {
                             /** @enum {string} */
                             type: "ioss" | "oss_non_union" | "oss_union" | "standard";
                         };
+                        /** simplified */
+                        ma?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
+                        /** simplified */
+                        md?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
                         /** europe */
                         mt?: {
                             /** standard */
@@ -56878,6 +60156,16 @@ export interface operations {
                             /** @enum {string} */
                             type: "ioss" | "oss_non_union" | "oss_union" | "standard";
                         };
+                        /** default */
+                        rs?: {
+                            /** @enum {string} */
+                            type: "standard";
+                        };
+                        /** simplified */
+                        ru?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
                         /** simplified */
                         sa?: {
                             /** @enum {string} */
@@ -56928,6 +60216,11 @@ export interface operations {
                             /** @enum {string} */
                             type: "simplified";
                         };
+                        /** simplified */
+                        tz?: {
+                            /** @enum {string} */
+                            type: "simplified";
+                        };
                         /** united_states */
                         us?: {
                             /** local_amusement_tax */
@@ -56948,7 +60241,12 @@ export interface operations {
                                 }[];
                             };
                             /** @enum {string} */
-                            type: "local_amusement_tax" | "local_lease_tax" | "state_communications_tax" | "state_sales_tax";
+                            type: "local_amusement_tax" | "local_lease_tax" | "state_communications_tax" | "state_retail_delivery_fee" | "state_sales_tax";
+                        };
+                        /** simplified */
+                        uz?: {
+                            /** @enum {string} */
+                            type: "simplified";
                         };
                         /** simplified */
                         vn?: {
@@ -57556,10 +60854,10 @@ export interface operations {
                         type: "account" | "application" | "customer" | "self";
                     };
                     /**
-                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`
+                     * @description Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `by_tin`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_uid`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `de_stn`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hr_oib`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `ma_vat`, `md_vat`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `tz_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `uz_tin`, `uz_vat`, `ve_rif`, `vn_tin`, or `za_vat`
                      * @enum {string}
                      */
-                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "ve_rif" | "vn_tin" | "za_vat";
+                    type: "ad_nrt" | "ae_trn" | "ar_cuit" | "au_abn" | "au_arn" | "bg_uic" | "bh_vat" | "bo_tin" | "br_cnpj" | "br_cpf" | "by_tin" | "ca_bn" | "ca_gst_hst" | "ca_pst_bc" | "ca_pst_mb" | "ca_pst_sk" | "ca_qst" | "ch_uid" | "ch_vat" | "cl_tin" | "cn_tin" | "co_nit" | "cr_tin" | "de_stn" | "do_rcn" | "ec_ruc" | "eg_tin" | "es_cif" | "eu_oss_vat" | "eu_vat" | "gb_vat" | "ge_vat" | "hk_br" | "hr_oib" | "hu_tin" | "id_npwp" | "il_vat" | "in_gst" | "is_vat" | "jp_cn" | "jp_rn" | "jp_trn" | "ke_pin" | "kr_brn" | "kz_bin" | "li_uid" | "ma_vat" | "md_vat" | "mx_rfc" | "my_frp" | "my_itn" | "my_sst" | "ng_tin" | "no_vat" | "no_voec" | "nz_gst" | "om_vat" | "pe_ruc" | "ph_tin" | "ro_tin" | "rs_pib" | "ru_inn" | "ru_kpp" | "sa_vat" | "sg_gst" | "sg_uen" | "si_tin" | "sv_nit" | "th_vat" | "tr_tin" | "tw_vat" | "tz_vat" | "ua_vat" | "us_ein" | "uy_ruc" | "uz_tin" | "uz_vat" | "ve_rif" | "vn_tin" | "za_vat";
                     /** @description Value of the tax ID. */
                     value: string;
                 };
@@ -57759,7 +61057,7 @@ export interface operations {
                      * @description The high-level tax type, such as `vat` or `sales_tax`.
                      * @enum {string}
                      */
-                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
                 };
             };
         };
@@ -57856,7 +61154,7 @@ export interface operations {
                      * @description The high-level tax type, such as `vat` or `sales_tax`.
                      * @enum {string}
                      */
-                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "rst" | "sales_tax" | "vat";
+                    tax_type?: "amusement_tax" | "communications_tax" | "gst" | "hst" | "igst" | "jct" | "lease_tax" | "pst" | "qst" | "retail_delivery_fee" | "rst" | "sales_tax" | "vat";
                 };
             };
         };
@@ -58040,6 +61338,12 @@ export interface operations {
                         };
                         /** currency_specific_config */
                         nzd?: {
+                            fixed_amounts?: number[];
+                            percentages?: number[];
+                            smart_tip_threshold?: number;
+                        };
+                        /** currency_specific_config */
+                        pln?: {
                             fixed_amounts?: number[];
                             percentages?: number[];
                             smart_tip_threshold?: number;
@@ -58229,6 +61533,12 @@ export interface operations {
                         };
                         /** currency_specific_config */
                         nzd?: {
+                            fixed_amounts?: number[];
+                            percentages?: number[];
+                            smart_tip_threshold?: number;
+                        };
+                        /** currency_specific_config */
+                        pln?: {
                             fixed_amounts?: number[];
                             percentages?: number[];
                             smart_tip_threshold?: number;
@@ -58877,6 +62187,8 @@ export interface operations {
                      * @description Configuration overrides
                      */
                     process_config?: {
+                        /** @enum {string} */
+                        allow_redisplay?: "always" | "limited" | "unspecified";
                         enable_customer_cancellation?: boolean;
                         skip_tipping?: boolean;
                         /** tipping_config */
@@ -58920,8 +62232,11 @@ export interface operations {
         requestBody: {
             content: {
                 "application/x-www-form-urlencoded": {
-                    /** @description Customer Consent Collected */
-                    customer_consent_collected?: boolean;
+                    /**
+                     * @description This field indicates whether this payment method can be shown again to its customer in a checkout flow. Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow.
+                     * @enum {string}
+                     */
+                    allow_redisplay: "always" | "limited" | "unspecified";
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /**
@@ -59107,6 +62422,8 @@ export interface operations {
                         /** @enum {string} */
                         allow_redisplay?: "always" | "limited" | "unspecified";
                         /** param */
+                        alma?: Record<string, never>;
+                        /** param */
                         amazon_pay?: Record<string, never>;
                         /** param */
                         au_becs_debit?: {
@@ -59166,6 +62483,8 @@ export interface operations {
                         /** param */
                         interac_present?: Record<string, never>;
                         /** param */
+                        kakao_pay?: Record<string, never>;
+                        /** param */
                         klarna?: {
                             /** date_of_birth */
                             dob?: {
@@ -59177,6 +62496,8 @@ export interface operations {
                         /** param */
                         konbini?: Record<string, never>;
                         /** param */
+                        kr_card?: Record<string, never>;
+                        /** param */
                         link?: Record<string, never>;
                         metadata?: {
                             [key: string]: string;
@@ -59186,12 +62507,19 @@ export interface operations {
                         /** param */
                         multibanco?: Record<string, never>;
                         /** param */
+                        naver_pay?: {
+                            /** @enum {string} */
+                            funding?: "card" | "points";
+                        };
+                        /** param */
                         oxxo?: Record<string, never>;
                         /** param */
                         p24?: {
                             /** @enum {string} */
                             bank?: "alior_bank" | "bank_millennium" | "bank_nowy_bfg_sa" | "bank_pekao_sa" | "banki_spbdzielcze" | "blik" | "bnp_paribas" | "boz" | "citi_handlowy" | "credit_agricole" | "envelobank" | "etransfer_pocztowy24" | "getin_bank" | "ideabank" | "ing" | "inteligo" | "mbank_mtransfer" | "nest_przelew" | "noble_pay" | "pbac_z_ipko" | "plus_bank" | "santander_przelew24" | "tmobile_usbugi_bankowe" | "toyota_bank" | "velobank" | "volkswagen_bank";
                         };
+                        /** param */
+                        payco?: Record<string, never>;
                         /** param */
                         paynow?: Record<string, never>;
                         /** param */
@@ -59207,6 +62535,8 @@ export interface operations {
                         /** param */
                         revolut_pay?: Record<string, never>;
                         /** param */
+                        samsung_pay?: Record<string, never>;
+                        /** param */
                         sepa_debit?: {
                             iban: string;
                         };
@@ -59220,7 +62550,7 @@ export interface operations {
                         /** param */
                         twint?: Record<string, never>;
                         /** @enum {string} */
-                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "konbini" | "link" | "mobilepay" | "multibanco" | "oxxo" | "p24" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
+                        type: "acss_debit" | "affirm" | "afterpay_clearpay" | "alipay" | "alma" | "amazon_pay" | "au_becs_debit" | "bacs_debit" | "bancontact" | "blik" | "boleto" | "cashapp" | "customer_balance" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "kakao_pay" | "klarna" | "konbini" | "kr_card" | "link" | "mobilepay" | "multibanco" | "naver_pay" | "oxxo" | "p24" | "payco" | "paynow" | "paypal" | "pix" | "promptpay" | "revolut_pay" | "samsung_pay" | "sepa_debit" | "sofort" | "swish" | "twint" | "us_bank_account" | "wechat_pay" | "zip";
                         /** payment_method_param */
                         us_bank_account?: {
                             /** @enum {string} */
@@ -59947,6 +63277,44 @@ export interface operations {
         };
     };
     PostTestHelpersIssuingCardsCardShippingShip: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                card: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description Specifies which fields in the response should be expanded. */
+                    expand?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successful response. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["issuing.card"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
+    };
+    PostTestHelpersIssuingCardsCardShippingSubmit: {
         parameters: {
             query?: never;
             header?: never;
@@ -64283,13 +67651,13 @@ export interface operations {
                      * @description Events sent to this endpoint will be generated with this Stripe Version instead of your account's default Stripe Version.
                      * @enum {string}
                      */
-                    api_version?: "2011-01-01" | "2011-06-21" | "2011-06-28" | "2011-08-01" | "2011-09-15" | "2011-11-17" | "2012-02-23" | "2012-03-25" | "2012-06-18" | "2012-06-28" | "2012-07-09" | "2012-09-24" | "2012-10-26" | "2012-11-07" | "2013-02-11" | "2013-02-13" | "2013-07-05" | "2013-08-12" | "2013-08-13" | "2013-10-29" | "2013-12-03" | "2014-01-31" | "2014-03-13" | "2014-03-28" | "2014-05-19" | "2014-06-13" | "2014-06-17" | "2014-07-22" | "2014-07-26" | "2014-08-04" | "2014-08-20" | "2014-09-08" | "2014-10-07" | "2014-11-05" | "2014-11-20" | "2014-12-08" | "2014-12-17" | "2014-12-22" | "2015-01-11" | "2015-01-26" | "2015-02-10" | "2015-02-16" | "2015-02-18" | "2015-03-24" | "2015-04-07" | "2015-06-15" | "2015-07-07" | "2015-07-13" | "2015-07-28" | "2015-08-07" | "2015-08-19" | "2015-09-03" | "2015-09-08" | "2015-09-23" | "2015-10-01" | "2015-10-12" | "2015-10-16" | "2016-02-03" | "2016-02-19" | "2016-02-22" | "2016-02-23" | "2016-02-29" | "2016-03-07" | "2016-06-15" | "2016-07-06" | "2016-10-19" | "2017-01-27" | "2017-02-14" | "2017-04-06" | "2017-05-25" | "2017-06-05" | "2017-08-15" | "2017-12-14" | "2018-01-23" | "2018-02-05" | "2018-02-06" | "2018-02-28" | "2018-05-21" | "2018-07-27" | "2018-08-23" | "2018-09-06" | "2018-09-24" | "2018-10-31" | "2018-11-08" | "2019-02-11" | "2019-02-19" | "2019-03-14" | "2019-05-16" | "2019-08-14" | "2019-09-09" | "2019-10-08" | "2019-10-17" | "2019-11-05" | "2019-12-03" | "2020-03-02" | "2020-08-27" | "2022-08-01" | "2022-11-15" | "2023-08-16" | "2023-10-16" | "2024-04-10" | "2024-06-20";
+                    api_version?: "2011-01-01" | "2011-06-21" | "2011-06-28" | "2011-08-01" | "2011-09-15" | "2011-11-17" | "2012-02-23" | "2012-03-25" | "2012-06-18" | "2012-06-28" | "2012-07-09" | "2012-09-24" | "2012-10-26" | "2012-11-07" | "2013-02-11" | "2013-02-13" | "2013-07-05" | "2013-08-12" | "2013-08-13" | "2013-10-29" | "2013-12-03" | "2014-01-31" | "2014-03-13" | "2014-03-28" | "2014-05-19" | "2014-06-13" | "2014-06-17" | "2014-07-22" | "2014-07-26" | "2014-08-04" | "2014-08-20" | "2014-09-08" | "2014-10-07" | "2014-11-05" | "2014-11-20" | "2014-12-08" | "2014-12-17" | "2014-12-22" | "2015-01-11" | "2015-01-26" | "2015-02-10" | "2015-02-16" | "2015-02-18" | "2015-03-24" | "2015-04-07" | "2015-06-15" | "2015-07-07" | "2015-07-13" | "2015-07-28" | "2015-08-07" | "2015-08-19" | "2015-09-03" | "2015-09-08" | "2015-09-23" | "2015-10-01" | "2015-10-12" | "2015-10-16" | "2016-02-03" | "2016-02-19" | "2016-02-22" | "2016-02-23" | "2016-02-29" | "2016-03-07" | "2016-06-15" | "2016-07-06" | "2016-10-19" | "2017-01-27" | "2017-02-14" | "2017-04-06" | "2017-05-25" | "2017-06-05" | "2017-08-15" | "2017-12-14" | "2018-01-23" | "2018-02-05" | "2018-02-06" | "2018-02-28" | "2018-05-21" | "2018-07-27" | "2018-08-23" | "2018-09-06" | "2018-09-24" | "2018-10-31" | "2018-11-08" | "2019-02-11" | "2019-02-19" | "2019-03-14" | "2019-05-16" | "2019-08-14" | "2019-09-09" | "2019-10-08" | "2019-10-17" | "2019-11-05" | "2019-12-03" | "2020-03-02" | "2020-08-27" | "2022-08-01" | "2022-11-15" | "2023-08-16" | "2023-10-16" | "2024-04-10" | "2024-06-20" | "2024-09-30.acacia" | "2024-10-28.acacia";
                     /** @description Whether this endpoint should receive events from connected accounts (`true`), or from your account (`false`). Defaults to `false`. */
                     connect?: boolean;
                     /** @description An optional description of what the webhook is used for. */
                     description?: string | "";
                     /** @description The list of events to enable for this endpoint. You may specify `['*']` to enable all events, except those that require explicit selection. */
-                    enabled_events: ("*" | "account.application.authorized" | "account.application.deauthorized" | "account.external_account.created" | "account.external_account.deleted" | "account.external_account.updated" | "account.updated" | "application_fee.created" | "application_fee.refund.updated" | "application_fee.refunded" | "balance.available" | "billing.alert.triggered" | "billing_portal.configuration.created" | "billing_portal.configuration.updated" | "billing_portal.session.created" | "capability.updated" | "cash_balance.funds_available" | "charge.captured" | "charge.dispute.closed" | "charge.dispute.created" | "charge.dispute.funds_reinstated" | "charge.dispute.funds_withdrawn" | "charge.dispute.updated" | "charge.expired" | "charge.failed" | "charge.pending" | "charge.refund.updated" | "charge.refunded" | "charge.succeeded" | "charge.updated" | "checkout.session.async_payment_failed" | "checkout.session.async_payment_succeeded" | "checkout.session.completed" | "checkout.session.expired" | "climate.order.canceled" | "climate.order.created" | "climate.order.delayed" | "climate.order.delivered" | "climate.order.product_substituted" | "climate.product.created" | "climate.product.pricing_updated" | "coupon.created" | "coupon.deleted" | "coupon.updated" | "credit_note.created" | "credit_note.updated" | "credit_note.voided" | "customer.created" | "customer.deleted" | "customer.discount.created" | "customer.discount.deleted" | "customer.discount.updated" | "customer.source.created" | "customer.source.deleted" | "customer.source.expiring" | "customer.source.updated" | "customer.subscription.created" | "customer.subscription.deleted" | "customer.subscription.paused" | "customer.subscription.pending_update_applied" | "customer.subscription.pending_update_expired" | "customer.subscription.resumed" | "customer.subscription.trial_will_end" | "customer.subscription.updated" | "customer.tax_id.created" | "customer.tax_id.deleted" | "customer.tax_id.updated" | "customer.updated" | "customer_cash_balance_transaction.created" | "entitlements.active_entitlement_summary.updated" | "file.created" | "financial_connections.account.created" | "financial_connections.account.deactivated" | "financial_connections.account.disconnected" | "financial_connections.account.reactivated" | "financial_connections.account.refreshed_balance" | "financial_connections.account.refreshed_ownership" | "financial_connections.account.refreshed_transactions" | "identity.verification_session.canceled" | "identity.verification_session.created" | "identity.verification_session.processing" | "identity.verification_session.redacted" | "identity.verification_session.requires_input" | "identity.verification_session.verified" | "invoice.created" | "invoice.deleted" | "invoice.finalization_failed" | "invoice.finalized" | "invoice.marked_uncollectible" | "invoice.overdue" | "invoice.paid" | "invoice.payment_action_required" | "invoice.payment_failed" | "invoice.payment_succeeded" | "invoice.sent" | "invoice.upcoming" | "invoice.updated" | "invoice.voided" | "invoice.will_be_due" | "invoiceitem.created" | "invoiceitem.deleted" | "issuing_authorization.created" | "issuing_authorization.request" | "issuing_authorization.updated" | "issuing_card.created" | "issuing_card.updated" | "issuing_cardholder.created" | "issuing_cardholder.updated" | "issuing_dispute.closed" | "issuing_dispute.created" | "issuing_dispute.funds_reinstated" | "issuing_dispute.funds_rescinded" | "issuing_dispute.submitted" | "issuing_dispute.updated" | "issuing_personalization_design.activated" | "issuing_personalization_design.deactivated" | "issuing_personalization_design.rejected" | "issuing_personalization_design.updated" | "issuing_token.created" | "issuing_token.updated" | "issuing_transaction.created" | "issuing_transaction.updated" | "mandate.updated" | "payment_intent.amount_capturable_updated" | "payment_intent.canceled" | "payment_intent.created" | "payment_intent.partially_funded" | "payment_intent.payment_failed" | "payment_intent.processing" | "payment_intent.requires_action" | "payment_intent.succeeded" | "payment_link.created" | "payment_link.updated" | "payment_method.attached" | "payment_method.automatically_updated" | "payment_method.detached" | "payment_method.updated" | "payout.canceled" | "payout.created" | "payout.failed" | "payout.paid" | "payout.reconciliation_completed" | "payout.updated" | "person.created" | "person.deleted" | "person.updated" | "plan.created" | "plan.deleted" | "plan.updated" | "price.created" | "price.deleted" | "price.updated" | "product.created" | "product.deleted" | "product.updated" | "promotion_code.created" | "promotion_code.updated" | "quote.accepted" | "quote.canceled" | "quote.created" | "quote.finalized" | "radar.early_fraud_warning.created" | "radar.early_fraud_warning.updated" | "refund.created" | "refund.updated" | "reporting.report_run.failed" | "reporting.report_run.succeeded" | "reporting.report_type.updated" | "review.closed" | "review.opened" | "setup_intent.canceled" | "setup_intent.created" | "setup_intent.requires_action" | "setup_intent.setup_failed" | "setup_intent.succeeded" | "sigma.scheduled_query_run.created" | "source.canceled" | "source.chargeable" | "source.failed" | "source.mandate_notification" | "source.refund_attributes_required" | "source.transaction.created" | "source.transaction.updated" | "subscription_schedule.aborted" | "subscription_schedule.canceled" | "subscription_schedule.completed" | "subscription_schedule.created" | "subscription_schedule.expiring" | "subscription_schedule.released" | "subscription_schedule.updated" | "tax.settings.updated" | "tax_rate.created" | "tax_rate.updated" | "terminal.reader.action_failed" | "terminal.reader.action_succeeded" | "test_helpers.test_clock.advancing" | "test_helpers.test_clock.created" | "test_helpers.test_clock.deleted" | "test_helpers.test_clock.internal_failure" | "test_helpers.test_clock.ready" | "topup.canceled" | "topup.created" | "topup.failed" | "topup.reversed" | "topup.succeeded" | "transfer.created" | "transfer.reversed" | "transfer.updated" | "treasury.credit_reversal.created" | "treasury.credit_reversal.posted" | "treasury.debit_reversal.completed" | "treasury.debit_reversal.created" | "treasury.debit_reversal.initial_credit_granted" | "treasury.financial_account.closed" | "treasury.financial_account.created" | "treasury.financial_account.features_status_updated" | "treasury.inbound_transfer.canceled" | "treasury.inbound_transfer.created" | "treasury.inbound_transfer.failed" | "treasury.inbound_transfer.succeeded" | "treasury.outbound_payment.canceled" | "treasury.outbound_payment.created" | "treasury.outbound_payment.expected_arrival_date_updated" | "treasury.outbound_payment.failed" | "treasury.outbound_payment.posted" | "treasury.outbound_payment.returned" | "treasury.outbound_payment.tracking_details_updated" | "treasury.outbound_transfer.canceled" | "treasury.outbound_transfer.created" | "treasury.outbound_transfer.expected_arrival_date_updated" | "treasury.outbound_transfer.failed" | "treasury.outbound_transfer.posted" | "treasury.outbound_transfer.returned" | "treasury.outbound_transfer.tracking_details_updated" | "treasury.received_credit.created" | "treasury.received_credit.failed" | "treasury.received_credit.succeeded" | "treasury.received_debit.created")[];
+                    enabled_events: ("*" | "account.application.authorized" | "account.application.deauthorized" | "account.external_account.created" | "account.external_account.deleted" | "account.external_account.updated" | "account.updated" | "application_fee.created" | "application_fee.refund.updated" | "application_fee.refunded" | "balance.available" | "billing.alert.triggered" | "billing_portal.configuration.created" | "billing_portal.configuration.updated" | "billing_portal.session.created" | "capability.updated" | "cash_balance.funds_available" | "charge.captured" | "charge.dispute.closed" | "charge.dispute.created" | "charge.dispute.funds_reinstated" | "charge.dispute.funds_withdrawn" | "charge.dispute.updated" | "charge.expired" | "charge.failed" | "charge.pending" | "charge.refund.updated" | "charge.refunded" | "charge.succeeded" | "charge.updated" | "checkout.session.async_payment_failed" | "checkout.session.async_payment_succeeded" | "checkout.session.completed" | "checkout.session.expired" | "climate.order.canceled" | "climate.order.created" | "climate.order.delayed" | "climate.order.delivered" | "climate.order.product_substituted" | "climate.product.created" | "climate.product.pricing_updated" | "coupon.created" | "coupon.deleted" | "coupon.updated" | "credit_note.created" | "credit_note.updated" | "credit_note.voided" | "customer.created" | "customer.deleted" | "customer.discount.created" | "customer.discount.deleted" | "customer.discount.updated" | "customer.source.created" | "customer.source.deleted" | "customer.source.expiring" | "customer.source.updated" | "customer.subscription.created" | "customer.subscription.deleted" | "customer.subscription.paused" | "customer.subscription.pending_update_applied" | "customer.subscription.pending_update_expired" | "customer.subscription.resumed" | "customer.subscription.trial_will_end" | "customer.subscription.updated" | "customer.tax_id.created" | "customer.tax_id.deleted" | "customer.tax_id.updated" | "customer.updated" | "customer_cash_balance_transaction.created" | "entitlements.active_entitlement_summary.updated" | "file.created" | "financial_connections.account.created" | "financial_connections.account.deactivated" | "financial_connections.account.disconnected" | "financial_connections.account.reactivated" | "financial_connections.account.refreshed_balance" | "financial_connections.account.refreshed_ownership" | "financial_connections.account.refreshed_transactions" | "identity.verification_session.canceled" | "identity.verification_session.created" | "identity.verification_session.processing" | "identity.verification_session.redacted" | "identity.verification_session.requires_input" | "identity.verification_session.verified" | "invoice.created" | "invoice.deleted" | "invoice.finalization_failed" | "invoice.finalized" | "invoice.marked_uncollectible" | "invoice.overdue" | "invoice.paid" | "invoice.payment_action_required" | "invoice.payment_failed" | "invoice.payment_succeeded" | "invoice.sent" | "invoice.upcoming" | "invoice.updated" | "invoice.voided" | "invoice.will_be_due" | "invoiceitem.created" | "invoiceitem.deleted" | "issuing_authorization.created" | "issuing_authorization.request" | "issuing_authorization.updated" | "issuing_card.created" | "issuing_card.updated" | "issuing_cardholder.created" | "issuing_cardholder.updated" | "issuing_dispute.closed" | "issuing_dispute.created" | "issuing_dispute.funds_reinstated" | "issuing_dispute.funds_rescinded" | "issuing_dispute.submitted" | "issuing_dispute.updated" | "issuing_personalization_design.activated" | "issuing_personalization_design.deactivated" | "issuing_personalization_design.rejected" | "issuing_personalization_design.updated" | "issuing_token.created" | "issuing_token.updated" | "issuing_transaction.created" | "issuing_transaction.purchase_details_receipt_updated" | "issuing_transaction.updated" | "mandate.updated" | "payment_intent.amount_capturable_updated" | "payment_intent.canceled" | "payment_intent.created" | "payment_intent.partially_funded" | "payment_intent.payment_failed" | "payment_intent.processing" | "payment_intent.requires_action" | "payment_intent.succeeded" | "payment_link.created" | "payment_link.updated" | "payment_method.attached" | "payment_method.automatically_updated" | "payment_method.detached" | "payment_method.updated" | "payout.canceled" | "payout.created" | "payout.failed" | "payout.paid" | "payout.reconciliation_completed" | "payout.updated" | "person.created" | "person.deleted" | "person.updated" | "plan.created" | "plan.deleted" | "plan.updated" | "price.created" | "price.deleted" | "price.updated" | "product.created" | "product.deleted" | "product.updated" | "promotion_code.created" | "promotion_code.updated" | "quote.accepted" | "quote.canceled" | "quote.created" | "quote.finalized" | "radar.early_fraud_warning.created" | "radar.early_fraud_warning.updated" | "refund.created" | "refund.failed" | "refund.updated" | "reporting.report_run.failed" | "reporting.report_run.succeeded" | "reporting.report_type.updated" | "review.closed" | "review.opened" | "setup_intent.canceled" | "setup_intent.created" | "setup_intent.requires_action" | "setup_intent.setup_failed" | "setup_intent.succeeded" | "sigma.scheduled_query_run.created" | "source.canceled" | "source.chargeable" | "source.failed" | "source.mandate_notification" | "source.refund_attributes_required" | "source.transaction.created" | "source.transaction.updated" | "subscription_schedule.aborted" | "subscription_schedule.canceled" | "subscription_schedule.completed" | "subscription_schedule.created" | "subscription_schedule.expiring" | "subscription_schedule.released" | "subscription_schedule.updated" | "tax.settings.updated" | "tax_rate.created" | "tax_rate.updated" | "terminal.reader.action_failed" | "terminal.reader.action_succeeded" | "test_helpers.test_clock.advancing" | "test_helpers.test_clock.created" | "test_helpers.test_clock.deleted" | "test_helpers.test_clock.internal_failure" | "test_helpers.test_clock.ready" | "topup.canceled" | "topup.created" | "topup.failed" | "topup.reversed" | "topup.succeeded" | "transfer.created" | "transfer.reversed" | "transfer.updated" | "treasury.credit_reversal.created" | "treasury.credit_reversal.posted" | "treasury.debit_reversal.completed" | "treasury.debit_reversal.created" | "treasury.debit_reversal.initial_credit_granted" | "treasury.financial_account.closed" | "treasury.financial_account.created" | "treasury.financial_account.features_status_updated" | "treasury.inbound_transfer.canceled" | "treasury.inbound_transfer.created" | "treasury.inbound_transfer.failed" | "treasury.inbound_transfer.succeeded" | "treasury.outbound_payment.canceled" | "treasury.outbound_payment.created" | "treasury.outbound_payment.expected_arrival_date_updated" | "treasury.outbound_payment.failed" | "treasury.outbound_payment.posted" | "treasury.outbound_payment.returned" | "treasury.outbound_payment.tracking_details_updated" | "treasury.outbound_transfer.canceled" | "treasury.outbound_transfer.created" | "treasury.outbound_transfer.expected_arrival_date_updated" | "treasury.outbound_transfer.failed" | "treasury.outbound_transfer.posted" | "treasury.outbound_transfer.returned" | "treasury.outbound_transfer.tracking_details_updated" | "treasury.received_credit.created" | "treasury.received_credit.failed" | "treasury.received_credit.succeeded" | "treasury.received_debit.created")[];
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */
@@ -64377,7 +67745,7 @@ export interface operations {
                     /** @description Disable the webhook endpoint if set to true. */
                     disabled?: boolean;
                     /** @description The list of events to enable for this endpoint. You may specify `['*']` to enable all events, except those that require explicit selection. */
-                    enabled_events?: ("*" | "account.application.authorized" | "account.application.deauthorized" | "account.external_account.created" | "account.external_account.deleted" | "account.external_account.updated" | "account.updated" | "application_fee.created" | "application_fee.refund.updated" | "application_fee.refunded" | "balance.available" | "billing.alert.triggered" | "billing_portal.configuration.created" | "billing_portal.configuration.updated" | "billing_portal.session.created" | "capability.updated" | "cash_balance.funds_available" | "charge.captured" | "charge.dispute.closed" | "charge.dispute.created" | "charge.dispute.funds_reinstated" | "charge.dispute.funds_withdrawn" | "charge.dispute.updated" | "charge.expired" | "charge.failed" | "charge.pending" | "charge.refund.updated" | "charge.refunded" | "charge.succeeded" | "charge.updated" | "checkout.session.async_payment_failed" | "checkout.session.async_payment_succeeded" | "checkout.session.completed" | "checkout.session.expired" | "climate.order.canceled" | "climate.order.created" | "climate.order.delayed" | "climate.order.delivered" | "climate.order.product_substituted" | "climate.product.created" | "climate.product.pricing_updated" | "coupon.created" | "coupon.deleted" | "coupon.updated" | "credit_note.created" | "credit_note.updated" | "credit_note.voided" | "customer.created" | "customer.deleted" | "customer.discount.created" | "customer.discount.deleted" | "customer.discount.updated" | "customer.source.created" | "customer.source.deleted" | "customer.source.expiring" | "customer.source.updated" | "customer.subscription.created" | "customer.subscription.deleted" | "customer.subscription.paused" | "customer.subscription.pending_update_applied" | "customer.subscription.pending_update_expired" | "customer.subscription.resumed" | "customer.subscription.trial_will_end" | "customer.subscription.updated" | "customer.tax_id.created" | "customer.tax_id.deleted" | "customer.tax_id.updated" | "customer.updated" | "customer_cash_balance_transaction.created" | "entitlements.active_entitlement_summary.updated" | "file.created" | "financial_connections.account.created" | "financial_connections.account.deactivated" | "financial_connections.account.disconnected" | "financial_connections.account.reactivated" | "financial_connections.account.refreshed_balance" | "financial_connections.account.refreshed_ownership" | "financial_connections.account.refreshed_transactions" | "identity.verification_session.canceled" | "identity.verification_session.created" | "identity.verification_session.processing" | "identity.verification_session.redacted" | "identity.verification_session.requires_input" | "identity.verification_session.verified" | "invoice.created" | "invoice.deleted" | "invoice.finalization_failed" | "invoice.finalized" | "invoice.marked_uncollectible" | "invoice.overdue" | "invoice.paid" | "invoice.payment_action_required" | "invoice.payment_failed" | "invoice.payment_succeeded" | "invoice.sent" | "invoice.upcoming" | "invoice.updated" | "invoice.voided" | "invoice.will_be_due" | "invoiceitem.created" | "invoiceitem.deleted" | "issuing_authorization.created" | "issuing_authorization.request" | "issuing_authorization.updated" | "issuing_card.created" | "issuing_card.updated" | "issuing_cardholder.created" | "issuing_cardholder.updated" | "issuing_dispute.closed" | "issuing_dispute.created" | "issuing_dispute.funds_reinstated" | "issuing_dispute.funds_rescinded" | "issuing_dispute.submitted" | "issuing_dispute.updated" | "issuing_personalization_design.activated" | "issuing_personalization_design.deactivated" | "issuing_personalization_design.rejected" | "issuing_personalization_design.updated" | "issuing_token.created" | "issuing_token.updated" | "issuing_transaction.created" | "issuing_transaction.updated" | "mandate.updated" | "payment_intent.amount_capturable_updated" | "payment_intent.canceled" | "payment_intent.created" | "payment_intent.partially_funded" | "payment_intent.payment_failed" | "payment_intent.processing" | "payment_intent.requires_action" | "payment_intent.succeeded" | "payment_link.created" | "payment_link.updated" | "payment_method.attached" | "payment_method.automatically_updated" | "payment_method.detached" | "payment_method.updated" | "payout.canceled" | "payout.created" | "payout.failed" | "payout.paid" | "payout.reconciliation_completed" | "payout.updated" | "person.created" | "person.deleted" | "person.updated" | "plan.created" | "plan.deleted" | "plan.updated" | "price.created" | "price.deleted" | "price.updated" | "product.created" | "product.deleted" | "product.updated" | "promotion_code.created" | "promotion_code.updated" | "quote.accepted" | "quote.canceled" | "quote.created" | "quote.finalized" | "radar.early_fraud_warning.created" | "radar.early_fraud_warning.updated" | "refund.created" | "refund.updated" | "reporting.report_run.failed" | "reporting.report_run.succeeded" | "reporting.report_type.updated" | "review.closed" | "review.opened" | "setup_intent.canceled" | "setup_intent.created" | "setup_intent.requires_action" | "setup_intent.setup_failed" | "setup_intent.succeeded" | "sigma.scheduled_query_run.created" | "source.canceled" | "source.chargeable" | "source.failed" | "source.mandate_notification" | "source.refund_attributes_required" | "source.transaction.created" | "source.transaction.updated" | "subscription_schedule.aborted" | "subscription_schedule.canceled" | "subscription_schedule.completed" | "subscription_schedule.created" | "subscription_schedule.expiring" | "subscription_schedule.released" | "subscription_schedule.updated" | "tax.settings.updated" | "tax_rate.created" | "tax_rate.updated" | "terminal.reader.action_failed" | "terminal.reader.action_succeeded" | "test_helpers.test_clock.advancing" | "test_helpers.test_clock.created" | "test_helpers.test_clock.deleted" | "test_helpers.test_clock.internal_failure" | "test_helpers.test_clock.ready" | "topup.canceled" | "topup.created" | "topup.failed" | "topup.reversed" | "topup.succeeded" | "transfer.created" | "transfer.reversed" | "transfer.updated" | "treasury.credit_reversal.created" | "treasury.credit_reversal.posted" | "treasury.debit_reversal.completed" | "treasury.debit_reversal.created" | "treasury.debit_reversal.initial_credit_granted" | "treasury.financial_account.closed" | "treasury.financial_account.created" | "treasury.financial_account.features_status_updated" | "treasury.inbound_transfer.canceled" | "treasury.inbound_transfer.created" | "treasury.inbound_transfer.failed" | "treasury.inbound_transfer.succeeded" | "treasury.outbound_payment.canceled" | "treasury.outbound_payment.created" | "treasury.outbound_payment.expected_arrival_date_updated" | "treasury.outbound_payment.failed" | "treasury.outbound_payment.posted" | "treasury.outbound_payment.returned" | "treasury.outbound_payment.tracking_details_updated" | "treasury.outbound_transfer.canceled" | "treasury.outbound_transfer.created" | "treasury.outbound_transfer.expected_arrival_date_updated" | "treasury.outbound_transfer.failed" | "treasury.outbound_transfer.posted" | "treasury.outbound_transfer.returned" | "treasury.outbound_transfer.tracking_details_updated" | "treasury.received_credit.created" | "treasury.received_credit.failed" | "treasury.received_credit.succeeded" | "treasury.received_debit.created")[];
+                    enabled_events?: ("*" | "account.application.authorized" | "account.application.deauthorized" | "account.external_account.created" | "account.external_account.deleted" | "account.external_account.updated" | "account.updated" | "application_fee.created" | "application_fee.refund.updated" | "application_fee.refunded" | "balance.available" | "billing.alert.triggered" | "billing_portal.configuration.created" | "billing_portal.configuration.updated" | "billing_portal.session.created" | "capability.updated" | "cash_balance.funds_available" | "charge.captured" | "charge.dispute.closed" | "charge.dispute.created" | "charge.dispute.funds_reinstated" | "charge.dispute.funds_withdrawn" | "charge.dispute.updated" | "charge.expired" | "charge.failed" | "charge.pending" | "charge.refund.updated" | "charge.refunded" | "charge.succeeded" | "charge.updated" | "checkout.session.async_payment_failed" | "checkout.session.async_payment_succeeded" | "checkout.session.completed" | "checkout.session.expired" | "climate.order.canceled" | "climate.order.created" | "climate.order.delayed" | "climate.order.delivered" | "climate.order.product_substituted" | "climate.product.created" | "climate.product.pricing_updated" | "coupon.created" | "coupon.deleted" | "coupon.updated" | "credit_note.created" | "credit_note.updated" | "credit_note.voided" | "customer.created" | "customer.deleted" | "customer.discount.created" | "customer.discount.deleted" | "customer.discount.updated" | "customer.source.created" | "customer.source.deleted" | "customer.source.expiring" | "customer.source.updated" | "customer.subscription.created" | "customer.subscription.deleted" | "customer.subscription.paused" | "customer.subscription.pending_update_applied" | "customer.subscription.pending_update_expired" | "customer.subscription.resumed" | "customer.subscription.trial_will_end" | "customer.subscription.updated" | "customer.tax_id.created" | "customer.tax_id.deleted" | "customer.tax_id.updated" | "customer.updated" | "customer_cash_balance_transaction.created" | "entitlements.active_entitlement_summary.updated" | "file.created" | "financial_connections.account.created" | "financial_connections.account.deactivated" | "financial_connections.account.disconnected" | "financial_connections.account.reactivated" | "financial_connections.account.refreshed_balance" | "financial_connections.account.refreshed_ownership" | "financial_connections.account.refreshed_transactions" | "identity.verification_session.canceled" | "identity.verification_session.created" | "identity.verification_session.processing" | "identity.verification_session.redacted" | "identity.verification_session.requires_input" | "identity.verification_session.verified" | "invoice.created" | "invoice.deleted" | "invoice.finalization_failed" | "invoice.finalized" | "invoice.marked_uncollectible" | "invoice.overdue" | "invoice.paid" | "invoice.payment_action_required" | "invoice.payment_failed" | "invoice.payment_succeeded" | "invoice.sent" | "invoice.upcoming" | "invoice.updated" | "invoice.voided" | "invoice.will_be_due" | "invoiceitem.created" | "invoiceitem.deleted" | "issuing_authorization.created" | "issuing_authorization.request" | "issuing_authorization.updated" | "issuing_card.created" | "issuing_card.updated" | "issuing_cardholder.created" | "issuing_cardholder.updated" | "issuing_dispute.closed" | "issuing_dispute.created" | "issuing_dispute.funds_reinstated" | "issuing_dispute.funds_rescinded" | "issuing_dispute.submitted" | "issuing_dispute.updated" | "issuing_personalization_design.activated" | "issuing_personalization_design.deactivated" | "issuing_personalization_design.rejected" | "issuing_personalization_design.updated" | "issuing_token.created" | "issuing_token.updated" | "issuing_transaction.created" | "issuing_transaction.purchase_details_receipt_updated" | "issuing_transaction.updated" | "mandate.updated" | "payment_intent.amount_capturable_updated" | "payment_intent.canceled" | "payment_intent.created" | "payment_intent.partially_funded" | "payment_intent.payment_failed" | "payment_intent.processing" | "payment_intent.requires_action" | "payment_intent.succeeded" | "payment_link.created" | "payment_link.updated" | "payment_method.attached" | "payment_method.automatically_updated" | "payment_method.detached" | "payment_method.updated" | "payout.canceled" | "payout.created" | "payout.failed" | "payout.paid" | "payout.reconciliation_completed" | "payout.updated" | "person.created" | "person.deleted" | "person.updated" | "plan.created" | "plan.deleted" | "plan.updated" | "price.created" | "price.deleted" | "price.updated" | "product.created" | "product.deleted" | "product.updated" | "promotion_code.created" | "promotion_code.updated" | "quote.accepted" | "quote.canceled" | "quote.created" | "quote.finalized" | "radar.early_fraud_warning.created" | "radar.early_fraud_warning.updated" | "refund.created" | "refund.failed" | "refund.updated" | "reporting.report_run.failed" | "reporting.report_run.succeeded" | "reporting.report_type.updated" | "review.closed" | "review.opened" | "setup_intent.canceled" | "setup_intent.created" | "setup_intent.requires_action" | "setup_intent.setup_failed" | "setup_intent.succeeded" | "sigma.scheduled_query_run.created" | "source.canceled" | "source.chargeable" | "source.failed" | "source.mandate_notification" | "source.refund_attributes_required" | "source.transaction.created" | "source.transaction.updated" | "subscription_schedule.aborted" | "subscription_schedule.canceled" | "subscription_schedule.completed" | "subscription_schedule.created" | "subscription_schedule.expiring" | "subscription_schedule.released" | "subscription_schedule.updated" | "tax.settings.updated" | "tax_rate.created" | "tax_rate.updated" | "terminal.reader.action_failed" | "terminal.reader.action_succeeded" | "test_helpers.test_clock.advancing" | "test_helpers.test_clock.created" | "test_helpers.test_clock.deleted" | "test_helpers.test_clock.internal_failure" | "test_helpers.test_clock.ready" | "topup.canceled" | "topup.created" | "topup.failed" | "topup.reversed" | "topup.succeeded" | "transfer.created" | "transfer.reversed" | "transfer.updated" | "treasury.credit_reversal.created" | "treasury.credit_reversal.posted" | "treasury.debit_reversal.completed" | "treasury.debit_reversal.created" | "treasury.debit_reversal.initial_credit_granted" | "treasury.financial_account.closed" | "treasury.financial_account.created" | "treasury.financial_account.features_status_updated" | "treasury.inbound_transfer.canceled" | "treasury.inbound_transfer.created" | "treasury.inbound_transfer.failed" | "treasury.inbound_transfer.succeeded" | "treasury.outbound_payment.canceled" | "treasury.outbound_payment.created" | "treasury.outbound_payment.expected_arrival_date_updated" | "treasury.outbound_payment.failed" | "treasury.outbound_payment.posted" | "treasury.outbound_payment.returned" | "treasury.outbound_payment.tracking_details_updated" | "treasury.outbound_transfer.canceled" | "treasury.outbound_transfer.created" | "treasury.outbound_transfer.expected_arrival_date_updated" | "treasury.outbound_transfer.failed" | "treasury.outbound_transfer.posted" | "treasury.outbound_transfer.returned" | "treasury.outbound_transfer.tracking_details_updated" | "treasury.received_credit.created" | "treasury.received_credit.failed" | "treasury.received_credit.succeeded" | "treasury.received_debit.created")[];
                     /** @description Specifies which fields in the response should be expanded. */
                     expand?: string[];
                     /** @description Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. */

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -80,6 +80,7 @@ export default async function openapiTS(
     exportType: options.exportType ?? false,
     immutable: options.immutable ?? false,
     rootTypes: options.rootTypes ?? false,
+    rootTypesNoSchemaPrefix: options.rootTypesNoSchemaPrefix ?? false,
     injectFooter: [],
     pathParamsAsTypes: options.pathParamsAsTypes ?? false,
     postTransform: typeof options.postTransform === "function" ? options.postTransform : undefined,

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -70,9 +70,15 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
           let aliasName = changeCase.pascalCase(singularizeComponentKey(key)) + changeCase.pascalCase(name);
           // Add counter suffix (e.g. "_2") if conflict in name
           let conflictCounter = 1;
+
+          let rootTypePrefix = changeCase.pascalCase(singularizeComponentKey(key));
+          if (ctx.rootTypesNoSchemaPrefix && key.toLowerCase() == "schemas") {
+            rootTypePrefix = "";
+          }
+
           while (rootTypeAliases[aliasName] !== undefined) {
             conflictCounter++;
-            aliasName = `${changeCase.pascalCase(singularizeComponentKey(key))}${changeCase.pascalCase(name)}_${conflictCounter}`;
+            aliasName = `${rootTypePrefix}${changeCase.pascalCase(name)}_${conflictCounter}`;
           }
           const ref = ts.factory.createTypeReferenceNode(`components['${key}']['${name}']`);
           const typeAlias = ts.factory.createTypeAliasDeclaration(

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -29,7 +29,6 @@ const transformers: Record<ComponentTransforms, (node: any, options: TransformNo
 export default function transformComponentsObject(componentsObject: ComponentsObject, ctx: GlobalContext): ts.Node[] {
   const type: ts.TypeElement[] = [];
   const rootTypeAliases: { [key: string]: ts.TypeAliasDeclaration } = {};
-
   for (const key of Object.keys(transformers) as ComponentTransforms[]) {
     const componentT = performance.now();
 
@@ -67,20 +66,20 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
         items.push(property);
 
         if (ctx.rootTypes) {
-          let aliasName = changeCase.pascalCase(singularizeComponentKey(key)) + changeCase.pascalCase(name);
+          let componentKey = changeCase.pascalCase(singularizeComponentKey(key));
+          let aliasName = `${componentKey}${changeCase.pascalCase(name)}`;
+
           // Add counter suffix (e.g. "_2") if conflict in name
           let conflictCounter = 1;
 
-          let rootTypePrefix = changeCase.pascalCase(singularizeComponentKey(key));
-          if (ctx.rootTypesNoSchemaPrefix && key.toLowerCase() == "schemas") {
-            rootTypePrefix = "";
-          }
-
           while (rootTypeAliases[aliasName] !== undefined) {
             conflictCounter++;
-            aliasName = `${rootTypePrefix}${changeCase.pascalCase(name)}_${conflictCounter}`;
+            aliasName = `${componentKey}${changeCase.pascalCase(name)}_${conflictCounter}`
           }
           const ref = ts.factory.createTypeReferenceNode(`components['${key}']['${name}']`);
+          if (ctx.rootTypesNoSchemaPrefix && key === "schemas") {
+            aliasName = aliasName.replace(componentKey, "")
+          }
           const typeAlias = ts.factory.createTypeAliasDeclaration(
             /* modifiers      */ tsModifiers({ export: true }),
             /* name           */ aliasName,

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -66,7 +66,7 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
         items.push(property);
 
         if (ctx.rootTypes) {
-          let componentKey = changeCase.pascalCase(singularizeComponentKey(key));
+          const componentKey = changeCase.pascalCase(singularizeComponentKey(key));
           let aliasName = `${componentKey}${changeCase.pascalCase(name)}`;
 
           // Add counter suffix (e.g. "_2") if conflict in name
@@ -74,11 +74,11 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 
           while (rootTypeAliases[aliasName] !== undefined) {
             conflictCounter++;
-            aliasName = `${componentKey}${changeCase.pascalCase(name)}_${conflictCounter}`
+            aliasName = `${componentKey}${changeCase.pascalCase(name)}_${conflictCounter}`;
           }
           const ref = ts.factory.createTypeReferenceNode(`components['${key}']['${name}']`);
           if (ctx.rootTypesNoSchemaPrefix && key === "schemas") {
-            aliasName = aliasName.replace(componentKey, "")
+            aliasName = aliasName.replace(componentKey, "");
           }
           const typeAlias = ts.factory.createTypeAliasDeclaration(
             /* modifiers      */ tsModifiers({ export: true }),

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -659,6 +659,8 @@ export interface OpenAPITSOptions {
   propertiesRequiredByDefault?: boolean;
   /** (optional) Generate schema types at root level */
   rootTypes?: boolean;
+  /** (optional) Do not add Schema prefix to types at root level */
+  rootTypesNoSchemaPrefix?: boolean;
   /**
    * Configure Redocly for validation, schema fetching, and bundling
    * @see https://redocly.com/docs/cli/configuration/
@@ -691,6 +693,7 @@ export interface GlobalContext {
   postTransform: OpenAPITSOptions["postTransform"];
   propertiesRequiredByDefault: boolean;
   rootTypes: boolean;
+  rootTypesNoSchemaPrefix: boolean;
   redoc: RedoclyConfig;
   silent: boolean;
   transform: OpenAPITSOptions["transform"];

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -24,6 +24,7 @@ export const DEFAULT_CTX: GlobalContext = {
   postTransform: undefined,
   propertiesRequiredByDefault: false,
   rootTypes: false,
+  rootTypesNoSchemaPrefix: false,
   redoc: await createConfig({}, { extends: ["minimal"] }),
   resolve($ref) {
     return resolveRef({}, $ref, { silent: false });

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -699,7 +699,8 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
         options: { ...DEFAULT_OPTIONS, rootTypes: true },
       },
     ],
-    ["options > rootTypes: true and rootTypesNoSchemaPrefix: true",
+    [
+      "options > rootTypes: true and rootTypesNoSchemaPrefix: true",
       {
         given: {
           schemas: {
@@ -711,7 +712,7 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
                 url: { type: "string" },
               },
             },
-            "Document": {
+            Document: {
               type: "object",
               required: ["name", "size", "url"],
               properties: {
@@ -850,7 +851,7 @@ export type Error = components['schemas']['Error'];
     headers: never;
     pathItems: never;
 }`,
-        options: DEFAULT_OPTIONS
+        options: DEFAULT_OPTIONS,
       },
     ],
   ];

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -212,8 +212,8 @@ describe("transformComponentsObject", () => {
     headers: never;
     pathItems: never;
 }`,
+        options: DEFAULT_OPTIONS,
       },
-      // options: DEFAULT_OPTIONS,
     ],
     [
       "options > alphabetize: true",
@@ -699,6 +699,66 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
         options: { ...DEFAULT_OPTIONS, rootTypes: true },
       },
     ],
+    ["options > rootTypes: true and rootTypesNoSchemaPrefix: true",
+      {
+        given: {
+          schemas: {
+            Item: {
+              type: "object",
+              required: ["name", "url"],
+              properties: {
+                name: { type: "string" },
+                url: { type: "string" },
+              },
+            },
+            "Document": {
+              type: "object",
+              required: ["name", "size", "url"],
+              properties: {
+                name: { type: "string" },
+                size: { type: "number" },
+                url: { type: "string" },
+              },
+            },
+            Error: {
+              type: "object",
+              required: ["code", "message"],
+              properties: {
+                code: { type: "string" },
+                message: { type: "string" },
+              },
+            },
+          },
+        },
+        want: `{
+    schemas: {
+        Item: {
+            name: string;
+            url: string;
+        };
+        Document: {
+            name: string;
+            size: number;
+            url: string;
+        };
+        Error: {
+            code: string;
+            message: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type Item = components['schemas']['Item'];
+export type Document = components['schemas']['Document'];
+export type Error = components['schemas']['Error'];
+`,
+        options: { ...DEFAULT_OPTIONS, rootTypes: true, rootTypesNoSchemaPrefix: true },
+      },
+    ],
     [
       "transform > with transform object",
       {
@@ -790,11 +850,12 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
     headers: never;
     pathItems: never;
 }`,
+        options: DEFAULT_OPTIONS
       },
     ],
   ];
 
-  for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {
+  for (const [testName, { given, want, options, ci }] of tests) {
     test.skipIf(ci?.skipIf)(
       testName,
       async () => {
@@ -802,7 +863,7 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
         if (want instanceof URL) {
           expect(result).toMatchFileSnapshot(fileURLToPath(want));
         } else {
-          expect(result).toBe(`${want}\n`);
+          expect(result.trim()).toBe(want.trim());
         }
       },
       ci?.timeout,


### PR DESCRIPTION
## Changes

This PR adds another cli flag `--root-types-no-prefix` which complements `--root-types`.
If set it will render root types without `Schema` prefix.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
