### PR TITLE
CI: Add bot token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'openapi-ts' }}
     permissions:
       contents: write
       pull-requests: write
@@ -28,5 +29,5 @@ jobs:
           commit: "[ci] release"
           title: "[ci] release"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENAPI_TS_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Changes

CI-change only. Adds @openapi-ts-bot user token to run the changesets action that prepares releases.

Currently, we are using the default GitHub Actions bot, which CAN’T run PR checks, which means a normal maintainer can’t merge release PRs without admin override permissions. This ensures not only release PRs run actions; it also lets maintainers approve package releases more-easily. This is a common workaround implemented by many open source repos; we just hadn’t taken the time to set this up before.

## How to Review

- There’s nothing to review; this may require some post-merge fixes

## Checklist

N/A
