### PR TITLE
feat: 204 to undefined

### DIFF
--- a/.changeset/rude-pumas-wonder.md
+++ b/.changeset/rude-pumas-wonder.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": minor
+---
+
+204 responses or response with a Content-Length of 0 will now return undefined instead of an empty object

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -151,9 +151,8 @@ export default function createClient(clientOptions) {
     }
 
     // handle empty content
-    // note: we return `{}` because we want user truthy checks for `.data` or `.error` to succeed
     if (response.status === 204 || response.headers.get("Content-Length") === "0") {
-      return response.ok ? { data: {}, response } : { error: {}, response };
+      return response.ok ? { data: undefined, response } : { error: undefined, response };
     }
 
     // parse response (falling back to .text() when necessary)

--- a/packages/openapi-fetch/test/http-methods/delete.test.ts
+++ b/packages/openapi-fetch/test/http-methods/delete.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, assertType } from "vitest";
 import { createObservedClient } from "../helpers.js";
 import type { paths } from "./schemas/delete.js";
 
@@ -10,7 +10,8 @@ describe("DELETE", () => {
     });
 
     // assert correct data was returned
-    expect(data).toEqual({});
+    assertType<undefined>(data);
+    expect(data).toEqual(undefined);
     expect(response.status).toBe(204);
 
     // assert error is empty
@@ -27,7 +28,7 @@ describe("DELETE", () => {
     expect(method).toBe("DELETE");
   });
 
-  test("returns empty object on Content-Length: 0", async () => {
+  test("returns undefined on Content-Length: 0", async () => {
     const client = createObservedClient<paths>(
       {},
       async () => new Response(null, { status: 200, headers: { "Content-Length": "0" } }),
@@ -39,7 +40,8 @@ describe("DELETE", () => {
     });
 
     // assert correct data was returned
-    expect(data).toEqual({});
+    assertType<undefined>(data);
+    expect(data).toEqual(undefined);
 
     // assert error is empty
     expect(error).toBeUndefined();

--- a/packages/openapi-fetch/test/never-response/never-response.test.ts
+++ b/packages/openapi-fetch/test/never-response/never-response.test.ts
@@ -58,8 +58,8 @@ describe("GET", () => {
     // assert correct URL was called
     expect(actualPathname).toBe("/posts/123");
 
-    // assert 204 to be transformed to empty object
-    expect(data).toEqual({});
+    // assert 204 to be transformed to be undefined
+    expect(data).toEqual(undefined);
     expect(response.status).toBe(204);
 
     // assert error is empty
@@ -128,8 +128,8 @@ describe("GET", () => {
     // assert correct method was called
     expect(method).toBe("GET");
 
-    // assert 204 to be transformed to empty object
-    expect(data).toEqual({});
+    // assert 204 to be transformed to undefined
+    expect(data).toEqual(undefined);
   });
 
   test("gracefully handles invalid JSON for errors", async () => {


### PR DESCRIPTION
## Changes

This PR updates the current behavior for handling `204` and empty responses.

`data`/`error` will not be set to `undefined` to match the generated type.

Follow-up from https://github.com/openapi-ts/openapi-typescript/pull/1937#discussion_r1785904312

## How to Review

Check updated tests. The type displayed for empty 204 responses (`content?: never`) will now match the returned data/error type. 

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
