### PR TITLE
feat: narrow type based on status code

### DIFF
--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -114,10 +114,10 @@ export type FetchResponse<
   } & (S extends OkStatus
     ? {
         data: ParseAsResponse<GetResponseContent<ResponseObjectMap<T>, Media, S>, Options>;
-        error: never;
+        error?: never;
       }
     : {
-        data: never;
+        data?: never;
         error: GetResponseContent<ResponseObjectMap<T>, Media, S>;
       });
 }[TStatus];

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -152,16 +152,16 @@ export default function createClient(clientOptions) {
 
     // handle empty content
     if (response.status === 204 || response.headers.get("Content-Length") === "0") {
-      return response.ok ? { data: undefined, response } : { error: undefined, response };
+      return response.ok ? { data: undefined, response, status: response.status  } : { error: undefined, response, status: response.status };
     }
 
     // parse response (falling back to .text() when necessary)
     if (response.ok) {
       // if "stream", skip parsing entirely
       if (parseAs === "stream") {
-        return { data: response.body, response };
+        return { data: response.body, response, status: response.status };
       }
-      return { data: await response[parseAs](), response };
+      return { data: await response[parseAs](), response, status: response.status };
     }
 
     // handle errors
@@ -171,7 +171,7 @@ export default function createClient(clientOptions) {
     } catch {
       // noop
     }
-    return { error, response };
+    return { error, response, status: response.status };
   }
 
   return {

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -152,7 +152,9 @@ export default function createClient(clientOptions) {
 
     // handle empty content
     if (response.status === 204 || response.headers.get("Content-Length") === "0") {
-      return response.ok ? { data: undefined, response, status: response.status  } : { error: undefined, response, status: response.status };
+      return response.ok
+        ? { data: undefined, response, status: response.status }
+        : { error: undefined, response, status: response.status };
     }
 
     // parse response (falling back to .text() when necessary)

--- a/packages/openapi-fetch/test/common/response.test.ts
+++ b/packages/openapi-fetch/test/common/response.test.ts
@@ -65,7 +65,7 @@ describe("response", () => {
       }
     });
 
-    test("returns union for mismatched errors", async () => {
+    test("returns union for mismatched errors", async () => {
       const client = createObservedClient<paths>();
       const result = await client.GET("/mismatched-errors");
       if (result.data) {

--- a/packages/openapi-typescript-helpers/index.d.ts
+++ b/packages/openapi-typescript-helpers/index.d.ts
@@ -7,6 +7,19 @@ export type OkStatus = 200 | 201 | 202 | 203 | 204 | 206 | 207 | "2XX";
 // biome-ignore format: keep on one line
 export type ErrorStatus = 500 | 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511 | '5XX' | 400 | 401 | 402 | 403 | 404 | 405 | 406 | 407 | 408 | 409 | 410 | 411 | 412 | 413 | 414 | 415 | 416 | 417 | 418 | 420 | 421 | 422 | 423 | 424 | 425 | 426 | 427 | 428 | 429 | 430 | 431 | 444 | 450 | 451 | 497 | 498 | 499 | '4XX' | "default";
 
+/**
+ * 'default' returns every status code
+ * '2XX' returns all 2XX status codes
+ * '4XX' returns all 4XX status codes
+ * '5XX' returns all 5XX status codes
+ */
+export type OpenApiStatusToHttpStatus<Status> = 
+  Status extends number ? Status :
+  Status extends "default" ? number :
+  Status extends "2XX" ? Exclude<OkStatus, string> :
+  Status extends "4XX" | "5XX" ? Exclude<ErrorStatus, string> :
+  never;
+
 /** Get a union of OK Statuses */
 export type OKStatusUnion<T> = FilterKeys<T, OkStatus>;
 


### PR DESCRIPTION
## Changes

The various client methods (`GET`, `POST`, `PUT` e.t.c.) now have an additional `status` property. 

This property allows users to narrow the type of their `data`/`error` based on their documented response status codes.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
