### PR TITLE
feat(openapi-fetch): add onError handler to middleware

### DIFF
--- a/.changeset/heavy-kangaroos-beam.md
+++ b/.changeset/heavy-kangaroos-beam.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+add onError handler to middleware

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -6,8 +6,8 @@ import type {
   MediaType,
   OperationRequestBodyContent,
   PathsWithMethod,
-  ResponseObjectMap,
   RequiredKeysOf,
+  ResponseObjectMap,
   SuccessResponse,
 } from "openapi-typescript-helpers";
 
@@ -152,15 +152,25 @@ type MiddlewareOnRequest = (
 type MiddlewareOnResponse = (
   options: MiddlewareCallbackParams & { response: Response },
 ) => void | Response | undefined | Promise<Response | undefined | void>;
+type MiddlewareOnError = (
+  options: MiddlewareCallbackParams & { error: unknown },
+) => void | Response | Error | Promise<void | Response | Error>;
 
 export type Middleware =
   | {
       onRequest: MiddlewareOnRequest;
       onResponse?: MiddlewareOnResponse;
+      onError?: MiddlewareOnError;
     }
   | {
       onRequest?: MiddlewareOnRequest;
       onResponse: MiddlewareOnResponse;
+      onError?: MiddlewareOnError;
+    }
+  | {
+      onRequest?: MiddlewareOnRequest;
+      onResponse?: MiddlewareOnResponse;
+      onError: MiddlewareOnError;
     };
 
 /** This type helper makes the 2nd function param required if params/requestBody are required; otherwise, optional */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -124,7 +124,49 @@ export default function createClient(clientOptions) {
     }
 
     // fetch!
-    let response = await fetch(request);
+    let response;
+    try {
+      response = await fetch(request);
+    } catch (error) {
+      let errorAfterMiddleware = error;
+      // middleware (error)
+      // execute in reverse-array order (first priority gets last transform)
+      if (middlewares.length) {
+        for (let i = middlewares.length - 1; i >= 0; i--) {
+          const m = middlewares[i];
+          if (m && typeof m === "object" && typeof m.onError === "function") {
+            const result = await m.onError({
+              request,
+              error: errorAfterMiddleware,
+              schemaPath,
+              params,
+              options,
+              id,
+            });
+            if (result) {
+              // if error is handled by returning a response, skip remaining middleware
+              if (result instanceof Response) {
+                errorAfterMiddleware = undefined;
+                response = result;
+                break;
+              }
+
+              if (result instanceof Error) {
+                errorAfterMiddleware = result;
+                continue;
+              }
+
+              throw new Error("onError: must return new Response() or instance of Error");
+            }
+          }
+        }
+      }
+
+      // rethrow error if not handled by middleware
+      if (errorAfterMiddleware) {
+        throw errorAfterMiddleware;
+      }
+    }
 
     // middleware (response)
     // execute in reverse-array order (first priority gets last transform)
@@ -213,8 +255,8 @@ export default function createClient(clientOptions) {
         if (!m) {
           continue;
         }
-        if (typeof m !== "object" || !("onRequest" in m || "onResponse" in m)) {
-          throw new Error("Middleware must be an object with one of `onRequest()` or `onResponse()`");
+        if (typeof m !== "object" || !("onRequest" in m || "onResponse" in m || "onError" in m)) {
+          throw new Error("Middleware must be an object with one of `onRequest()`, `onResponse() or `onError()`");
         }
         middlewares.push(m);
       }


### PR DESCRIPTION
## Changes

This PR adds an optional `onError` handler to the middleware feature. It allows handling errors thrown by `fetch` in three ways:

- return nothing which means that the error will still be thrown, but useful for logging,

```ts
  client.use({
    onError({ error }) {
      console.error(error);
      return;
    },
  });
```

- return another instance of `Error` to be thrown instead,

```ts
  client.use({
    onError({ error }) {
      return new Error("Oops", { cause: error });
    },
  });
```

- or return a new instance of `Response` which means that the `fetch` call will proceed as successful.

```ts
  client.use({
    onError({ error }) {
      return Response.json({ message: 'nothing to see' });
    },
  });
```

## How to Review

See additional tests in [`packages/openapi-fetch/test/middleware/middleware.test.ts`](https://github.com/openapi-ts/openapi-typescript/pull/1974/files#diff-1ebe4e3e3485da65d98a45febf3668051271be815e3e5fb8b175458468faa17b)

If multiple middlewares with `onError` are configured, they are executed in reverse order like `onResponse`. I'm not sure if that's intuitive or not. 🤔

## Checklist

- [X] Unit tests updated
- [-] `docs/` updated (if necessary) **👈 I'll amend the commit with docs if this feature request is accepted**
- [-] `pnpm run update:examples` run (only applicable for openapi-typescript)
