### PR TITLE
Fix middleware docs

### DIFF
--- a/.changeset/.changeset/silver-wasps-relate.md
+++ b/.changeset/.changeset/silver-wasps-relate.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix throwing middleware example in docs

--- a/.changeset/.changeset/silver-wasps-relate.md
+++ b/.changeset/.changeset/silver-wasps-relate.md
@@ -1,5 +1,0 @@
----
-"openapi-fetch": patch
----
-
-Fix throwing middleware example in docs

--- a/docs/openapi-fetch/middleware-auth.md
+++ b/docs/openapi-fetch/middleware-auth.md
@@ -64,8 +64,9 @@ Middleware can also be used to throw an error that `fetch()` wouldn’t normally
 
 ```ts
 onResponse({ response }) {
-  if (response.error) {
-    throw new Error(response.error.message);
+  if (!response.ok) {
+    // Will produce error messages like "https://example.org/api/v1/example: 404 Not Found".
+    throw new Error(`${response.url}: ${response.status} ${response.statusText}`)
   }
 }
 ```


### PR DESCRIPTION
## Changes

Fix throwing middleware example in docs

Fixes https://github.com/openapi-ts/openapi-typescript/issues/1954

## How to Review

Doc change only.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
