### PR TITLE
Fix path params as types

### DIFF
--- a/.changeset/thirty-queens-try.md
+++ b/.changeset/thirty-queens-try.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Make pathParamsAsTypes work with integer/boolean types

--- a/packages/openapi-typescript/src/transform/paths-object.ts
+++ b/packages/openapi-typescript/src/transform/paths-object.ts
@@ -52,10 +52,17 @@ export default function transformPathsObject(pathsObject: PathsObject, ctx: Glob
           for (const match of matches) {
             const paramName = match.slice(1, -1);
             const param = pathParams[paramName];
-            if (!param) {
-              rawPath = rawPath.replace(match, "${string}");
-            } else {
-              rawPath = rawPath.replace(match, `$\{${(param.schema as any)?.type ?? "string"}}`);
+            switch (param?.schema?.type) {
+              case "number":
+              case "integer":
+                rawPath = rawPath.replace(match, "${number}");
+                break;
+              case "boolean":
+                rawPath = rawPath.replace(match, "${boolean}");
+                break;
+              default:
+                rawPath = rawPath.replace(match, "${string}");
+                break;
             }
           }
           // note: creating a string template literal’s AST manually is hard!

--- a/packages/openapi-typescript/test/transform/paths-object.test.ts
+++ b/packages/openapi-typescript/test/transform/paths-object.test.ts
@@ -274,13 +274,18 @@ describe("transformPathsObject", () => {
       "options > pathParamsAsTypes: true",
       {
         given: {
-          "/api/v1/user/me": {
+          "/api/v1/user/{user_id}": {
             parameters: [
               {
                 name: "page",
                 in: "query",
                 schema: { type: "number" },
                 description: "Page number.",
+              },
+              {
+                name: "user_id",
+                in: "path",
+                schema: { format: "int64", type: "integer" },
               },
             ],
             get: {
@@ -315,14 +320,16 @@ describe("transformPathsObject", () => {
           },
         },
         want: `{
-    "/api/v1/user/me": {
+    [path: \`/api/v1/user/\${number}\`]: {
         parameters: {
             query?: {
                 /** @description Page number. */
                 page?: number;
             };
             header?: never;
-            path?: never;
+            path: {
+                user_id: number;
+            };
             cookie?: never;
         };
         get: {
@@ -332,7 +339,9 @@ describe("transformPathsObject", () => {
                     page?: number;
                 };
                 header?: never;
-                path?: never;
+                path: {
+                    user_id: number;
+                };
                 cookie?: never;
             };
             requestBody?: never;


### PR DESCRIPTION
## Changes

Make pathParamsAsTypes work with integer/boolean types

Fixes #1930 

~Also, corepack added a `packageManager` to `package.json` which is normally useful, but I can remove it if you want.~

## Checklist

- [x] Unit tests updated
