### PR TITLE
fix(#1977): refactor handling for empty responses

### DIFF
--- a/.changeset/great-zoos-live.md
+++ b/.changeset/great-zoos-live.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+fixed `parseAs` behaviour being different for error responses

--- a/.changeset/thirty-singers-join.md
+++ b/.changeset/thirty-singers-join.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+fixed empty responses body causing error `Unexpected end of JSON input`

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -106,7 +106,7 @@ export type FetchResponse<T extends Record<string | number, any>, Options, Media
     }
   | {
       data?: never;
-      error: ErrorResponse<ResponseObjectMap<T>, Media>;
+      error: ParseAsResponse<ErrorResponse<ResponseObjectMap<T>, Media>, Options>;
       response: Response;
     };
 

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -152,8 +152,12 @@ export default function createClient(clientOptions) {
 
     const resultKey = response.ok ? "data" : "error";
 
-    // handle empty content
-    if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+    /**
+     * handle empty content
+     * NOTE: Current browsers don't actually conform to the spec requirement to set the body property to null for responses with no body
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Response/body
+     */
+    if (response.body === null || response.headers.get("Content-Length") === "0") {
       return { [resultKey]: undefined, response };
     }
 
@@ -172,7 +176,10 @@ export default function createClient(clientOptions) {
       try {
         data = JSON.parse(data); // attempt to parse as JSON
       } catch {
-        // noop
+        // Handle empty content
+        if (data === "") {
+          data = undefined;
+        }
       }
 
       return { [resultKey]: data, response };

--- a/packages/openapi-fetch/test/common/response.test.ts
+++ b/packages/openapi-fetch/test/common/response.test.ts
@@ -123,6 +123,14 @@ describe("response", () => {
         assertType<Error>(error);
       }
     });
+
+    test("fallback on empty response", async () => {
+      const client = createObservedClient<paths>({}, async () => new Response(undefined, { status: 200 }));
+
+      const { data, error } = await client.GET("/error-empty-response");
+      expect(data).toBe(undefined);
+      expect(error).toBe(undefined);
+    });
   });
 
   describe("response object", () => {

--- a/packages/openapi-fetch/test/common/response.test.ts
+++ b/packages/openapi-fetch/test/common/response.test.ts
@@ -124,8 +124,16 @@ describe("response", () => {
       }
     });
 
-    test("fallback on empty response", async () => {
+    test("fallback on null response", async () => {
       const client = createObservedClient<paths>({}, async () => new Response(undefined, { status: 200 }));
+
+      const { data, error } = await client.GET("/error-empty-response");
+      expect(data).toBe(undefined);
+      expect(error).toBe(undefined);
+    });
+
+    test("fallback on empty body steam", async () => {
+      const client = createObservedClient<paths>({}, async () => new Response("", { status: 200 }));
 
       const { data, error } = await client.GET("/error-empty-response");
       expect(data).toBe(undefined);
@@ -143,7 +151,7 @@ describe("response", () => {
     });
   });
 
-  describe("parseAs", () => {
+  describe("data parseAs", () => {
     const client = createObservedClient<paths>({}, async () => Response.json({}));
 
     test("text", async () => {
@@ -197,6 +205,66 @@ describe("response", () => {
       });
       if (data) {
         assertType<{ bar: string }>(data);
+      }
+    });
+  });
+
+  describe("error parseAs", () => {
+    const client = createObservedClient<paths>({}, async () => Response.json({}, { status: 500 }));
+
+    test("text", async () => {
+      const { data, error } = (await client.GET("/resources", {
+        parseAs: "text",
+      })) satisfies { error?: string };
+      if (data) {
+        throw new Error("parseAs text: error");
+      }
+      expect(error).toBe("{}");
+    });
+
+    test("arrayBuffer", async () => {
+      const { data, error } = (await client.GET("/resources", {
+        parseAs: "arrayBuffer",
+      })) satisfies { error?: ArrayBuffer };
+      if (data) {
+        throw new Error("parseAs arrayBuffer: error");
+      }
+      expect(error.byteLength).toBe("{}".length);
+    });
+
+    test("blob", async () => {
+      const { data, error } = (await client.GET("/resources", {
+        parseAs: "blob",
+      })) satisfies { error?: Blob };
+      if (data) {
+        throw new Error("parseAs blob: error");
+      }
+      expect(error.constructor.name).toBe("Blob");
+    });
+
+    test("stream", async () => {
+      const { error } = (await client.GET("/resources", {
+        parseAs: "stream",
+      })) satisfies { error?: ReadableStream<Uint8Array> | null };
+      if (!error) {
+        throw new Error("parseAs stream: error");
+      }
+
+      expect(error).toBeInstanceOf(ReadableStream);
+      const reader = error.getReader();
+      const result = await reader.read();
+      expect(result.value?.length).toBe(2);
+    });
+
+    test("use the selected content", async () => {
+      const client = createObservedClient<paths, "application/ld+json">({}, async () =>
+        Response.json({ bar: "bar" }, { status: 500 }),
+      );
+      const { error } = await client.GET("/media-multiple", {
+        headers: { Accept: "application/ld+json" },
+      });
+      if (error) {
+        assertType<{ bar: string }>(error);
       }
     });
   });

--- a/packages/openapi-fetch/test/common/schemas/common.d.ts
+++ b/packages/openapi-fetch/test/common/schemas/common.d.ts
@@ -190,6 +190,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/error-empty-response": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/error-default": {
         parameters: {
             query?: never;

--- a/packages/openapi-fetch/test/common/schemas/common.yaml
+++ b/packages/openapi-fetch/test/common/schemas/common.yaml
@@ -79,6 +79,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /error-empty-response:
+    get:
+      responses:
+        200:
+          description: OK
+        204:
+          description: No content
   /error-default:
     get:
       responses:

--- a/packages/openapi-fetch/test/never-response/never-response.test.ts
+++ b/packages/openapi-fetch/test/never-response/never-response.test.ts
@@ -140,4 +140,32 @@ describe("GET", () => {
     expect(data).toBeUndefined();
     expect(error).toBe("Unauthorized");
   });
+
+  describe("handles error as", () => {
+    test("text", async () => {
+      const client = createObservedClient<paths>({}, async () => new Response("Unauthorized", { status: 401 }));
+
+      const { data, error } = await client.GET("/posts", { parseAs: "text" });
+
+      expect(data).toBeUndefined();
+      expect(error).toBe("Unauthorized");
+    });
+
+    test("stream", async () => {
+      const client = createObservedClient<paths>({}, async () => new Response("Unauthorized", { status: 401 }));
+
+      const { data, error } = (await client.GET("/posts", { parseAs: "stream" })) satisfies {
+        error?: ReadableStream<Uint8Array> | null;
+      };
+      if (!error) {
+        throw new Error("parseAs stream: error");
+      }
+
+      expect(data).toBeUndefined();
+      expect(error).toBeInstanceOf(ReadableStream);
+      const reader = error.getReader();
+      const result = await reader.read();
+      expect(result.value?.length).toBe(12);
+    });
+  });
 });


### PR DESCRIPTION
## Changes

This PR includes a couple of different changes for `openapi-fetch`:

- A refactor (Breaking change?) to ensure the behaviour of `data` and `error` are the same to reduce complexity.
As an example, this means that whenever a user uses the `parseAs: 'stream'` both the `data` and `error` property will return a `ReadableStream` from `response.body`
- The logic for empty response bodies has been changed:
  - It no longer explicity checks for `204` status to determine if a response is empty
  - It now follows[ the spec](https://developer.mozilla.org/en-US/docs/Web/API/Response/body) by checking if `response.body` is null
    - Backwards compatibality with browsers: empty string (`''`) get converted to `undefined` after failing to parse it as `json` (fixes https://github.com/openapi-ts/openapi-typescript/issues/1977)

## How to Review

See changes & tests

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
