### PR TITLE
fix(openapi-typescript): include location in error messages

### DIFF
--- a/.changeset/three-bobcats-mate.md
+++ b/.changeset/three-bobcats-mate.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Improved error messages to contain locations.

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -66,7 +66,9 @@ export function transformSchemaObjectWithComposition(
   }
   // for any other unexpected type, throw error
   if (Array.isArray(schemaObject) || typeof schemaObject !== "object") {
-    throw new Error(`Expected SchemaObject, received ${Array.isArray(schemaObject) ? "Array" : typeof schemaObject}`);
+    throw new Error(
+      `Expected SchemaObject, received ${Array.isArray(schemaObject) ? "Array" : typeof schemaObject} at ${options.path}`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Changes

- improved error messages - added locations to help find the problem in schema
- do not throw error on first problem - display all the problems with the schema before throwing an error - helps to find out how many things are broken in schema
- repeated code moved to internal method, reused in both Validation and Bundling

Examples: 
- from ` ✘  Can't resolve $ref `  to ` ✘  Can't resolve $ref at #/components/schemas/Pet/properties/type`
- from `Expected SchemaObject, received Array` to `Expected SchemaObject, received Array at #/components/schemas/someSchema`

## How to Review

Apart of more explicit error messages the only change is in not throwing the first `problem`, but rather display all the problems to help quickly fix them before the next run. This is not affecting the application flow, as the Error is still thrown right after `problems` are processed.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
