### PR TITLE
feat(react-query): add prefixQueryKey to createClient

### DIFF
--- a/.changeset/good-buttons-bake.md
+++ b/.changeset/good-buttons-bake.md
@@ -1,0 +1,5 @@
+---
+'openapi-react-query': minor
+---
+
+Add `prefixQueryKey` to `createClient` to avoid query key collision between different openapi-fetch clients.


### PR DESCRIPTION
## Background

- Based on the feedback on #1981, the direction was adjusted, so I continued work in a separate PR.

Close #1979. 

## Changes

- Added a `prefixQueryKey` parameter to differentiate cache identities.

## How to Review

I haven't changed the documentation, but if you think it's necessary, please comment.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
