### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  GITHUB_TOKEN: ${{ secrets.OPENAPI_TS_BOT_GITHUB_TOKEN }}
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,5 @@ jobs:
           commit: "[ci] release"
           title: "[ci] release"
         env:
+          GITHUB_TOKEN: ${{ secrets.OPENAPI_TS_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     types: [opened, synchronize]
 
-env:
-  GITHUB_TOKEN: ${{ secrets.OPENAPI_TS_BOT_GITHUB_TOKEN }}
-
 jobs:
   size-limit:
     permissions:

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm run update-contributors && vitepress build && cp _redirects .vitepress/dist",
-    "dev": "pnpm run update-contributors && vitepress dev",
+    "build-docs": "pnpm run update-contributors && vitepress build && cp _redirects .vitepress/dist",
+    "dev": "vitepress dev",
     "update-contributors": "node scripts/update-contributors.js"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["GITHUB_TOKEN"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Changes

#2027 Broke the build by requiring an env var set in all contexts (it builds the docs alongside everything else). This changes the docs to use a separate build command to sidestep this issue, and removes the env var from Turborepo’s context.

## How to Review

- CI should pass
- Cloudflare should fail; that’s OK (can be fixed after merge since that’s separate)

## Checklist

N/A