### PR TITLE
Increase size limit for openapi-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "size-limit": [
     {
       "path": "packages/openapi-fetch/dist/index.min.js",
-      "limit": "6.5 kB",
+      "limit": "7 kB",
       "brotli": false
     }
   ]


### PR DESCRIPTION
## Changes

A recent PR increased the weight of openapi-fetch by ~0.2kb. This is all perfectly-safe, and normal, especially with handwritten code.

The size-limits check isn’t to try to get us to participate in [code golf](https://en.wikipedia.org/wiki/Code_golf) or enforce arbitrary limits. Especially in openapi-fetch’s case, the purpose is to:

1. Guard against sneaky package dependencies (openapi-fetch as of now should have no dependencies; just a single one could increase it by 30kb or more!)
2. Set a baseline for size. We just want to have a gauge of roughly how big this package is (also so we know when to Find + Replace all the docs that brag about its size :P)
3. Help reviewers catch unintentional increases. It is very easy to miss a one-line package import in a PR review. This should be an automated check.

For all these reasons, size-limit is **NOT** a required check, because it shouldn’t block PRs. But if failing, it should force follow-up PRs like this one.

## How to Review

- CI should pass

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
