### PR TITLE
feat: explicitly export root types

### DIFF
--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -71,30 +71,29 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
             aliasName = aliasName.replace(componentKey, "");
           }
           const typeAlias = ts.factory.createTypeAliasDeclaration(
-              /* modifiers      */ tsModifiers({ export: true }),
-              /* name          */ aliasName,
-              /* typeParameters */ undefined,
-              subType,
+            /* modifiers      */ tsModifiers({ export: true }),
+            /* name          */ aliasName,
+            /* typeParameters */ undefined,
+            subType,
           );
 
           rootTypeAliases[aliasName] = typeAlias;
 
           const property = ts.factory.createPropertySignature(
-              /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
-              /* name          */ tsPropertyIndex(name),
-              /* typeParameters */ undefined,
-              /* type          */ ts.factory.createTypeReferenceNode(aliasName),
+            /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
+            /* name          */ tsPropertyIndex(name),
+            /* typeParameters */ undefined,
+            /* type          */ ts.factory.createTypeReferenceNode(aliasName),
           );
 
           addJSDocComment(item as unknown as any, property);
           items.push(property);
-
         } else {
           const property = ts.factory.createPropertySignature(
-              /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
-              /* name          */ tsPropertyIndex(name),
-              /* questionToken */ hasQuestionToken ? QUESTION_TOKEN : undefined,
-              /* type          */ subType,
+            /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
+            /* name          */ tsPropertyIndex(name),
+            /* questionToken */ hasQuestionToken ? QUESTION_TOKEN : undefined,
+            /* type          */ subType,
           );
           addJSDocComment(item as unknown as any, property);
           items.push(property);
@@ -102,12 +101,12 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
       }
     }
     type.push(
-        ts.factory.createPropertySignature(
-            /* modifiers     */ undefined,
-            /* name          */ tsPropertyIndex(key),
-            /* questionToken */ undefined,
-            /* type          */ items.length ? ts.factory.createTypeLiteralNode(items) : NEVER,
-        ),
+      ts.factory.createPropertySignature(
+        /* modifiers     */ undefined,
+        /* name          */ tsPropertyIndex(key),
+        /* questionToken */ undefined,
+        /* type          */ items.length ? ts.factory.createTypeLiteralNode(items) : NEVER,
+      ),
     );
 
     debug(`Transformed components → ${key}`, "ts", performance.now() - componentT);
@@ -123,13 +122,13 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 }
 
 export function singularizeComponentKey(
-    key: `x-${string}` | "schemas" | "responses" | "parameters" | "requestBodies" | "headers" | "pathItems",
+  key: `x-${string}` | "schemas" | "responses" | "parameters" | "requestBodies" | "headers" | "pathItems",
 ): string {
   switch (key) {
-      // Handle special singular case
+    // Handle special singular case
     case "requestBodies":
       return "requestBody";
-      // Default to removing the "s"
+    // Default to removing the "s"
     default:
       return key.slice(0, -1);
   }

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -56,15 +56,6 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
           }
         }
 
-        const property = ts.factory.createPropertySignature(
-          /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
-          /* name          */ tsPropertyIndex(name),
-          /* questionToken */ hasQuestionToken ? QUESTION_TOKEN : undefined,
-          /* type          */ subType,
-        );
-        addJSDocComment(item as unknown as any, property);
-        items.push(property);
-
         if (ctx.rootTypes) {
           const componentKey = changeCase.pascalCase(singularizeComponentKey(key));
           let aliasName = `${componentKey}${changeCase.pascalCase(name)}`;
@@ -76,27 +67,47 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
             conflictCounter++;
             aliasName = `${componentKey}${changeCase.pascalCase(name)}_${conflictCounter}`;
           }
-          const ref = ts.factory.createTypeReferenceNode(`components['${key}']['${name}']`);
           if (ctx.rootTypesNoSchemaPrefix && key === "schemas") {
             aliasName = aliasName.replace(componentKey, "");
           }
           const typeAlias = ts.factory.createTypeAliasDeclaration(
-            /* modifiers      */ tsModifiers({ export: true }),
-            /* name           */ aliasName,
-            /* typeParameters */ undefined,
-            /* type           */ ref,
+              /* modifiers      */ tsModifiers({ export: true }),
+              /* name          */ aliasName,
+              /* typeParameters */ undefined,
+              subType,
           );
+
           rootTypeAliases[aliasName] = typeAlias;
+
+          const property = ts.factory.createPropertySignature(
+              /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
+              /* name          */ tsPropertyIndex(name),
+              /* typeParameters */ undefined,
+              /* type          */ ts.factory.createTypeReferenceNode(aliasName),
+          );
+
+          addJSDocComment(item as unknown as any, property);
+          items.push(property);
+
+        } else {
+          const property = ts.factory.createPropertySignature(
+              /* modifiers     */ tsModifiers({ readonly: ctx.immutable }),
+              /* name          */ tsPropertyIndex(name),
+              /* questionToken */ hasQuestionToken ? QUESTION_TOKEN : undefined,
+              /* type          */ subType,
+          );
+          addJSDocComment(item as unknown as any, property);
+          items.push(property);
         }
       }
     }
     type.push(
-      ts.factory.createPropertySignature(
-        /* modifiers     */ undefined,
-        /* name          */ tsPropertyIndex(key),
-        /* questionToken */ undefined,
-        /* type          */ items.length ? ts.factory.createTypeLiteralNode(items) : NEVER,
-      ),
+        ts.factory.createPropertySignature(
+            /* modifiers     */ undefined,
+            /* name          */ tsPropertyIndex(key),
+            /* questionToken */ undefined,
+            /* type          */ items.length ? ts.factory.createTypeLiteralNode(items) : NEVER,
+        ),
     );
 
     debug(`Transformed components → ${key}`, "ts", performance.now() - componentT);
@@ -112,13 +123,13 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 }
 
 export function singularizeComponentKey(
-  key: `x-${string}` | "schemas" | "responses" | "parameters" | "requestBodies" | "headers" | "pathItems",
+    key: `x-${string}` | "schemas" | "responses" | "parameters" | "requestBodies" | "headers" | "pathItems",
 ): string {
   switch (key) {
-    // Handle special singular case
+      // Handle special singular case
     case "requestBodies":
       return "requestBody";
-    // Default to removing the "s"
+      // Default to removing the "s"
     default:
       return key.slice(0, -1);
   }

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -581,121 +581,121 @@ describe("transformComponentsObject", () => {
         },
         want: `{
     schemas: {
-        SomeType: {
-            name: string;
-            url: string;
-        };
-        "Some-Type": {
-            name: string;
-            url: string;
-        };
-        "Some.Type": {
-            name: string;
-            url: string;
-        };
-        "Some/Type": {
-            name: string;
-            url: string;
-        };
-        "1Type": {
-            value: string;
-        };
-        Error: {
-            code: string;
-            message: string;
-        };
+        SomeType: SchemaSomeType;
+        "Some-Type": SchemaSomeType_2;
+        "Some.Type": SchemaSomeType_3;
+        "Some/Type": SchemaSomeType_4;
+        "1Type": Schema1Type;
+        Error: SchemaError;
     };
     responses: {
         /** @description OK */
-        OK: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "text/html": string;
-            };
-        };
+        OK: ResponseOk;
         /** @description No Content */
-        NoContent: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content?: never;
-        };
-        ErrorResponse: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["Error"];
-            };
-        };
-        SomeType: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["SomeType"];
-            };
-        };
+        NoContent: ResponseNoContent;
+        ErrorResponse: ResponseErrorResponse;
+        SomeType: ResponseSomeType;
     };
     parameters: {
-        Search: string;
+        Search: ParameterSearch;
     };
     requestBodies: {
-        UploadUser: {
-            content: {
-                "application/json": {
-                    email: string;
-                };
-            };
-        };
+        UploadUser: RequestBodyUploadUser;
     };
     headers: {
-        Auth: string;
+        Auth: HeaderAuth;
     };
     pathItems: {
-        UploadUser: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            get: {
-                parameters: {
-                    query?: never;
-                    header?: never;
-                    path?: never;
-                    cookie?: never;
-                };
-                requestBody?: components["requestBodies"]["UploadUser"];
-                responses: never;
-            };
-            put?: never;
-            post?: never;
-            delete?: never;
-            options?: never;
-            head?: never;
-            patch?: never;
-            trace?: never;
-        };
+        UploadUser: PathItemUploadUser;
     };
 }
-export type SchemaSomeType = components['schemas']['SomeType'];
-export type SchemaSomeType_2 = components['schemas']['Some-Type'];
-export type SchemaSomeType_3 = components['schemas']['Some.Type'];
-export type SchemaSomeType_4 = components['schemas']['Some/Type'];
-export type Schema1Type = components['schemas']['1Type'];
-export type SchemaError = components['schemas']['Error'];
-export type ResponseOk = components['responses']['OK'];
-export type ResponseNoContent = components['responses']['NoContent'];
-export type ResponseErrorResponse = components['responses']['ErrorResponse'];
-export type ResponseSomeType = components['responses']['SomeType'];
-export type ParameterSearch = components['parameters']['Search'];
-export type RequestBodyUploadUser = components['requestBodies']['UploadUser'];
-export type HeaderAuth = components['headers']['Auth'];
-export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
+export type SchemaSomeType = {
+    name: string;
+    url: string;
+};
+export type SchemaSomeType_2 = {
+    name: string;
+    url: string;
+};
+export type SchemaSomeType_3 = {
+    name: string;
+    url: string;
+};
+export type SchemaSomeType_4 = {
+    name: string;
+    url: string;
+};
+export type Schema1Type = {
+    value: string;
+};
+export type SchemaError = {
+    code: string;
+    message: string;
+};
+export type ResponseOk = {
+    headers: {
+        [name: string]: unknown;
+    };
+    content: {
+        "text/html": string;
+    };
+};
+export type ResponseNoContent = {
+    headers: {
+        [name: string]: unknown;
+    };
+    content?: never;
+};
+export type ResponseErrorResponse = {
+    headers: {
+        [name: string]: unknown;
+    };
+    content: {
+        "application/json": components["schemas"]["Error"];
+    };
+};
+export type ResponseSomeType = {
+    headers: {
+        [name: string]: unknown;
+    };
+    content: {
+        "application/json": components["schemas"]["SomeType"];
+    };
+};
+export type ParameterSearch = string;
+export type RequestBodyUploadUser = {
+    content: {
+        "application/json": {
+            email: string;
+        };
+    };
+};
+export type HeaderAuth = string;
+export type PathItemUploadUser = {
+    parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+    };
+    get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: components["requestBodies"]["UploadUser"];
+        responses: never;
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+};`,
         options: { ...DEFAULT_OPTIONS, rootTypes: true },
       },
     ],
@@ -733,19 +733,9 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
         },
         want: `{
     schemas: {
-        Item: {
-            name: string;
-            url: string;
-        };
-        Document: {
-            name: string;
-            size: number;
-            url: string;
-        };
-        Error: {
-            code: string;
-            message: string;
-        };
+        Item: Item;
+        Document: Document;
+        Error: Error;
     };
     responses: never;
     parameters: never;
@@ -753,9 +743,19 @@ export type PathItemUploadUser = components['pathItems']['UploadUser'];`,
     headers: never;
     pathItems: never;
 }
-export type Item = components['schemas']['Item'];
-export type Document = components['schemas']['Document'];
-export type Error = components['schemas']['Error'];
+export type Item = {
+    name: string;
+    url: string;
+};
+export type Document = {
+    name: string;
+    size: number;
+    url: string;
+};
+export type Error = {
+    code: string;
+    message: string;
+};
 `,
         options: { ...DEFAULT_OPTIONS, rootTypes: true, rootTypesNoSchemaPrefix: true },
       },
@@ -858,16 +858,16 @@ export type Error = components['schemas']['Error'];
 
   for (const [testName, { given, want, options, ci }] of tests) {
     test.skipIf(ci?.skipIf)(
-      testName,
-      async () => {
-        const result = astToString(transformComponentsObject(given, options ?? DEFAULT_OPTIONS));
-        if (want instanceof URL) {
-          expect(result).toMatchFileSnapshot(fileURLToPath(want));
-        } else {
-          expect(result.trim()).toBe(want.trim());
-        }
-      },
-      ci?.timeout,
+        testName,
+        async () => {
+          const result = astToString(transformComponentsObject(given, options ?? DEFAULT_OPTIONS));
+          if (want instanceof URL) {
+            expect(result).toMatchFileSnapshot(fileURLToPath(want));
+          } else {
+            expect(result.trim()).toBe(want.trim());
+          }
+        },
+        ci?.timeout,
     );
   }
 });

--- a/packages/openapi-typescript/test/transform/components-object.test.ts
+++ b/packages/openapi-typescript/test/transform/components-object.test.ts
@@ -858,16 +858,16 @@ export type Error = {
 
   for (const [testName, { given, want, options, ci }] of tests) {
     test.skipIf(ci?.skipIf)(
-        testName,
-        async () => {
-          const result = astToString(transformComponentsObject(given, options ?? DEFAULT_OPTIONS));
-          if (want instanceof URL) {
-            expect(result).toMatchFileSnapshot(fileURLToPath(want));
-          } else {
-            expect(result.trim()).toBe(want.trim());
-          }
-        },
-        ci?.timeout,
+      testName,
+      async () => {
+        const result = astToString(transformComponentsObject(given, options ?? DEFAULT_OPTIONS));
+        if (want instanceof URL) {
+          expect(result).toMatchFileSnapshot(fileURLToPath(want));
+        } else {
+          expect(result.trim()).toBe(want.trim());
+        }
+      },
+      ci?.timeout,
     );
   }
 });


### PR DESCRIPTION
## Changes

This PR implements the changes proposed in:
- #2033

Instead of inlining objects into `components` and exporting a type alias, we are now exporting the inlined object (technically still a type alias) and reference it from `components`.

This should be a backwards compatible change, but if you prefer, we could use a new cli arg too.

fixes #2033 

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

I don’t think a docs update is necessary as this PR only changes an implementation detail on how types are exported; it should be non-breaking for users.

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
