### PR TITLE
Add schema to postTransform options

### DIFF
--- a/.changeset/four-worms-leave.md
+++ b/.changeset/four-worms-leave.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Add schema to postTransform options

--- a/docs/6.x/node.md
+++ b/docs/6.x/node.md
@@ -122,6 +122,16 @@ Resultant diff with correctly-typed `file` property:
 +    file?: Blob;
 ```
 
-Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through this formatter (even remote ones!). Also be sure to check the `metadata` parameter for additional context that may be helpful.
+#### transform / postTransform metadata
 
-There are many other uses for this besides checking `format`. Because this must return a **string** you can produce any arbitrary TypeScript code you’d like (even your own custom types).
+Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through `transform`, prior to its conversion to a TypeScript AST node, and `postTransform` after its conversion, including remote schemas!
+
+The `metadata` parameter present on both `transform` and `postTransform` has additional context that may be helpful.
+
+| Property | Description |
+|-|-|
+| `metadata.path` | A [`$ref`](https://json-schema.org/understanding-json-schema/structuring#dollarref) URI string, pointing to the current schema object |
+| `metadata.schema` | The schema object being transformed (only present for `postTransform`) |
+| `metadata.ctx` | The GlobalContext object, containing
+
+There are many other uses for this besides checking `format`. Because `tranform` may return a **string** you can produce any arbitrary TypeScript code you’d like (even your own custom types).

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -34,16 +34,18 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 
     const items: ts.TypeElement[] = [];
     if (componentsObject[key]) {
-      for (const [name, item] of getEntries(componentsObject[key], ctx)) {
+      for (const [name, item] of getEntries<SchemaObject>(componentsObject[key], ctx)) {
         let subType = transformers[key](item, {
           path: createRef(["components", key, name]),
+          schema: item,
           ctx,
         });
 
         let hasQuestionToken = false;
         if (ctx.transform) {
-          const result = ctx.transform(item as SchemaObject, {
+          const result = ctx.transform(item, {
             path: createRef(["components", key, name]),
+            schema: item,
             ctx,
           });
           if (result) {

--- a/packages/openapi-typescript/src/transform/index.ts
+++ b/packages/openapi-typescript/src/transform/index.ts
@@ -14,7 +14,7 @@ const transformers: Record<SchemaTransforms, (node: any, options: GlobalContext)
   paths: transformPathsObject,
   webhooks: transformWebhooksObject,
   components: transformComponentsObject,
-  $defs: (node, options) => transformSchemaObject(node, { path: createRef(["$defs"]), ctx: options }),
+  $defs: (node, options) => transformSchemaObject(node, { path: createRef(["$defs"]), ctx: options, schema: node }),
 };
 
 export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -707,5 +707,6 @@ export type $defs = Record<string, SchemaObject>;
 /** generic options for most internal transform* functions */
 export interface TransformNodeOptions {
   path?: string;
+  schema?: SchemaObject | ReferenceObject;
   ctx: GlobalContext;
 }

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -538,7 +538,7 @@ export type operations = Record<string, never>;`,
             schemas: {
               Date: { type: "string", format: "date-time" },
               Set: {
-                ["x-string-enum-to-set"]: true,
+                "x-string-enum-to-set": true,
                 type: "string",
                 enum: ["low", "medium", "high"],
               },
@@ -592,18 +592,13 @@ export type operations = Record<string, never>;`,
                 return typeof enumMember === "string";
               })
             ) {
-              return ts.factory.createTypeReferenceNode(
-                ts.factory.createIdentifier("Set"),
-                [
-                  ts.factory.createUnionTypeNode(
-                    schema.enum.map((value) => {
-                      return ts.factory.createLiteralTypeNode(
-                        ts.factory.createStringLiteral(value)
-                      );
-                    })
-                  ),
-                ]
-              );
+              return ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Set"), [
+                ts.factory.createUnionTypeNode(
+                  schema.enum.map((value) => {
+                    return ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(value));
+                  }),
+                ),
+              ]);
             }
           },
         },

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -570,9 +570,7 @@ export type operations = Record<string, never>;`,
                * then use the `typescript` parser and it will tell you the desired
                * AST
                */
-              return ts.factory.createTypeReferenceNode(
-                ts.factory.createIdentifier("DateOrTime")
-              );
+              return ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("DateOrTime"));
             }
 
             // Previously, in order to access the schema in postTransform,


### PR DESCRIPTION
Closes #2013

## Changes

* [x] Add `schema` to `postTransform` options
* [x] Add documentation about `postTransform` options
* [x] Add specs / example using the `schema` option to declare a string Set

## How to Review

* Make sure `TransformNodeOptions` is extension is acceptable.
* Decide whether `schema` should be populated for `transform` options; it's redundant since the first argument to transform is already the schema node, but it introduces consistency between the `transform` and `postTrannsform` APIs that I think might be desirable.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript) (I tried this and got swamped with changes, please advise!)
