### PR TITLE
Fix colliding enumValues exports

### DIFF
--- a/.changeset/four-worms-leave.md
+++ b/.changeset/four-worms-leave.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Add schema to postTransform options

--- a/.changeset/four-worms-leave.md
+++ b/.changeset/four-worms-leave.md
@@ -1,5 +1,0 @@
----
-"openapi-typescript": patch
----
-
-Add schema to postTransform options

--- a/.changeset/shaggy-impalas-develop.md
+++ b/.changeset/shaggy-impalas-develop.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": major
+---
+
+Export enumValues as const arrays. Derive schema types from literal values.

--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
@@ -6,18 +6,21 @@ labels:
   - triage
 body:
   - type: input
+    id: version
     attributes:
       label: openapi-typescript version
       placeholder: x.x.x
     validations:
       required: true
   - type: input
+    id: node
     attributes:
       label: Node.js version
       placeholder: 20.x.x
     validations:
       required: true
   - type: input
+    id: os
     attributes:
       label: OS + version
       placeholder: macOS 15.1.1
@@ -45,14 +48,14 @@ body:
       required: true
   - type: checkboxes
     id: required
-    label: Required
     attributes:
+      label: Required
       options:
         - label: My OpenAPI schema is valid and passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
           required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
@@ -1,6 +1,5 @@
 name: "openapi-typescript: Feature request"
 description: Propose new functionality or a breaking change
-title: ""
 labels:
   - openapi-ts
   - enhancement
@@ -21,7 +20,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
@@ -3,6 +3,8 @@ description: Propose new functionality or a breaking change
 labels:
   - openapi-ts
   - enhancement
+projects:
+  - openapi-ts/2
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
@@ -6,8 +6,9 @@ labels:
   - triage
 body:
   - type: input
+    id: version
     attributes:
-      label: Version
+      label: openapi-fetch version
       placeholder: x.x.x
     validations:
       required: true
@@ -33,7 +34,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
@@ -3,6 +3,8 @@ description: Propose new functionality or a breaking change
 labels:
   - openapi-fetch
   - enhancement
+projects:
+  - openapi-ts/3
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
@@ -1,6 +1,5 @@
 name: "openapi-fetch: Feature request"
 description: Propose new functionality or a breaking change
-title: ""
 labels:
   - openapi-fetch
   - enhancement
@@ -21,7 +20,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
@@ -6,8 +6,9 @@ labels:
   - triage
 body:
   - type: input
+    id: version
     attributes:
-      label: Version
+      label: openapi-react-query version
       placeholder: x.x.x
     validations:
       required: true
@@ -26,6 +27,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: expected
     attributes:
       label: Expected result
       description: (In case it’s not obvious)
@@ -33,7 +35,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
@@ -1,6 +1,5 @@
 name: "openapi-react-query: Feature request"
 description: Propose new functionality or a breaking change
-title: ""
 labels:
   - openapi-react-query
   - enhancement
@@ -21,7 +20,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
@@ -5,8 +5,9 @@ labels:
   - bug
 body:
   - type: input
+    id: version
     attributes:
-      label: Version
+      label: swr-openapi version
       placeholder: x.x.x
     validations:
       required: true
@@ -25,6 +26,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: expected
     attributes:
       label: Expected result
       description: (In case it’s not obvious)
@@ -32,7 +34,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
@@ -1,6 +1,5 @@
 name: "swr-openapi: Feature request"
 description: Propose new functionality or a breaking change
-title: ""
 labels:
   - swr-openapi
   - enhancement
@@ -21,7 +20,7 @@ body:
       required: true
   - type: checkboxes
     id: extra
-    label: Extra
     attributes:
+      label: Extra
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,7 +4,7 @@ import zh from "./zh";
 import ja from "./ja";
 import shared from "./shared";
 import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
-import { ModuleKind, ModuleResolutionKind } from "typescript";
+import { ModuleResolutionKind } from "typescript";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -139,7 +139,7 @@ export default defineConfig({
     ],
     footer: {
       message:
-        'Released under the <a href="https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT License</a>.',
+        'Released under the <a href="https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/LICENSE">MIT License</a>. Powered by <a href="https://netlify.com">Netlify</a>.',
     },
   },
 });

--- a/docs/.vitepress/shared.ts
+++ b/docs/.vitepress/shared.ts
@@ -26,7 +26,7 @@ const shared: UserConfig = {
   themeConfig: {
     siteTitle: false,
     logo: "/assets/openapi-ts.svg",
-    outline: 'deep',
+    outline: "deep",
     search: {
       provider: "algolia",
       options: {

--- a/docs/.vitepress/theme/CustomLayout.vue
+++ b/docs/.vitepress/theme/CustomLayout.vue
@@ -39,7 +39,7 @@ const { Layout } = DefaultTheme;
       </a></template
     >
 
-    <!-- Silver sponsor logos -->
+    <!-- Sidebar sponsors -->
     <template #sidebar-nav-after>
       <div class="sidenav-sponsors">
         <h5>Gold Sponsors</h5>
@@ -58,6 +58,9 @@ const { Layout } = DefaultTheme;
             </a>
           </li>
         </ul>
+        <p class="sidebar-hosting">
+          Powered by <a href="https://netlify.com">Netlify</a>
+        </p>
       </div>
     </template>
   </Layout>
@@ -146,6 +149,25 @@ const { Layout } = DefaultTheme;
 .sponsor-list--silver img {
   height: 3rem;
   width: auto;
+}
+
+.sidebar-hosting {
+  color: var(--vp-c-text-3);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.0625em;
+  margin-block-start: 2rem;
+  text-transform: uppercase;
+
+  a {
+    color: var(--vp-c-brand-1);
+    text-decoration: underline;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--vp-c-brand-2);
+    }
+  }
 }
 </style>
 

--- a/docs/6.x/node.md
+++ b/docs/6.x/node.md
@@ -122,6 +122,16 @@ Resultant diff with correctly-typed `file` property:
 +    file?: Blob;
 ```
 
-Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through this formatter (even remote ones!). Also be sure to check the `metadata` parameter for additional context that may be helpful.
+#### transform / postTransform metadata
 
-There are many other uses for this besides checking `format`. Because this must return a **string** you can produce any arbitrary TypeScript code you’d like (even your own custom types).
+Any [Schema Object](https://spec.openapis.org/oas/latest.html#schema-object) present in your schema will be run through `transform`, prior to its conversion to a TypeScript AST node, and `postTransform` after its conversion, including remote schemas!
+
+The `metadata` parameter present on both `transform` and `postTransform` has additional context that may be helpful.
+
+| Property | Description |
+|-|-|
+| `metadata.path` | A [`$ref`](https://json-schema.org/understanding-json-schema/structuring#dollarref) URI string, pointing to the current schema object |
+| `metadata.schema` | The schema object being transformed (only present for `postTransform`) |
+| `metadata.ctx` | The GlobalContext object, containing
+
+There are many other uses for this besides checking `format`. Because `tranform` may return a **string** you can produce any arbitrary TypeScript code you’d like (even your own custom types).

--- a/packages/openapi-typescript/CHANGELOG.md
+++ b/packages/openapi-typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openapi-typescript
 
+## 7.5.1
+
+### Patch Changes
+
+- [#2049](https://github.com/openapi-ts/openapi-typescript/pull/2049) [`39f9b2f`](https://github.com/openapi-ts/openapi-typescript/commit/39f9b2fb913eb13817592b22f1bbe35de1bc4c33) Thanks [@duncanbeevers](https://github.com/duncanbeevers)! - Add schema to postTransform options
+
 ## 7.5.0
 
 ### Minor Changes

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -3,6 +3,9 @@
  * Do not make direct changes to the file.
  */
 
+type WithRequired<T, K extends keyof T> = T & {
+    [P in K]-?: T[P];
+};
 export interface paths {
     "/v2/1-clicks": {
         parameters: {
@@ -28798,6 +28801,3 @@ export interface operations {
         };
     };
 }
-type WithRequired<T, K extends keyof T> = T & {
-    [P in K]-?: T[P];
-};

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -81,7 +81,7 @@ export default async function openapiTS(
     immutable: options.immutable ?? false,
     rootTypes: options.rootTypes ?? false,
     rootTypesNoSchemaPrefix: options.rootTypesNoSchemaPrefix ?? false,
-    injectFooter: [],
+    injectNodes: [],
     pathParamsAsTypes: options.pathParamsAsTypes ?? false,
     postTransform: typeof options.postTransform === "function" ? options.postTransform : undefined,
     propertiesRequiredByDefault: options.propertiesRequiredByDefault ?? false,

--- a/packages/openapi-typescript/src/transform/components-object.ts
+++ b/packages/openapi-typescript/src/transform/components-object.ts
@@ -34,16 +34,18 @@ export default function transformComponentsObject(componentsObject: ComponentsOb
 
     const items: ts.TypeElement[] = [];
     if (componentsObject[key]) {
-      for (const [name, item] of getEntries(componentsObject[key], ctx)) {
+      for (const [name, item] of getEntries<SchemaObject>(componentsObject[key], ctx)) {
         let subType = transformers[key](item, {
           path: createRef(["components", key, name]),
+          schema: item,
           ctx,
         });
 
         let hasQuestionToken = false;
         if (ctx.transform) {
-          const result = ctx.transform(item as SchemaObject, {
+          const result = ctx.transform(item, {
             path: createRef(["components", key, name]),
+            schema: item,
             ctx,
           });
           if (result) {

--- a/packages/openapi-typescript/src/transform/index.ts
+++ b/packages/openapi-typescript/src/transform/index.ts
@@ -15,7 +15,7 @@ const transformers: Record<SchemaTransforms, (node: any, options: GlobalContext)
   paths: transformPathsObject,
   webhooks: transformWebhooksObject,
   components: transformComponentsObject,
-  $defs: (node, options) => transformSchemaObject(node, { path: createRef(["$defs"]), ctx: options }),
+  $defs: (node, options) => transformSchemaObject(node, { path: createRef(["$defs"]), ctx: options, schema: node }),
 };
 
 export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {

--- a/packages/openapi-typescript/src/transform/index.ts
+++ b/packages/openapi-typescript/src/transform/index.ts
@@ -1,4 +1,4 @@
-import ts, { type InterfaceDeclaration, type TypeLiteralNode } from "typescript";
+import ts, { type TypeLiteralNode } from "typescript";
 import { performance } from "node:perf_hooks";
 import { NEVER, STRING, stringToAST, tsModifiers, tsRecord } from "../lib/ts.js";
 import { createRef, debug } from "../lib/utils.js";
@@ -18,14 +18,16 @@ const transformers: Record<SchemaTransforms, (node: any, options: GlobalContext)
   $defs: (node, options) => transformSchemaObject(node, { path: createRef(["$defs"]), ctx: options, schema: node }),
 };
 
+function isOperationsInterfaceNode(node: ts.Node) {
+  const interfaceDeclaration = ts.isInterfaceDeclaration(node) ? node : undefined;
+  return interfaceDeclaration?.name.escapedText === "operations";
+}
+
 export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {
-  const type: ts.Node[] = [];
+  const schemaNodes: ts.Node[] = [];
 
-  if (ctx.inject) {
-    const injectNodes = stringToAST(ctx.inject) as ts.Node[];
-    type.push(...injectNodes);
-  }
-
+  // Traverse the schema root elements, gathering type information and accumulating
+  // supporting nodes in `cts.injectNodes`.
   for (const root of Object.keys(transformers) as SchemaTransforms[]) {
     const emptyObj = ts.factory.createTypeAliasDeclaration(
       /* modifiers      */ tsModifiers({ export: true }),
@@ -40,7 +42,7 @@ export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {
       for (const subType of subTypes) {
         if (ts.isTypeNode(subType)) {
           if ((subType as ts.TypeLiteralNode).members?.length) {
-            type.push(
+            schemaNodes.push(
               ctx.exportType
                 ? ts.factory.createTypeAliasDeclaration(
                     /* modifiers      */ tsModifiers({ export: true }),
@@ -58,45 +60,44 @@ export default function transformSchema(schema: OpenAPI3, ctx: GlobalContext) {
             );
             debug(`${root} done`, "ts", performance.now() - rootT);
           } else {
-            type.push(emptyObj);
+            schemaNodes.push(emptyObj);
             debug(`${root} done (skipped)`, "ts", 0);
           }
         } else if (ts.isTypeAliasDeclaration(subType)) {
-          type.push(subType);
+          schemaNodes.push(subType);
         } else {
-          type.push(emptyObj);
+          schemaNodes.push(emptyObj);
           debug(`${root} done (skipped)`, "ts", 0);
         }
       }
     } else {
-      type.push(emptyObj);
+      schemaNodes.push(emptyObj);
       debug(`${root} done (skipped)`, "ts", 0);
     }
   }
 
-  // inject
-  let hasOperations = false;
-  for (const injectedType of ctx.injectFooter) {
-    if (!hasOperations && (injectedType as InterfaceDeclaration)?.name?.escapedText === "operations") {
-      hasOperations = true;
-    }
-    type.push(injectedType);
-  }
-  if (!hasOperations) {
-    // if no operations created, inject empty operations type
-    type.push(
-      ts.factory.createTypeAliasDeclaration(
+  // Identify any operations node that was injected during traversal
+  const operationsNodeIndex = ctx.injectNodes.findIndex(isOperationsInterfaceNode);
+  const hasOperations = operationsNodeIndex !== -1;
+  const operationsNode = hasOperations
+    ? ctx.injectNodes.at(operationsNodeIndex)
+    : ts.factory.createTypeAliasDeclaration(
         /* modifiers      */ tsModifiers({ export: true }),
         /* name           */ "operations",
         /* typeParameters */ undefined,
         /* type           */ tsRecord(STRING, NEVER),
-      ),
-    );
-  }
+      );
 
-  if (ctx.makePathsEnum && schema.paths) {
-    type.push(makeApiPathsEnum(schema.paths));
-  }
-
-  return type;
+  return [
+    // Inject user-defined header
+    ...(ctx.inject ? (stringToAST(ctx.inject) as ts.Node[]) : []),
+    // Inject gathered values and types, except operations
+    ...ctx.injectNodes.filter((node) => node !== operationsNode),
+    // Inject schema
+    ...schemaNodes,
+    // Inject operations
+    ...(operationsNode ? [operationsNode] : []),
+    // Inject paths enum
+    ...(ctx.makePathsEnum && schema.paths ? [makeApiPathsEnum(schema.paths)] : []),
+  ];
 }

--- a/packages/openapi-typescript/src/transform/operation-object.ts
+++ b/packages/openapi-typescript/src/transform/operation-object.ts
@@ -72,7 +72,7 @@ export function injectOperationObject(
   options: TransformNodeOptions,
 ): void {
   // find or create top-level operations interface
-  let operations = options.ctx.injectFooter.find(
+  let operations = options.ctx.injectNodes.find(
     (node) => ts.isInterfaceDeclaration(node) && (node as ts.InterfaceDeclaration).name.text === "operations",
   ) as unknown as ts.InterfaceDeclaration;
   if (!operations) {
@@ -86,7 +86,7 @@ export function injectOperationObject(
       /* heritageClauses */ undefined,
       /* members         */ [],
     );
-    options.ctx.injectFooter.push(operations);
+    options.ctx.injectNodes.push(operations);
   }
 
   // inject operation object

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -710,5 +710,6 @@ export type $defs = Record<string, SchemaObject>;
 /** generic options for most internal transform* functions */
 export interface TransformNodeOptions {
   path?: string;
+  schema?: SchemaObject | ReferenceObject;
   ctx: GlobalContext;
 }

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -690,7 +690,7 @@ export interface GlobalContext {
   excludeDeprecated: boolean;
   exportType: boolean;
   immutable: boolean;
-  injectFooter: ts.Node[];
+  injectNodes: ts.Node[];
   pathParamsAsTypes: boolean;
   postTransform: OpenAPITSOptions["postTransform"];
   propertiesRequiredByDefault: boolean;

--- a/packages/openapi-typescript/test/cjs.test.js
+++ b/packages/openapi-typescript/test/cjs.test.js
@@ -14,7 +14,7 @@ describe("CJS bundle", () => {
  */
 
 ${astToString(await openapiTS(new URL("../examples/stripe-api.yaml", import.meta.url)))}`;
-      expect(output).toMatchFileSnapshot(fileURLToPath(new URL("../examples/stripe-api.ts", import.meta.url)));
+      await expect(output).toMatchFileSnapshot(fileURLToPath(new URL("../examples/stripe-api.ts", import.meta.url)));
     },
     { timeout: TIMEOUT },
   );

--- a/packages/openapi-typescript/test/cli.test.ts
+++ b/packages/openapi-typescript/test/cli.test.ts
@@ -84,7 +84,7 @@ describe("CLI", () => {
       async () => {
         const { stdout } = await execa(cmd, given, { cwd });
         if (want instanceof URL) {
-          expect(stdout).toMatchFileSnapshot(fileURLToPath(want));
+          await expect(stdout).toMatchFileSnapshot(fileURLToPath(want));
         } else {
           expect(stdout).toBe(`${want}\n`);
         }
@@ -145,7 +145,7 @@ describe("CLI", () => {
         cwd,
       });
       for (const schema of ["a", "b", "c"]) {
-        expect(
+        await expect(
           fs.readFileSync(new URL(`./test/fixtures/redocly-flag/output/${schema}.ts`, root), "utf8"),
         ).toMatchFileSnapshot(fileURLToPath(new URL("./examples/simple-example.ts", root)));
       }

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -636,7 +636,10 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export type paths = Record<string, never>;
+        want: `type WithRequired<T, K extends keyof T> = T & {
+    [P in K]-?: T[P];
+};
+export type paths = Record<string, never>;
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
@@ -661,9 +664,6 @@ export interface components {
     pathItems: never;
 }
 export type $defs = Record<string, never>;
-type WithRequired<T, K extends keyof T> = T & {
-    [P in K]-?: T[P];
-};
 export type operations = Record<string, never>;`,
         // options: DEFAULT_OPTIONS,
       },

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -228,27 +228,64 @@ describe("tsArrayLiteralExpression", () => {
       astToString(
         tsArrayLiteralExpression("-my-color-Values", oapiRef("#/components/schemas/Color"), ["green", "red", "blue"]),
       ).trim(),
-    ).toBe(`const myColorValues: components["schemas"]["Color"][] = ["green", "red", "blue"];`);
+    ).toBe(`const MyColorValues: components["schemas"]["Color"][] = ["green", "red", "blue"];`);
   });
 
   test("with setting: export", () => {
     expect(
       astToString(
-        tsArrayLiteralExpression("-my-color-Values", oapiRef("#/components/schemas/Color"), ["green", "red", "blue"], {
-          export: true,
-        }),
+        tsArrayLiteralExpression(
+          "-my-color-Values",
+          oapiRef("#/components/schemas/Color"),
+          ["green", "red", "blue"],
+          undefined,
+          {
+            export: true,
+          },
+        ),
       ).trim(),
-    ).toBe(`export const myColorValues: components["schemas"]["Color"][] = ["green", "red", "blue"];`);
+    ).toBe(`export const MyColorValues: components["schemas"]["Color"][] = ["green", "red", "blue"];`);
   });
 
   test("with setting: readonly", () => {
     expect(
       astToString(
-        tsArrayLiteralExpression("-my-color-Values", oapiRef("#/components/schemas/Color"), ["green", "red", "blue"], {
-          readonly: true,
-        }),
+        tsArrayLiteralExpression(
+          "-my-color-Values",
+          oapiRef("#/components/schemas/Color"),
+          ["green", "red", "blue"],
+          undefined,
+          {
+            readonly: true,
+          },
+        ),
       ).trim(),
-    ).toBe(`const myColorValues: ReadonlyArray<components["schemas"]["Color"]> = ["green", "red", "blue"];`);
+    ).toBe(`const MyColorValues: ReadonlyArray<components["schemas"]["Color"]> = ["green", "red", "blue"];`);
+  });
+
+  test("with metadata: name", () => {
+    expect(
+      astToString(
+        tsArrayLiteralExpression(
+          "-my-color-Values",
+          oapiRef("#/components/schemas/Color"),
+          ["green", "red", "blue"],
+          [{ description: "Healthy" }, { description: "Unhealthy" }, { description: "Booting" }],
+        ),
+      ).trim(),
+    ).toBe(`const MyColorValues: components["schemas"]["Color"][] = [
+    // Healthy
+    "green", 
+    // Unhealthy
+    "red", 
+    // Booting
+    "blue"];`);
+  });
+
+  test("with no element type", () => {
+    expect(astToString(tsArrayLiteralExpression("-my-color-Values", undefined, ["green", "red", "blue"])).trim()).toBe(
+      `const MyColorValues = ["green", "red", "blue"] as const;`,
+    );
   });
 
   test("name from path", () => {
@@ -260,7 +297,7 @@ describe("tsArrayLiteralExpression", () => {
           ["active", "inactive"],
         ),
       ).trim(),
-    ).toBe(`const pathsUrlGetParametersQueryStatusValues: components["schemas"]["Status"][] = ["active", "inactive"];`);
+    ).toBe(`const PathsUrlGetParametersQueryStatusValues: components["schemas"]["Status"][] = ["active", "inactive"];`);
   });
 
   test("number members", () => {
@@ -272,7 +309,7 @@ describe("tsArrayLiteralExpression", () => {
           [100, 101, 102, -100],
         ),
       ).trim(),
-    ).toBe(`const errorCodeValues: components["schemas"]["ErrorCode"][] = [100, 101, 102, -100];`);
+    ).toBe(`const ErrorCodeValues: components["schemas"]["ErrorCode"][] = [100, 101, 102, -100];`);
   });
 });
 

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -623,12 +623,45 @@ export type operations = Record<string, never>;`,
                 ],
               },
             },
+            "/url2": {
+              get: {
+                parameters: [
+                  {
+                    name: "status",
+                    in: "query",
+                    schema: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          enum: ["approved", "rejected"],
+                        },
+                        {
+                          type: "string",
+                          enum: ["appealed"],
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
           },
           components: {
             schemas: {
               Status: {
                 type: "string",
                 enum: ["active", "inactive"],
+              },
+              ModeratedStatus: {
+                anyOf: [
+                  {
+                    $ref: "#/components/schemas/Status",
+                  },
+                  {
+                    type: "string",
+                    enum: ["appealed"],
+                  },
+                ],
               },
               ErrorCode: {
                 type: "number",
@@ -657,63 +690,23 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export interface paths {
-    "/url": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: {
-                    status?: PathsUrlGetParametersQueryStatus;
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-}
-export type webhooks = Record<string, never>;
-export interface components {
-    schemas: {
-        /** @enum {string} */
-        Status: Status;
-        /** @enum {number} */
-        ErrorCode: ErrorCode;
-        /** @enum {number} */
-        XEnumVarnames: XEnumVarnames;
-        /** @enum {number} */
-        XEnumNames: XEnumNames;
-        /** @enum {string} */
-        InvalidPropertyNameChars: InvalidPropertyNameChars;
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
-}
-export type $defs = Record<string, never>;
-export enum PathsUrlGetParametersQueryStatus {
+        want: `export enum PathsUrlGetParametersQueryStatus {
     active = "active",
     inactive = "inactive"
+}
+export enum PathsUrl2GetParametersQueryStatusAnyOf0 {
+    approved = "approved",
+    rejected = "rejected"
+}
+export enum PathsUrl2GetParametersQueryStatusAnyOf1 {
+    appealed = "appealed"
 }
 export enum Status {
     active = "active",
     inactive = "inactive"
+}
+export enum ModeratedStatusAnyOf1 {
+    appealed = "appealed"
 }
 export enum ErrorCode {
     Value100 = 100,
@@ -747,6 +740,84 @@ export enum InvalidPropertyNameChars {
     "^" = "^",
     TE_ST = "TE=ST"
 }
+export interface paths {
+    "/url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    status?: PathsUrlGetParametersQueryStatus;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/url2": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    status?: PathsUrl2GetParametersQueryStatusAnyOf0 | PathsUrl2GetParametersQueryStatusAnyOf1;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /** @enum {string} */
+        Status: Status;
+        ModeratedStatus: components["schemas"]["Status"] | ModeratedStatusAnyOf1;
+        /** @enum {number} */
+        ErrorCode: ErrorCode;
+        /** @enum {number} */
+        XEnumVarnames: XEnumVarnames;
+        /** @enum {number} */
+        XEnumNames: XEnumNames;
+        /** @enum {string} */
+        InvalidPropertyNameChars: InvalidPropertyNameChars;
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
 export type operations = Record<string, never>;`,
         options: { enum: true },
       },
@@ -772,12 +843,43 @@ export type operations = Record<string, never>;`,
                 ],
               },
             },
+            "/url2": {
+              get: {
+                parameters: [
+                  {
+                    name: "status",
+                    in: "query",
+                    schema: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          enum: ["approved", "rejected"],
+                        },
+                        {
+                          type: "string",
+                          enum: ["appealed"],
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
           },
           components: {
             schemas: {
               Status: {
-                type: "string",
-                enum: ["active", "inactive"],
+                anyOf: [
+                  {
+                    type: "string",
+                    enum: ["active", "inactive"],
+                  },
+                  {
+                    type: "string",
+                    deprecated: true,
+                    enum: ["pending"],
+                  },
+                ],
               },
               ErrorCode: {
                 type: "number",
@@ -786,7 +888,19 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export interface paths {
+        want: `export const pathsUrlGetParametersQueryStatusValues = ["active", "inactive"] as const;
+export type pathsUrlGetParametersQueryStatus = (typeof pathsUrlGetParametersQueryStatusValues)[number];
+export const pathsUrl2GetParametersQueryStatusAnyOf0Values = ["approved", "rejected"] as const;
+export type pathsUrl2GetParametersQueryStatusAnyOf0 = (typeof pathsUrl2GetParametersQueryStatusAnyOf0Values)[number];
+export const pathsUrl2GetParametersQueryStatusAnyOf1Values = ["appealed"] as const;
+export type pathsUrl2GetParametersQueryStatusAnyOf1 = (typeof pathsUrl2GetParametersQueryStatusAnyOf1Values)[number];
+export const StatusAnyOf0Values = ["active", "inactive"] as const;
+export type StatusAnyOf0 = (typeof StatusAnyOf0Values)[number];
+export const StatusAnyOf1Values = ["pending"] as const;
+export type StatusAnyOf1 = (typeof StatusAnyOf1Values)[number];
+export const ErrorCodeValues = [100, 101, 102, 103, 104, 105] as const;
+export type ErrorCode = (typeof ErrorCodeValues)[number];
+export interface paths {
     "/url": {
         parameters: {
             query?: never;
@@ -797,7 +911,34 @@ export type operations = Record<string, never>;`,
         get: {
             parameters: {
                 query?: {
-                    status?: "active" | "inactive";
+                    status?: pathsUrlGetParametersQueryStatus;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/url2": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    status?: pathsUrl2GetParametersQueryStatusAnyOf0 | pathsUrl2GetParametersQueryStatusAnyOf1;
                 };
                 header?: never;
                 path?: never;
@@ -818,10 +959,9 @@ export type operations = Record<string, never>;`,
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        /** @enum {string} */
-        Status: "active" | "inactive";
+        Status: StatusAnyOf0 | StatusAnyOf1;
         /** @enum {number} */
-        ErrorCode: 100 | 101 | 102 | 103 | 104 | 105;
+        ErrorCode: ErrorCode;
     };
     responses: never;
     parameters: never;
@@ -830,14 +970,6 @@ export interface components {
     pathItems: never;
 }
 export type $defs = Record<string, never>;
-type ReadonlyArray<T> = [
-    Exclude<T, undefined>
-] extends [
-    any[]
-] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;
-export const pathsUrlGetParametersQueryStatusValues: ReadonlyArray<paths["/url"]["get"]["parameters"]["query"]["status"]> = ["active", "inactive"];
-export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["active", "inactive"];
-export const errorCodeValues: ReadonlyArray<components["schemas"]["ErrorCode"]> = [100, 101, 102, 103, 104, 105];
 export type operations = Record<string, never>;`,
         options: { enumValues: true },
       },
@@ -877,7 +1009,11 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export interface paths {
+        want: `export enum PathsUrlGetParametersQueryStatus {
+    active = "active",
+    inactive = "inactive"
+}
+export interface paths {
     "/url": {
         parameters: {
             query?: never;
@@ -921,10 +1057,6 @@ export interface components {
     pathItems: never;
 }
 export type $defs = Record<string, never>;
-export enum PathsUrlGetParametersQueryStatus {
-    active = "active",
-    inactive = "inactive"
-}
 export type operations = Record<string, never>;`,
         options: { enum: true, dedupeEnums: true },
       },
@@ -982,7 +1114,7 @@ export type operations = Record<string, never>;`,
       async () => {
         const result = astToString(await openapiTS(given, options));
         if (want instanceof URL) {
-          expect(`${COMMENT_HEADER}${result}`).toMatchFileSnapshot(fileURLToPath(want));
+          await expect(`${COMMENT_HEADER}${result}`).toMatchFileSnapshot(fileURLToPath(want));
         } else {
           expect(result).toBe(`${want}\n`);
         }

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import openapiTS, { COMMENT_HEADER, astToString } from "../src/index.js";
-import type { OpenAPITSOptions } from "../src/types.js";
+import type { OpenAPITSOptions, ReferenceObject, SchemaObject } from "../src/types.js";
 import type { TestCase } from "./test-helpers.js";
 
 const EXAMPLES_DIR = new URL("../examples/", import.meta.url);
@@ -537,6 +537,11 @@ export type operations = Record<string, never>;`,
           components: {
             schemas: {
               Date: { type: "string", format: "date-time" },
+              Set: {
+                "x-string-enum-to-set": true,
+                type: "string",
+                enum: ["low", "medium", "high"],
+              },
             },
           },
         },
@@ -546,6 +551,8 @@ export interface components {
     schemas: {
         /** Format: date-time */
         Date: DateOrTime;
+        /** @enum {string} */
+        Set: Set<"low" | "medium" | "high">;
     };
     responses: never;
     parameters: never;
@@ -564,6 +571,32 @@ export type operations = Record<string, never>;`,
                * AST
                */
               return ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("DateOrTime"));
+            }
+
+            // Previously, in order to access the schema in postTransform,
+            // you could resolve the schema using the path.
+            // Now, the schema is made available directly on the options.
+            // const schema = options.path
+            //   ? options.ctx.resolve<ReferenceObject | SchemaObject>(options.path)
+            //   : undefined;
+            const schema = options.schema;
+
+            if (
+              schema &&
+              !("$ref" in schema) &&
+              Object.hasOwn(schema, "x-string-enum-to-set") &&
+              schema.type === "string" &&
+              schema.enum?.every((enumMember) => {
+                return typeof enumMember === "string";
+              })
+            ) {
+              return ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("Set"), [
+                ts.factory.createUnionTypeNode(
+                  schema.enum.map((value) => {
+                    return ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(value));
+                  }),
+                ),
+              ]);
             }
           },
         },

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -888,18 +888,29 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export const pathsUrlGetParametersQueryStatusValues = ["active", "inactive"] as const;
+        want: `function get_is<TItem extends number | string>(items: readonly TItem[]) {
+    return (value: null | number | string | undefined): value is TItem => {
+        return value !== null && value !== undefined && items.includes(value as TItem);
+    };
+}
+export const pathsUrlGetParametersQueryStatusValues = ["active", "inactive"] as const;
 export type pathsUrlGetParametersQueryStatus = (typeof pathsUrlGetParametersQueryStatusValues)[number];
+export const is_pathsUrlGetParametersQueryStatus = get_is<pathsUrlGetParametersQueryStatus>(pathsUrlGetParametersQueryStatusValues);
 export const pathsUrl2GetParametersQueryStatusAnyOf0Values = ["approved", "rejected"] as const;
 export type pathsUrl2GetParametersQueryStatusAnyOf0 = (typeof pathsUrl2GetParametersQueryStatusAnyOf0Values)[number];
+export const is_pathsUrl2GetParametersQueryStatusAnyOf0 = get_is<pathsUrl2GetParametersQueryStatusAnyOf0>(pathsUrl2GetParametersQueryStatusAnyOf0Values);
 export const pathsUrl2GetParametersQueryStatusAnyOf1Values = ["appealed"] as const;
 export type pathsUrl2GetParametersQueryStatusAnyOf1 = (typeof pathsUrl2GetParametersQueryStatusAnyOf1Values)[number];
+export const is_pathsUrl2GetParametersQueryStatusAnyOf1 = get_is<pathsUrl2GetParametersQueryStatusAnyOf1>(pathsUrl2GetParametersQueryStatusAnyOf1Values);
 export const StatusAnyOf0Values = ["active", "inactive"] as const;
 export type StatusAnyOf0 = (typeof StatusAnyOf0Values)[number];
+export const is_StatusAnyOf0 = get_is<StatusAnyOf0>(StatusAnyOf0Values);
 export const StatusAnyOf1Values = ["pending"] as const;
 export type StatusAnyOf1 = (typeof StatusAnyOf1Values)[number];
+export const is_StatusAnyOf1 = get_is<StatusAnyOf1>(StatusAnyOf1Values);
 export const ErrorCodeValues = [100, 101, 102, 103, 104, 105] as const;
 export type ErrorCode = (typeof ErrorCodeValues)[number];
+export const is_ErrorCode = get_is<ErrorCode>(ErrorCodeValues);
 export interface paths {
     "/url": {
         parameters: {

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -19,7 +19,7 @@ export const DEFAULT_CTX: GlobalContext = {
   excludeDeprecated: false,
   exportType: false,
   immutable: false,
-  injectFooter: [],
+  injectNodes: [],
   pathParamsAsTypes: false,
   postTransform: undefined,
   propertiesRequiredByDefault: false,

--- a/packages/swr-openapi/package.json
+++ b/packages/swr-openapi/package.json
@@ -56,8 +56,8 @@
     "version": "pnpm run build"
   },
   "peerDependencies": {
-    "openapi-fetch": "0.x",
-    "openapi-typescript": "7.x",
+    "openapi-fetch": "0.13.4",
+    "openapi-typescript": "7.5.1",
     "react": "18 || 19",
     "swr": "2",
     "typescript": "^5.x"


### PR DESCRIPTION
## 🗣️ Discussion

This work stemmed from an error encountered when using `enumValues: true`, and escalated from there.

### 🐞 The bugs

* Types of exported literals are non-exhaustive.
* Composing OpenAPI enums generates colliding variable names.

#### 💨 Non-exhaustive types

The existing values exported when using `enumValues` express their type relative to the union defined in the TS schema.

```ts
// Before
export interface components {
  schemas: {
    /** @enum {string} */
    Status: "active" | "inactive";
  };
}
export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["active", "inactive"];
```

Instead, if we start with an exhaustive concrete value, the union type can be derived.

```ts
// After
export const StatusValues = ["active", "inactive"] as const;
export type Status = (typeof StatusValues)[number];
export interface components {
  schemas: {
    Status: Status;
  }
}
```

#### ➕ Composing OpenAPI enums generates conflicting variable names

Given the following schema composing two enum schemas, the following bad code is generated.

```yaml
components:
  schemas:
    Status:
      anyOf:
        - type: string
          enum:
            - active
            - inactive
        - type: string
          enum:
            - appealed
```

```ts
export const statusValues: components["schemas"]["Status"] = ["active", "inactive"];
export const statusValues: components["schemas"]["Status"] = ["appealed"];
```

By unifying the enum member and literal string traversal + generation paths, I was able to generate non-conflicting export names.

## Changes

- [x] Preserve capitalization of named, exported enum values.
- [x] Type exported const values as const, instead of their location within the operations or components schemas.
- [x] Derive and export types for enum values from concrete values in const arrays.
- [x] Use derived enum value types in operations and components schemas.
- [x] Use non-conflicting variable names for composed OpenAPI enums (anyOf: [enum1, enum2])
- [x] Export a [type-predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) function for each enum constant.

## How to Review

- [ ] There's an unhealthy behavior around composition + `enum: true`. Since enums aren't composable, we still generate nonsense code like `ModeratedStatus: components["schemas"]["Status"] | ModeratedStatusAnyOf1;` (see the node-utils `options > enum` case for this example. This isn't resolved by this PR, and may be entirely unresolvable.
- [ ] Helpers and consts and such are now prepended before the primary root exports; this is necessary since some schema are now derived from these const values.
- [ ] Exported const values are no longer lower-cased. This eliminated some special-case code in a couple of spots, and allowed for exporting `sanitizeMemberName` and using it in `transformers/schema-object`. That alone makes this a breaking change.
- [ ] The `as const` style literals may not be for everyone, though I've found them to be succinct, reliable, and versatile for composition (literal and type-level) and iteration.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
