### PR TITLE
Fix prefixItems / minItems / maxItems tuple generation

### DIFF
--- a/.changeset/clean-phones-deliver.md
+++ b/.changeset/clean-phones-deliver.md
@@ -1,5 +1,9 @@
 ---
-"openapi-typescript": patch
+"openapi-typescript": major
 ---
 
-Simplify minItems / maxItems tuple generation.
+Generate heterogeneous array types.
+Generate readonly tuple spread when.
+Generate tuple types with prefix items.
+Stop generating fixed-length tuple types when no minItems or maxItems is present.
+Stop generating empty tuple type when arrayLength: true and minItems: 1.

--- a/.changeset/clean-phones-deliver.md
+++ b/.changeset/clean-phones-deliver.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Simplify minItems / maxItems tuple generation.

--- a/.changeset/clean-phones-deliver.md
+++ b/.changeset/clean-phones-deliver.md
@@ -2,8 +2,10 @@
 "openapi-typescript": major
 ---
 
-Generate heterogeneous array types.
-Generate readonly tuple spread when.
-Generate tuple types with prefix items.
-Stop generating fixed-length tuple types when no minItems or maxItems is present.
-Stop generating empty tuple type when arrayLength: true and minItems: 1.
+Extract types generation for Array-type schemas to `transformArraySchemaObject` method.
+Throw error when OpenAPI `items` is array.
+Generate correct number of union members for `minItems` * `maxItems` unions.
+Generate readonly tuple members for `minItems` & `maxItems` unions.
+Generate readonly spread member for `prefixItems` tuple.
+Preserve `prefixItems` type members in `minItems` & `maxItems` tuples.
+Generate spread member for `prefixItems` tuple with no `minItems` / `maxItems` constraints.

--- a/packages/openapi-typescript/examples/simple-example.ts
+++ b/packages/openapi-typescript/examples/simple-example.ts
@@ -245,7 +245,8 @@ export interface operations {
                 };
                 content: {
                     "application/json": [
-                        string
+                        string,
+                        ...unknown[]
                     ];
                 };
             };

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -303,7 +303,7 @@ function transformArraySchemaObject(schemaObject: ArraySchemaObject, options: Tr
     throw new Error(`${options.path}: invalid property items. Expected Schema Object, got Array`);
   }
 
-  const itemType = (schemaObject.items ? transformSchemaObject(schemaObject.items, options) : undefined) ?? UNKNOWN;
+  const itemType = schemaObject.items ? transformSchemaObject(schemaObject.items, options) : UNKNOWN;
 
   // The minimum number of tuple members to return
   const min: number = Math.max(

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -348,7 +348,7 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
 
       if (shouldGeneratePermutations && max !== undefined) {
         return tsUnion(
-          Array.from({ length: max === undefined ? min : max - min + 1 }).map((_, index) => {
+          Array.from({ length: max - min + 1 }).map((_, index) => {
             const tupleType = ts.factory.createTupleTypeNode(Array.from({ length: index + min }).map(() => itemType));
             return options.ctx.immutable
               ? ts.factory.createTypeOperatorNode(ts.SyntaxKind.ReadonlyKeyword, tupleType)

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -313,7 +313,10 @@ function transformArraySchemaObject(schemaObject: ArraySchemaObject, options: Tr
     prefixTypes.length,
   );
   const max: number | undefined =
-    typeof schemaObject.maxItems === "number" && schemaObject.maxItems >= 0 && min <= schemaObject.maxItems
+    options.ctx.arrayLength &&
+    typeof schemaObject.maxItems === "number" &&
+    schemaObject.maxItems >= 0 &&
+    min <= schemaObject.maxItems
       ? schemaObject.maxItems
       : undefined;
 

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -19,19 +19,13 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
-      "tuple > tuple items",
+      "array > heterogeneous items",
       {
         given: {
           type: "array",
-          items: [{ type: "string" }, { type: "number" }],
-          minItems: 2,
-          maxItems: 2,
+          items: [{ type: "number" }, { type: "string" }],
         },
-        want: `[
-    string,
-    number
-]`,
-        // options: DEFAULT_OPTIONS,
+        want: "(number | string)[]",
       },
     ],
     [
@@ -45,7 +39,8 @@ describe("transformSchemaObject > array", () => {
         want: `[
     number,
     number,
-    number
+    number,
+    ...number[]
 ]`,
         // options: DEFAULT_OPTIONS,
       },
@@ -287,6 +282,48 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true, immutable: true > prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+        },
+        want: `readonly [
+    string,
+    number,
+    string,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > prefixItems, minItems: 3, maxItems: 3",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+          maxItems: 3,
+        },
+        want: `readonly [
+    string,
+    number,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > immutable: true",
       {
         given: {
@@ -311,7 +348,8 @@ describe("transformSchemaObject > array", () => {
         want: `readonly [
     number,
     number,
-    number
+    number,
+    ...readonly number[]
 ]`,
         options: {
           ...DEFAULT_OPTIONS,

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -105,6 +105,28 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "readonly string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > minItems: 1",
       {
         given: { type: "array", items: { type: "string" }, minItems: 1 },
@@ -115,6 +137,50 @@ describe("transformSchemaObject > array", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 1",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1 },
+        want: `readonly [
+    string,
+    ...string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > minItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 2 },
+        want: `[
+    string,
+    string,
+    ...string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > minItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 2 },
+        want: `readonly [
+    string,
+    string,
+    ...string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
         },
       },
     ],
@@ -136,6 +202,23 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true, immutable: true > maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, maxItems: 2 },
+        want: `readonly [
+] | readonly [
+    string
+] | readonly [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > minItems: 1, maxItems: 2",
       {
         given: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 },
@@ -152,6 +235,22 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true, immutable: true > minItems: 1, maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 },
+        want: `readonly [
+    string
+] | readonly [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > maxItems: 20",
       {
         given: { type: "array", items: { type: "string" }, maxItems: 20 },
@@ -159,6 +258,17 @@ describe("transformSchemaObject > array", () => {
         options: {
           ...DEFAULT_OPTIONS,
           ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true, immutable: true > maxItems: 20",
+      {
+        given: { type: "array", items: { type: "string" }, maxItems: 20 },
+        want: "readonly string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true, immutable: true },
         },
       },
     ],

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -136,6 +136,22 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true > minItems: 1, maxItems: 2",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 2 },
+        want: `[
+    string
+] | [
+    string,
+    string
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > maxItems: 20",
       {
         given: { type: "array", items: { type: "string" }, maxItems: 20 },

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -23,7 +23,7 @@ describe("transformSchemaObject > array", () => {
       {
         given: {
           type: "array",
-          items: [{ type: "number" }, { type: "string" }],
+          items: { anyOf: [{ type: "number" }, { type: "string" }] },
         },
         want: "(number | string)[]",
       },
@@ -372,5 +372,26 @@ describe("transformSchemaObject > array", () => {
       },
       ci?.timeout,
     );
+  }
+
+  const invalidTests: TestCase[] = [
+    [
+      "error > items is array",
+      {
+        given: {
+          type: "array",
+          items: [{ type: "number" }, { type: "string" }],
+        },
+        want: '#/components/schemas/schema-object: invalid property items. Expected Schema Object, got Array',
+      },
+    ],
+  ];
+
+  for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of invalidTests) {
+    test.skipIf(ci?.skipIf)(testName, () => {
+      expect(() => {
+        transformSchemaObject(given, options);
+      }).toThrowError(want.toString());
+    });
   }
 });

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -367,6 +367,20 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: false > prefixItems, items: false",
+      {
+        given: {
+          type: "array",
+          items: false,
+          prefixItems: [{ type: "string", enum: ["professor"] }],
+        },
+        want: `[
+    "professor",
+    ...unknown[]
+]`,
+      },
+    ],
+    [
       "options > immutable: true",
       {
         given: {

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -346,6 +346,27 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: false, immutable: true > prefixItems, minItems: 3, maxItems: 5",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [{ type: "string" }, { type: "number" }],
+          minItems: 3,
+          maxItems: 5,
+        },
+        want: `readonly [
+    string,
+    number,
+    ...readonly string[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false, immutable: true },
+        },
+      },
+    ],
+    [
       "options > immutable: true",
       {
         given: {
@@ -404,7 +425,7 @@ describe("transformSchemaObject > array", () => {
           type: "array",
           items: [{ type: "number" }, { type: "string" }],
         },
-        want: '#/components/schemas/schema-object: invalid property items. Expected Schema Object, got Array',
+        want: "#/components/schemas/schema-object: invalid property items. Expected Schema Object, got Array",
       },
     ],
   ];

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -89,6 +89,28 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: false > minItems: 0",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 0 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: false > minItems: 1",
+      {
+        given: { type: "array", items: { type: "string" }, minItems: 1 },
+        want: "string[]",
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: false },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true > default",
       {
         given: { type: "array", items: { type: "string" } },

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -146,7 +146,7 @@ describe("transformSchemaObject > array", () => {
         given: { type: "array", items: { type: "string" }, minItems: 1 },
         want: `readonly [
     string,
-    ...string[]
+    ...readonly string[]
 ]`,
         options: {
           ...DEFAULT_OPTIONS,
@@ -176,7 +176,7 @@ describe("transformSchemaObject > array", () => {
         want: `readonly [
     string,
     string,
-    ...string[]
+    ...readonly string[]
 ]`,
         options: {
           ...DEFAULT_OPTIONS,

--- a/packages/openapi-typescript/test/transform/schema-object/array.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/array.test.ts
@@ -304,6 +304,116 @@ describe("transformSchemaObject > array", () => {
       },
     ],
     [
+      "options > arrayLength: true > prefixItems, minItems: 2, maxItems: 2",
+      {
+        given: {
+          type: "array",
+          items: { type: "string" },
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 2,
+          maxItems: 2,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 2, maxItems: 3",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 2,
+          maxItems: 3,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+] | [
+    "calcium",
+    "magnesium",
+    unknown
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 3",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+          ],
+          minItems: 3,
+        },
+        want: `[
+    "calcium",
+    "magnesium",
+    unknown,
+    ...unknown[]
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
+      "options > arrayLength: true > no items, prefixItems, minItems: 2, maxItems: 5",
+      {
+        given: {
+          type: "array",
+          prefixItems: [
+            { type: "string", enum: ["calcium"] },
+            { type: "string", enum: ["magnesium"] },
+            { type: "string", enum: ["tungsten"] },
+          ],
+          minItems: 2,
+          maxItems: 5,
+        },
+        want: `[
+    "calcium",
+    "magnesium"
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten"
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten",
+    unknown
+] | [
+    "calcium",
+    "magnesium",
+    "tungsten",
+    unknown,
+    unknown
+]`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
+        },
+      },
+    ],
+    [
       "options > arrayLength: true, immutable: true > prefixItems, minItems: 3",
       {
         given: {
@@ -421,6 +531,7 @@ describe("transformSchemaObject > array", () => {
       testName,
       async () => {
         const result = astToString(transformSchemaObject(given, options));
+        // console.log(result);
         if (want instanceof URL) {
           expect(result).toMatchFileSnapshot(fileURLToPath(want));
         } else {

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -376,7 +376,7 @@ describe("transformSchemaObject > object", () => {
       },
     ],
     [
-      "options > two-dimensional array",
+      "options > array of tuples",
       {
         given: {
           type: "object",
@@ -384,7 +384,7 @@ describe("transformSchemaObject > object", () => {
             array: {
               type: "array",
               items: {
-                items: [
+                prefixItems: [
                   {
                     type: "string",
                   },
@@ -407,7 +407,7 @@ describe("transformSchemaObject > object", () => {
 }`,
         options: {
           ...DEFAULT_OPTIONS,
-          ctx: { ...DEFAULT_OPTIONS.ctx },
+          ctx: { ...DEFAULT_OPTIONS.ctx, arrayLength: true },
         },
       },
     ],


### PR DESCRIPTION
## Changes

Closes #2048

- [x] Extract types generation for Array-type schemas to `transformArraySchemaObject` method
- [x] Throw error when OpenAPI `items` is array
- [x] Generate correct number of union members for `minItems` * `maxItems` unions
- [x] Generate readonly tuple members for `minItems` & `maxItems` unions
- [x] Generate readonly spread member for `prefixItems` tuple
- [x] Preserve `prefixItems` type members in `minItems` & `maxItems` tuples
- [x] Generate spread member for `prefixItems` tuple with no `minItems` / `maxItems` constraints
- [x] Add test case for error thrown when OpenAPI `items` is array
- [x] Add test case for heterogeneous item members: `items: oneOf: [{ type: 'string' }, { type: 'number' }]`
- [x] Add test cases for `minItems` + `maxItems` schema generating empty tuple, as outlined in #2048
- [x] Add test cases for many combinations of `arrayLength` and `immutable` options, and `prefixItems`, `minItems`, `maxItems` schemas

The previous union+tuples generation implementation was a little hair-ball, and difficult for me to parse, so I replaced it with a stepped implementation, returning early with results whenever possible.

 - first returning the full min + max union-of-tuples if possible; each union member may be `readonly`, but not the union as a whole
 - next, returning the min tuple if possible; the tuple as a whole may be `readonly`, as well as its spread members.
 - finally, returning the simple array type, which may be `readonly`

### Examples

Here's a simple schema, and the before+after generated types.

#### ☕ minItems empty tuple

```yaml
components:
  schemas:
    TwoNumbers:
      type: array
      items:
        type: number
      minItems: 1
      maxItems: 2
```

```ts
// Before
export interface components {
    schemas: {
        TwoNumbers: [
        ] | [
            number
        ];
    };
    …

// After
export interface components {
    schemas: {
        TwoNumbers: [
            number
        ] | [
            number,
            number
        ];
    };
    …
```

#### 📖 readonly spread type

```yaml
components:
  schemas:
    OneNumber:
      type: array
      items:
        type: number
      minItems: 1
```

```ts
// Before
export interface components {
    schemas: {
        readonly OneNumber: [
            number,
            ...number[]
        ];
    };
    …

// After
export interface components {
    schemas: {
        readonly OneNumber: readonly [
            number,
            ...readonly number[]
        ];
    };
    …
```

#### 🙉 preserve `prefixItems`

```yaml
components:
  schemas:
    WithPrefixItems:
      type: array
      items:
        type: string
      prefixItems:
        - type: string
          enum:
            - professor
        - type: string
          enum:
            - student
      minItems: 2
      maxItems: 4
```

```ts
// Before
export interface components {
    schemas: {
        WithPrefixItems: [
            "doctor",
            "intern"
        ];
    };
    …

// After
export interface components {
    schemas: {
        WithPrefixItems: [
            "doctor",
            "intern",
            ...string[]
        ];
    };
    …
```

The same schema with the `arrayLength: true` option set generates quite different types.

```ts
// Before
export interface components {
    schemas: {
        WithPrefixItems: [
        ] | [
            [
                "doctor",
                "intern"
            ]
        ] | [
            [
                "doctor",
                "intern"
            ],
            [
                "doctor",
                "intern"
            ]
        ];
    };
    …

// After
export interface components {
    schemas: {
        WithPrefixItems: [
            "doctor",
            "intern"
        ] | [
            "doctor",
            "intern",
            string
        ] | [
            "doctor",
            "intern",
            string,
            string
        ];
    };
    …
```

## How to Review

* [ ] Ensure generated schemas are all still acceptable
* [ ] Ensure code-style is appropriate
* [ ] Ensure newly-`readonly` spread member is acceptable (this may qualify as a breaking change)
* [ ] Ensure new error behavior on OpenAPI `items` is array is acceptable
* [ ] Ensure new spread behavior on `prefixItems` schemas is acceptable
* [ ] Look closely at the new tests cases, and changes to old test cases, including options and schemas passed to the schema transformer
* [ ] This PR undoes some of the work done in https://github.com/openapi-ts/openapi-typescript/pull/1489, updating its test case to use `prefixItems` and `arrayLength` in combination to generate the desired array-of-tuples

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
