### PR TITLE
Drop init argument when not needed in query key

### DIFF
--- a/.changeset/sour-steaks-double.md
+++ b/.changeset/sour-steaks-double.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+Drop init argument when not needed in query key

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -21,7 +21,8 @@ export type QueryKey<
   Paths extends Record<string, Record<HttpMethod, {}>>,
   Method extends HttpMethod,
   Path extends PathsWithMethod<Paths, Method>,
-> = readonly [Method, Path, MaybeOptionalInit<Paths[Path], Method>];
+  Init = MaybeOptionalInit<Paths[Path], Method>,
+> = Init extends undefined ? readonly [Method, Path] : readonly [Method, Path, Init];
 
 export type QueryOptionsFunction<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
@@ -123,7 +124,11 @@ export default function createClient<Paths extends {}, Media extends MediaType =
   };
 
   const queryOptions: QueryOptionsFunction<Paths, Media> = (method, path, ...[init, options]) => ({
-    queryKey: [method, path, init as InitWithUnknowns<typeof init>] as const,
+    queryKey: (init === undefined ? ([method, path] as const) : ([method, path, init] as const)) as QueryKey<
+      Paths,
+      typeof method,
+      typeof path
+    >,
     queryFn,
     ...options,
   });

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -231,6 +231,16 @@ describe("client", () => {
       expectTypeOf(result.current.data).toEqualTypeOf<"select(true)">();
       expectTypeOf(result.current.error).toEqualTypeOf<false | null>();
     });
+
+    it("returns query options without an init", async () => {
+      const fetchClient = createFetchClient<minimalGetPaths>({
+        baseUrl,
+        fetch: () => Promise.resolve(Response.json(true)),
+      });
+      const client = createClient(fetchClient);
+
+      expect(client.queryOptions("get", "/foo").queryKey.length).toBe(2);
+    });
   });
 
   describe("useQuery", () => {


### PR DESCRIPTION
## Changes

For urls that do not include an init param, generate a query key of length 2. This allows the value to be passed directly to `invalidateQueries()`.

Without this change, the package generates `["get", "/foo", undefined]` which does not correctly match the corresponding get query.

Related to https://github.com/openapi-ts/openapi-typescript/issues/1806

## How to Review

This doesn't quite solve the problem when there are init params but at least solves for the case where there are no params...

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
