### PR TITLE
feat(openapi-fetch): add support for arbitrary method

### DIFF
--- a/.changeset/hot-pants-sit.md
+++ b/.changeset/hot-pants-sit.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+add support for arbitrary method

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -199,6 +199,16 @@ export type ClientMethod<
   ...init: InitParam<Init>
 ) => Promise<FetchResponse<Paths[Path][Method], Init, Media>>;
 
+export type ClientRequestMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
+  Method extends HttpMethod,
+  Path extends PathsWithMethod<Paths, Method>,
+  Init extends MaybeOptionalInit<Paths[Path], Method>,
+>(
+  method: Method,
+  url: Path,
+  ...init: InitParam<Init>
+) => Promise<FetchResponse<Paths[Path][Method], Init, Media>>;
+
 export type ClientForPath<PathInfo extends Record<string | number, any>, Media extends MediaType> = {
   [Method in keyof PathInfo as Uppercase<string & Method>]: <Init extends MaybeOptionalInit<PathInfo, Method>>(
     ...init: InitParam<Init>
@@ -206,6 +216,7 @@ export type ClientForPath<PathInfo extends Record<string | number, any>, Media e
 };
 
 export interface Client<Paths extends {}, Media extends MediaType = MediaType> {
+  request: ClientRequestMethod<Paths, Media>;
   /** Call a GET endpoint */
   GET: ClientMethod<Paths, "get", Media>;
   /** Call a PUT endpoint */

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -227,6 +227,9 @@ export default function createClient(clientOptions) {
   }
 
   return {
+    request(method, url, init) {
+      return coreFetch(url, { ...init, method: method.toUpperCase() });
+    },
     /** Call a GET endpoint */
     GET(url, init) {
       return coreFetch(url, { ...init, method: "GET" });

--- a/packages/openapi-fetch/test/http-methods/request.test.ts
+++ b/packages/openapi-fetch/test/http-methods/request.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { createObservedClient } from "../helpers.js";
+import type { paths as get_paths } from "./schemas/get.js";
+import type { paths as post_paths } from "./schemas/post.js";
+
+describe("request", () => {
+  test("sends correct method", async () => {
+    let method = "";
+    const client = createObservedClient<get_paths>({}, async (req) => {
+      method = req.method;
+      return Response.json({});
+    });
+
+    await client.request("get", "/posts");
+    expect(method).toBe("GET");
+  });
+
+  test("sends correct method with params", async () => {
+    let method = "";
+    const client = createObservedClient<post_paths>({}, async (req) => {
+      method = req.method;
+      return Response.json({});
+    });
+
+    await client.request("post", "/posts", {
+      body: { title: "My Post", body: "Post body", publish_date: new Date("2024-06-06T12:00:00Z").getTime() },
+    });
+
+    expect(method).toBe("POST");
+  });
+});


### PR DESCRIPTION
## Changes

This Pull request closes #1808 by providing a `request` method that accept a method as its first arguments allowing to pass any `HttpMethod`. Making library authors' life easier.

This does not introduce any breaking change.

## How to Review

A new `request` should be available on the client that **must behave exactly** like the other `GET`, `OPTIONS`, etc methods but with the ability to pass the HttpMethod as first parameter.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)