### PR TITLE
Auto-assign issues

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,21 @@
+name: Issue creation
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Auto-assign issue
+        uses: pozil/auto-assign-issue@v2
+        with:
+          teams: maintainers
+          numOfAssignee: 1
+          allowSelfAssign: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENAPI_TS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

GitHub, by default, doesn’t allow auto issue assignment. Try out a GitHub action to automatically round-robin select one maintainer to triage the issue, and follow up.

## How to Review

- Any additional settings desirable?
- Any other GitHub Actions we should evaluate (I’ll admit I just picked the first one I found)?

## Checklist

N/A