### PR TITLE
fix 404 about page link in sidebar openapi-react-query

### DIFF
--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -84,7 +84,7 @@ export default defineConfig({
               text: "queryOptions",
               link: "/query-options",
             },
-            { text: "About", link: "/openapi-react-query/about" },
+            { text: "About", link: "/about" },
           ],
         },
         {


### PR DESCRIPTION
## Changes
- I fixed a problem that caused a 404 on the destination page when clicking on the About link in the openapi-react-query in the sidebar when opening the URL https://openapi-ts.dev/openapi-react-query/.

- After this fix, the about page of openapi-react-query will open correctly
- Now when you press about, it used to open https://openapi-ts.dev/openapi-react-query/openapi-react-query/about, but now it opens https://openapi-ts.dev/openapi-react-query/about has been modified to open.



## How to Review

- Make sure the about page of openapi-react-query opens correctly in the preview page docs.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
