### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
@@ -1,14 +1,26 @@
----
-name: "Bug report: swr-openapi"
-about: For the swr-openapi library
-title: ""
-labels: swr-openapi, bug
-assignees: ""
+name: "openapi-typescript: Bug report"
+about: Report a bug or unexpected behavior
+labels:
+  - openapi-ts
+  - bug
+  - triage
 body:
   - type: input
     attributes:
-      label: Version
+      label: openapi-typescript version
       placeholder: x.x.x
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Node.js version
+      placeholder: 20.x.x
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: OS + version
+      placeholder: macOS 15.1.1
     validations:
       required: true
   - type: textarea
@@ -35,5 +47,6 @@ body:
     id: checklist
     attributes:
       options:
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))
----
+        - label: My OpenAPI schema is valid and passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
+          required: true
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
@@ -1,9 +1,9 @@
----
-name: "Feature request: openapi-typescript"
-about: For the openapi-typescript library
+name: "openapi-typescript: Feature request"
+about: Propose new functionality or a breaking change
 title: ""
-labels: openapi-ts, enhancement, help wanted
-assignees: ""
+labels:
+  - openapi-ts
+  - enhancement
 body:
   - type: textarea
     id: description
@@ -24,4 +24,3 @@ body:
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))
----

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
@@ -1,9 +1,9 @@
----
-name: "Bug report: openapi-react-query"
-about: For the openapi-react-query library
-title: ""
-labels: openapi-react-query, bug
-assignees: ""
+name: "openapi-fetch: Bug report"
+about: Report a bug or unexpected behavior
+labels:
+  - openapi-fetch
+  - bug
+  - triage
 body:
   - type: input
     attributes:
@@ -35,5 +35,4 @@ body:
     id: checklist
     attributes:
       options:
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))
----
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
@@ -1,9 +1,9 @@
----
-name: "Feature request: swr-openapi"
-about: For the swr-openapi library
+name: "openapi-fetch: Feature request"
+about: Propose new functionality or a breaking change
 title: ""
-labels: swr-openapi, enhancement, help wanted
-assignees: ""
+labels:
+  - openapi-fetch
+  - enhancement
 body:
   - type: textarea
     id: description
@@ -23,5 +23,4 @@ body:
     id: checklist
     attributes:
       options:
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))
----
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
@@ -1,9 +1,9 @@
----
-name: "Bug report: openapi-fetch"
-about: For the openapi-fetch library
-title: ""
-labels: openapi-fetch, bug
-assignees: ""
+name: "openapi-react-query: Bug report"
+about: Report a bug or unexpected behavior
+labels:
+  - openapi-react-query
+  - bug
+  - triage
 body:
   - type: input
     attributes:
@@ -35,5 +35,4 @@ body:
     id: checklist
     attributes:
       options:
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))
----
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
@@ -1,9 +1,9 @@
----
-name: "Feature request: openapi-react-query"
-about: For the openapi-react-query library
+name: "openapi-react-query: Feature request"
+about: Propose new functionality or a breaking change
 title: ""
-labels: openapi-react-query, enhancement, help wanted
-assignees: ""
+labels:
+  - openapi-react-query
+  - enhancement
 body:
   - type: textarea
     id: description
@@ -24,4 +24,3 @@ body:
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))
----

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
@@ -1,26 +1,13 @@
----
-name: "Bug report: openapi-typescript"
-about: For the openapi-typescript library
-title: ""
-labels: openapi-ts, bug
-assignees: ""
+name: "swr-openapi: Bug report"
+about: Report a bug or unexpected behavior
+labels:
+  - swr-openapi
+  - bug
 body:
   - type: input
     attributes:
-      label: openapi-typescript version
+      label: Version
       placeholder: x.x.x
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: Node.js version
-      placeholder: 20.x.x
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: OS + version
-      placeholder: macOS 15.1.1
     validations:
       required: true
   - type: textarea
@@ -47,7 +34,4 @@ body:
     id: checklist
     attributes:
       options:
-        - label: My OpenAPI schema is valid and passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
-          required: true
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))
----
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
@@ -1,9 +1,9 @@
----
-name: "Feature request: openapi-fetch"
-about: For the openapi-fetch library
+name: "swr-openapi: Feature request"
+about: Propose new functionality or a breaking change
 title: ""
-labels: openapi-fetch, enhancement, help wanted
-assignees: ""
+labels:
+  - swr-openapi
+  - enhancement
 body:
   - type: textarea
     id: description
@@ -23,5 +23,4 @@ body:
     id: checklist
     attributes:
       options:
-        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))
----
+        - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Changes

Tried to use the new [Syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) but we have some config issues that prevent them from showing properly. This fixes that.

Also does some minor massaging for names and descriptions so they make more sense in context. Switched from grouping bugs together, and features together, to grouping by library first, then bug/feature 2nd. 

## How to Review

N/A

## Checklist

N/A