### PR TITLE
ci: Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-bug.yml
@@ -1,5 +1,5 @@
 name: "openapi-typescript: Bug report"
-about: Report a bug or unexpected behavior
+description: Report a bug or unexpected behavior
 labels:
   - openapi-ts
   - bug
@@ -44,9 +44,15 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: required
+    label: Required
     attributes:
       options:
         - label: My OpenAPI schema is valid and passes the [Redocly validator](https://redocly.com/docs/cli/commands/lint/) (`npx @redocly/cli@latest lint`)
           required: true
+  - type: checkboxes
+    id: extra
+    label: Extra
+    attributes:
+      options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
@@ -1,5 +1,5 @@
 name: "openapi-typescript: Feature request"
-about: Propose new functionality or a breaking change
+description: Propose new functionality or a breaking change
 title: ""
 labels:
   - openapi-ts
@@ -20,7 +20,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-typescript/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-bug.yml
@@ -1,5 +1,5 @@
 name: "openapi-fetch: Bug report"
-about: Report a bug or unexpected behavior
+description: Report a bug or unexpected behavior
 labels:
   - openapi-fetch
   - bug
@@ -32,7 +32,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
@@ -1,5 +1,5 @@
 name: "openapi-fetch: Feature request"
-about: Propose new functionality or a breaking change
+description: Propose new functionality or a breaking change
 title: ""
 labels:
   - openapi-fetch
@@ -20,7 +20,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-fetch/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-bug.yml
@@ -1,5 +1,5 @@
 name: "openapi-react-query: Bug report"
-about: Report a bug or unexpected behavior
+description: Report a bug or unexpected behavior
 labels:
   - openapi-react-query
   - bug
@@ -32,7 +32,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
+++ b/.github/ISSUE_TEMPLATE/03_openapi-react-query-feat.yml
@@ -1,5 +1,5 @@
 name: "openapi-react-query: Feature request"
-about: Propose new functionality or a breaking change
+description: Propose new functionality or a breaking change
 title: ""
 labels:
   - openapi-react-query
@@ -20,7 +20,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/openapi-react-query/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-bug.yml
@@ -1,5 +1,5 @@
 name: "swr-openapi: Bug report"
-about: Report a bug or unexpected behavior
+description: Report a bug or unexpected behavior
 labels:
   - swr-openapi
   - bug
@@ -31,7 +31,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))

--- a/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
+++ b/.github/ISSUE_TEMPLATE/04_swr-openapi-feat.yml
@@ -1,5 +1,5 @@
 name: "swr-openapi: Feature request"
-about: Propose new functionality or a breaking change
+description: Propose new functionality or a breaking change
 title: ""
 labels:
   - swr-openapi
@@ -20,7 +20,8 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: checklist
+    id: extra
+    label: Extra
     attributes:
       options:
         - label: I’m willing to open a PR (see [CONTRIBUTING.md](https://github.com/openapi-ts/openapi-typescript/blob/main/packages/swr-openapi/CONTRIBUTING.md))


### PR DESCRIPTION
## Changes

Additional fixes to get GitHub issue forms working. There’s no validator, and no way to preview on a PR, so we’re doing it live 😅 

## How to Review

N/A

## Checklist

N/A