### PR TITLE
ci: Add feat issues to projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
+++ b/.github/ISSUE_TEMPLATE/01_openapi-typescript-feat.yml
@@ -3,6 +3,8 @@ description: Propose new functionality or a breaking change
 labels:
   - openapi-ts
   - enhancement
+projects:
+  - openapi-ts/2
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
+++ b/.github/ISSUE_TEMPLATE/02_openapi-fetch-feat.yml
@@ -3,6 +3,8 @@ description: Propose new functionality or a breaking change
 labels:
   - openapi-fetch
   - enhancement
+projects:
+  - openapi-ts/3
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
## Changes

Automatically adds new `feature` issues for openapi-typescript and openapi-fetch to the corresponding Project boards.

Other projects may get Project boards in the future! This just starts making use of the 2 we have.

This is an organizational PR and doesn’t affect any library 

## How to Review

N/A

## Checklist

N/A