### PR TITLE
Encode the request body if `Content-Type` header is `x-www-form-urlencoded`

### DIFF
--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -192,6 +192,22 @@ or when instantiating the client.
 
 :::
 
+### URL-encoded body
+
+To send a body request in `application/x-www-form-urlencoded` format, which is commonly used to transmit key-value pairs in APIs like OAuth 2.0, pass the appropriate header and body as an object. `openapi-fetch` will automatically encode the body to the correct format.
+
+```ts
+const { data, error } = await client.POST("/tokens", {
+  body: {
+    clientId: "someClientId",
+    clientSecret: "someClientSecret",
+  },
+  headers: {
+    "Content-Type": "application/x-www-form-encoded",
+  },
+});
+```
+
 ## Path serialization
 
 openapi-fetch supports path serialization as [outlined in the 3.1 spec](https://swagger.io/docs/specification/serialization/#path). This happens automatically, based on the specific format in your OpenAPI schema:

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -72,7 +72,7 @@ export default function createClient(clientOptions) {
             });
     }
 
-    const serializedBody = body === undefined ? undefined : bodySerializer(body);
+    const serializedBody = body === undefined ? undefined : bodySerializer(body, headers);
 
     const defaultHeaders =
       // with no body, we should not to set Content-Type
@@ -568,9 +568,18 @@ export function defaultPathSerializer(pathname, pathParams) {
  * Serialize body object to string
  * @type {import("./index.js").defaultBodySerializer}
  */
-export function defaultBodySerializer(body) {
+export function defaultBodySerializer(body, headers) {
   if (body instanceof FormData) {
     return body;
+  }
+  if (headers) {
+    const contentType =
+      headers.get instanceof Function
+        ? (headers.get("Content-Type") ?? headers.get("content-type"))
+        : (headers["Content-Type"] ?? headers["content-type"]);
+    if (contentType === "application/x-www-form-urlencoded") {
+      return new URLSearchParams(body).toString();
+    }
   }
   return JSON.stringify(body);
 }

--- a/packages/openapi-fetch/test/common/request.test.ts
+++ b/packages/openapi-fetch/test/common/request.test.ts
@@ -265,6 +265,19 @@ describe("request", () => {
       expect(bodyUsed).toBe(true);
       expect(bodyText).toBe("0");
     });
+
+    test("`application/x-www-form-urlencoded` body", async () => {
+      const { bodyUsed, bodyText } = await fireRequestAndGetBodyInformation({
+        method: "POST",
+        fetchOptions: {
+          body: { key1: "value1", key2: "value2" },
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        },
+      });
+
+      expect(bodyUsed).toBe(true);
+      expect(bodyText).toBe("key1=value1&key2=value2");
+    });
   });
 
   test("cookie header is preserved", async () => {


### PR DESCRIPTION
## Changes

Fixes #2069 
This PR updates the `defaultBodySerializer` to correctly serialize the body if `Content-Type` header is set to `x-www-form-urlencoded`. This is useful for OAuth2 token requests.

## How to Review

I'm not sure about the headers: what type are they, and are they normalized?
I added handling for both a plain JS object (`headers['Accept-Content']`) and a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/get) object (`headers.get['Accept-Content']`), as well as both capitalized and lower-case versions.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
