### PR TITLE
feat(openapi-typescript): generate path params flag

### DIFF
--- a/.changeset/purple-walls-repeat.md
+++ b/.changeset/purple-walls-repeat.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Support generating path params for flaky schemas using --generate-path-params option

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,7 +121,8 @@ The following flags are supported in the CLI:
 | `--path-params-as-types`           |       | `false`  | Allow dynamic string lookups on the `paths` object                                                                  |
 | `--root-types`                     |       | `false`  | Exports types from `components` as root level type aliases                                                          |
 | `--root-types-no-schema-prefix`    |       | `false`  | Do not add "Schema" prefix to types at the root level (should only be used with --root-types)                       |
-| `--make-paths-enum `               |       | `false`  | Generate ApiPaths enum for all paths                                                                                |
+| `--make-paths-enum`                |       | `false`  | Generate ApiPaths enum for all paths                                                                                |
+| `--generate-path-params`           |       | `false`  | Generate path parameters for all paths where they are undefined by schema                                           |
 
 ### pathParamsAsTypes
 
@@ -227,3 +228,9 @@ export enum ApiPaths {
 ```
 
 :::
+
+### generatePathParams
+
+This option is useful for generating path params optimistically when the schema has flaky path parameter definitions.
+Checks the path for opening and closing brackets and extracts them as path parameters. 
+Does not override already defined by schema path parameters.

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -84,6 +84,7 @@ const flags = parser(args, {
     "rootTypes",
     "rootTypesNoSchemaPrefix",
     "makePathsEnum",
+    "generatePathParams",
   ],
   string: ["output", "redocly"],
   alias: {
@@ -146,6 +147,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       rootTypes: flags.rootTypes,
       rootTypesNoSchemaPrefix: flags.rootTypesNoSchemaPrefix,
       makePathsEnum: flags.makePathsEnum,
+      generatePathParams: flags.generatePathParams,
       redocly,
       silent,
     }),

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -90,6 +90,7 @@ export default async function openapiTS(
     inject: options.inject ?? undefined,
     transform: typeof options.transform === "function" ? options.transform : undefined,
     makePathsEnum: options.makePathsEnum ?? false,
+    generatePathParams: options.generatePathParams ?? false,
     resolve($ref) {
       return resolveRef(schema, $ref, { silent: options.silent ?? false });
     },

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -670,6 +670,8 @@ export interface OpenAPITSOptions {
   inject?: string;
   /** Generate ApiPaths enum */
   makePathsEnum?: boolean;
+  /** Generate path params based on path even if they are not defiend in the open api schema */
+  generatePathParams?: boolean;
 }
 
 /** Context passed to all submodules */
@@ -703,6 +705,7 @@ export interface GlobalContext {
   resolve<T>($ref: string): T | undefined;
   inject?: string;
   makePathsEnum: boolean;
+  generatePathParams: boolean;
 }
 
 export type $defs = Record<string, SchemaObject>;

--- a/packages/openapi-typescript/test/fixtures/generate-params-test.yaml
+++ b/packages/openapi-typescript/test/fixtures/generate-params-test.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /{id}/get-item-undefined-path-param:
+    description: Remote Ref
+    $ref: "_path-object-refs-paths.yaml#/GetItemOperation"
+  /{id}/get-item-undefined-nested-path-param/{secondId}:
+    description: Remote Ref
+    $ref: "_path-object-refs-paths.yaml#/GetItemOperation"
+    parameters:
+      -
+        name: id
+        in: path
+        required: true
+        schema:
+          type: number
+  /{id}/get-item-defined-path-param:
+    description: Remote Ref
+    $ref: "_path-object-refs-paths.yaml#/GetItemOperation"
+    parameters:
+      -
+        name: id
+        in: path
+        required: true
+        schema:
+          type: number

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -760,6 +760,152 @@ export enum ApiPaths {
       },
     ],
     [
+      "Generates path parameters",
+      {
+        given: new URL("./fixtures/generate-params-test.yaml", import.meta.url),
+        want: `export interface paths {
+    "/{id}/get-item-undefined-path-param": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Item"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/{id}/get-item-undefined-nested-path-param/{secondId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+                secondId: string;
+            };
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                    secondId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Item"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/{id}/get-item-defined-path-param": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Item"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        Item: {
+            id: string;
+            name: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+        options: {
+          generatePathParams: true,
+        },
+      },
+    ],
+    [
       "nullable > 3.0 syntax",
       {
         given: {

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -32,6 +32,7 @@ export const DEFAULT_CTX: GlobalContext = {
   silent: true,
   transform: undefined,
   makePathsEnum: false,
+  generatePathParams: false,
 };
 
 /** Generic test case */


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._
https://github.com/openapi-ts/openapi-typescript/issues/2103

## How to Review

Use openapi-typescript to convert a schema that has missing path paramaters definitions.
_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
