### PR TITLE
feat: fixed typescript error dynamic paths

### DIFF
--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -18,7 +18,7 @@ export { default as transformOperationObject } from "./transform/operation-objec
 export { default as transformParameterObject } from "./transform/parameter-object.js";
 export * from "./transform/path-item-object.js";
 export { default as transformPathItemObject } from "./transform/path-item-object.js";
-export { default as transformPathsObject } from "./transform/paths-object.js";
+export * from "./transform/paths-object.js";
 export { default as transformRequestBodyObject } from "./transform/request-body-object.js";
 export { default as transformResponseObject } from "./transform/response-object.js";
 export { default as transformResponsesObject } from "./transform/responses-object.js";

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -290,7 +290,7 @@ export type operations = Record<string, never>;`,
             },
           },
         },
-        want: `export interface paths {
+        want: `export type dynamicPaths = {
     [path: \`/user/\${string}\`]: {
         parameters: {
             query?: never;
@@ -322,6 +322,95 @@ export type operations = Record<string, never>;`,
             requestBody?: never;
             responses: never;
         };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+};
+export interface paths extends dynamicPaths {
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+        options: { pathParamsAsTypes: true },
+      },
+    ],
+    [
+      "options > pathParamsAsTypes > true simple and dynamic paths",
+      {
+        given: {
+          openapi: "3.1",
+          info: { title: "Test", version: "1.0" },
+          paths: {
+            "/users": {
+              get: [],
+            },
+            "/users/{user_id}": {
+              get: {
+                parameters: [{ name: "user_id", in: "path" }],
+              },
+            },
+          },
+        },
+        want: `export type dynamicPaths = {
+    [path: \`/users/\${string}\`]: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+};
+export interface paths extends dynamicPaths {
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
         post?: never;
         delete?: never;
         options?: never;

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "cache": false
     },
     "format": {
       "dependsOn": ["^format"]


### PR DESCRIPTION
## Changes

Openapi-typescript creates an faulty file when using --path-params-as-types to generate types when nested path parameters exists.

This is particularly annoying when used with a Restful CRUD like : 
- /users
- /users/{userId}
... 

[#1752](https://github.com/openapi-ts/openapi-typescript/issues/1752)

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
