### PR TITLE
fix: use index.d.ts as types for cjs

### DIFF
--- a/.changeset/witty-bottles-carry.md
+++ b/.changeset/witty-bottles-carry.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+[#2098](https://github.com/openapi-ts/openapi-typescript/pull/2098): Fix CJS type issues by pointing to proper d.ts file

--- a/packages/openapi-react-query/package.json
+++ b/packages/openapi-react-query/package.json
@@ -18,7 +18,7 @@
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/index.d.cts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.cjs"
       }
     },


### PR DESCRIPTION
## Changes

This pull request closes #2098. `exports.require.types` was pointing to a file that does not exist. It now points to the same `exports.imports.types` file (`index.d.ts`) fixing type issues when using this library with `require`. 

## How to Review

Types should properly resolved when using a `require` import.