### PR TITLE
feat(openapi-react-query): support for useInfiniteQuery()

### DIFF
--- a/.changeset/mighty-comics-worry.md
+++ b/.changeset/mighty-comics-worry.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": minor
+---
+
+Implements useInfiniteQuery() in openapi-react-query

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -104,9 +104,10 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
         UseInfiniteQueryOptions<
             Response["data"],
             Response["error"],
+            InfiniteData<Response["data"]>,
             Response["data"],
-            number,
-            QueryKey<Paths, Method, Path>
+            QueryKey<Paths, Method, Path>,
+            unknown
         >,
         "queryKey" | "queryFn"
     >
@@ -207,8 +208,9 @@ export default function createClient<Paths extends {}, Media extends MediaType =
                 Response["data"],
                 Response["error"],
                 Response["data"],
-                number,
-                QueryKey<Paths, Method, Path>
+                Response["data"],
+                QueryKey<Paths, Method, Path>,
+                unknown
             >,
             "queryKey" | "queryFn"
         >,

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -100,36 +100,28 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
     Path extends PathsWithMethod<Paths, Method>,
     Init extends MaybeOptionalInit<Paths[Path], Method>,
     Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>,
+    Options extends Omit<
+        UseInfiniteQueryOptions<
+            Response["data"],
+            Response["error"],
+            Response["data"],
+            number,
+            QueryKey<Paths, Method, Path>
+        >,
+        "queryKey" | "queryFn"
+    >
 >(
     method: Method,
     url: Path,
     ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
         ? [
             InitWithUnknowns<Init>?,
-            Omit<
-                UseInfiniteQueryOptions<
-                    Response["data"],
-                    Response["error"],
-                    Response["data"],
-                    number,
-                    QueryKey<Paths, Method, Path>
-                >,
-                "queryKey" | "queryFn"
-            >?,
+            Options?,
             QueryClient?,
         ]
         : [
             InitWithUnknowns<Init>,
-            Omit<
-                UseInfiniteQueryOptions<
-                    Response["data"],
-                    Response["error"],
-                    Response["data"],
-                    number,
-                    QueryKey<Paths, Method, Path>
-                >,
-                "queryKey" | "queryFn"
-            >?,
+            Options?,
             QueryClient?,
         ]
 ) => UseInfiniteQueryResult<InfiniteData<Response["data"]>, Response["error"]>;

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -3,6 +3,8 @@ import {
   type UseMutationResult,
   type UseQueryOptions,
   type UseQueryResult,
+  type InfiniteData,
+  type InfiniteQueryObserverResult,
   type UseInfiniteQueryOptions,
   type UseInfiniteQueryResult,
   type UseSuspenseQueryOptions,
@@ -103,34 +105,34 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
     url: Path,
     ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
         ? [
-          InitWithUnknowns<Init>?,
-          Omit<
-              UseInfiniteQueryOptions<
-                  Response["data"],
-                  Response["error"],
-                  Response["data"],
-                  number,
-                  QueryKey<Paths, Method, Path>
-              >,
-              "queryKey" | "queryFn"
-          >?,
-          QueryClient?,
+            InitWithUnknowns<Init>?,
+            Omit<
+                UseInfiniteQueryOptions<
+                    Response["data"],
+                    Response["error"],
+                    Response["data"],
+                    number,
+                    QueryKey<Paths, Method, Path>
+                >,
+                "queryKey" | "queryFn"
+            >?,
+            QueryClient?,
         ]
         : [
-          InitWithUnknowns<Init>,
-          Omit<
-              UseInfiniteQueryOptions<
-                  Response["data"],
-                  Response["error"],
-                  Response["data"],
-                  number,
-                  QueryKey<Paths, Method, Path>
-              >,
-              "queryKey" | "queryFn"
-          >?,
-          QueryClient?,
+            InitWithUnknowns<Init>,
+            Omit<
+                UseInfiniteQueryOptions<
+                    Response["data"],
+                    Response["error"],
+                    Response["data"],
+                    number,
+                    QueryKey<Paths, Method, Path>
+                >,
+                "queryKey" | "queryFn"
+            >?,
+            QueryClient?,
         ]
-) => UseInfiniteQueryResult<Response["data"], Response["error"]>;
+) => UseInfiniteQueryResult<InfiniteData<Response["data"]>, Response["error"]>;
 
 export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -17,7 +17,13 @@ import {
   useSuspenseQuery,
   useInfiniteQuery,
 } from "@tanstack/react-query";
-import type { ClientMethod, FetchResponse, MaybeOptionalInit, Client as FetchClient, DefaultParamsOption } from "openapi-fetch";
+import type {
+  ClientMethod,
+  FetchResponse,
+  MaybeOptionalInit,
+  Client as FetchClient,
+  DefaultParamsOption,
+} from "openapi-fetch";
 import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "openapi-typescript-helpers";
 
 // Helper type to dynamically infer the type from the `select` property
@@ -95,33 +101,29 @@ export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>,
     : [InitWithUnknowns<Init>, Options?, QueryClient?]
 ) => UseQueryResult<InferSelectReturnType<Response["data"], Options["select"]>, Response["error"]>;
 
-export type UseInfiniteQueryMethod<
-    Paths extends Record<string, Record<HttpMethod, {}>>,
-    Media extends MediaType
-> =
-    (<
-        Method extends HttpMethod,
-        Path extends PathsWithMethod<Paths, Method>,
-        Init extends MaybeOptionalInit<Paths[Path], Method>,
-        Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>,
-        Options extends Omit<
-            UseInfiniteQueryOptions<
-                Response["data"],
-                Response["error"],
-                InfiniteData<Response["data"]>,
-                Response["data"],
-                QueryKey<Paths, Method, Path>,
-                unknown
-            >,
-            "queryKey" | "queryFn"
-        >
-    >(
-        method: Method,
-        url: Path,
-        init: InitWithUnknowns<Init>,
-        options: Options,
-        queryClient?: QueryClient
-    ) => UseInfiniteQueryResult<InfiniteData<Response["data"]>, Response["error"]>);
+export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
+  Method extends HttpMethod,
+  Path extends PathsWithMethod<Paths, Method>,
+  Init extends MaybeOptionalInit<Paths[Path], Method>,
+  Response extends Required<FetchResponse<Paths[Path][Method], Init, Media>>,
+  Options extends Omit<
+    UseInfiniteQueryOptions<
+      Response["data"],
+      Response["error"],
+      InfiniteData<Response["data"]>,
+      Response["data"],
+      QueryKey<Paths, Method, Path>,
+      unknown
+    >,
+    "queryKey" | "queryFn"
+  >,
+>(
+  method: Method,
+  url: Path,
+  init: InitWithUnknowns<Init>,
+  options: Options,
+  queryClient?: QueryClient,
+) => UseInfiniteQueryResult<InfiniteData<Response["data"]>, Response["error"]>;
 
 export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,
@@ -197,41 +199,38 @@ export default function createClient<Paths extends {}, Media extends MediaType =
     useSuspenseQuery: (method, path, ...[init, options, queryClient]) =>
       useSuspenseQuery(queryOptions(method, path, init as InitWithUnknowns<typeof init>, options), queryClient),
     useInfiniteQuery: (method, path, init, options, queryClient) =>
-        useInfiniteQuery(
-            {
-              queryKey: [method, path, init] as const,
-              queryFn: async <
-                  Method extends HttpMethod,
-                  Path extends PathsWithMethod<Paths, Method>,
-              >({
-                  queryKey: [method, path, init],
-                  pageParam = 0,
-                  signal,
-                }: QueryFunctionContext<QueryKey<Paths, Method, Path>, unknown>) => {
-                const mth = method.toUpperCase() as Uppercase<typeof method>;
-                const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
-                const mergedInit = {
-                  ...init,
-                  signal,
-                  params: {
-                    ...(init?.params || {}),
-                    query: {
-                      ...(init?.params as { query?: DefaultParamsOption })?.query,
-                      cursor: pageParam,
-                    },
-                  },
-                };
-
-                const { data, error } = await fn(path, mergedInit as any);
-                if (error) {
-                  throw error;
-                }
-                return data;
+      useInfiniteQuery(
+        {
+          queryKey: [method, path, init] as const,
+          queryFn: async <Method extends HttpMethod, Path extends PathsWithMethod<Paths, Method>>({
+            queryKey: [method, path, init],
+            pageParam = 0,
+            signal,
+          }: QueryFunctionContext<QueryKey<Paths, Method, Path>, unknown>) => {
+            const mth = method.toUpperCase() as Uppercase<typeof method>;
+            const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
+            const mergedInit = {
+              ...init,
+              signal,
+              params: {
+                ...(init?.params || {}),
+                query: {
+                  ...(init?.params as { query?: DefaultParamsOption })?.query,
+                  cursor: pageParam,
+                },
               },
-              ...options,
-            },
-            queryClient,
-        ),
+            };
+
+            const { data, error } = await fn(path, mergedInit as any);
+            if (error) {
+              throw error;
+            }
+            return data;
+          },
+          ...options,
+        },
+        queryClient,
+      ),
     useMutation: (method, path, options, queryClient) =>
       useMutation(
         {
@@ -252,4 +251,3 @@ export default function createClient<Paths extends {}, Media extends MediaType =
       ),
   };
 }
-

--- a/packages/openapi-react-query/test/fixtures/api.d.ts
+++ b/packages/openapi-react-query/test/fixtures/api.d.ts
@@ -15,6 +15,7 @@ export interface paths {
             parameters: {
                 query: {
                     limit: number;
+                    cursor?: number;
                 };
                 header?: never;
                 path?: never;

--- a/packages/openapi-react-query/test/fixtures/api.yaml
+++ b/packages/openapi-react-query/test/fixtures/api.yaml
@@ -11,6 +11,11 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: Successful response

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -827,10 +827,6 @@ describe("client", () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);
 
-      // Track request URLs using the mock handler
-      let firstRequestUrl: URL | undefined;
-      let secondRequestUrl: URL | undefined;
-
       // First page request handler
       const firstRequestHandler = useMockRequestHandler({
         baseUrl,
@@ -841,18 +837,22 @@ describe("client", () => {
       });
 
       const { result, rerender } = renderHook(
-        () => client.useInfiniteQuery("get", "/paginated-data",
-        {
-          params: {
-            query: {
-              limit: 3
-            }
-          }
-        },
-        {
-          getNextPageParam: (lastPage) => lastPage.nextPage,
-          initialPageParam: 0,
-        }),
+        () =>
+          client.useInfiniteQuery(
+            "get",
+            "/paginated-data",
+            {
+              params: {
+                query: {
+                  limit: 3,
+                },
+              },
+            },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextPage,
+              initialPageParam: 0,
+            },
+          ),
         { wrapper },
       );
 
@@ -860,9 +860,9 @@ describe("client", () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       // Verify first request
-      firstRequestUrl = firstRequestHandler.getRequestUrl();
-      expect(firstRequestUrl?.searchParams.get('limit')).toBe('3');
-      expect(firstRequestUrl?.searchParams.get('cursor')).toBe('0');
+      const firstRequestUrl = firstRequestHandler.getRequestUrl();
+      expect(firstRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(firstRequestUrl?.searchParams.get("cursor")).toBe("0");
 
       // Set up mock for second page before triggering next page fetch
       const secondRequestHandler = useMockRequestHandler({
@@ -888,25 +888,24 @@ describe("client", () => {
       });
 
       // Verify second request
-      secondRequestUrl = secondRequestHandler.getRequestUrl();
-      expect(secondRequestUrl?.searchParams.get('limit')).toBe('3');
-      expect(secondRequestUrl?.searchParams.get('cursor')).toBe('1');
+      const secondRequestUrl = secondRequestHandler.getRequestUrl();
+      expect(secondRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(secondRequestUrl?.searchParams.get("cursor")).toBe("1");
 
       expect(result.current.data).toBeDefined();
-      expect(result.current.data!.pages[0].nextPage).toBe(1);
-
+      expect(result.current.data?.pages[0].nextPage).toBe(1);
 
       expect(result.current.data).toBeDefined();
-      expect(result.current.data!.pages[1].nextPage).toBe(2);
+      expect(result.current.data?.pages[1].nextPage).toBe(2);
 
       // Verify the complete data structure
       expect(result.current.data?.pages).toEqual([
         { items: [1, 2, 3], nextPage: 1 },
-        { items: [4, 5, 6], nextPage: 2 }
+        { items: [4, 5, 6], nextPage: 2 },
       ]);
 
       // Verify we can access all items through pages
-      const allItems = result.current.data?.pages.flatMap(page => page.items);
+      const allItems = result.current.data?.pages.flatMap((page) => page.items);
       expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
     });
     it("should reverse pages and pageParams when using the select option", async () => {
@@ -923,27 +922,27 @@ describe("client", () => {
       });
 
       const { result, rerender } = renderHook(
-          () =>
-              client.useInfiniteQuery(
-                  "get",
-                  "/paginated-data",
-                  {
-                    params: {
-                      query: {
-                        limit: 3,
-                      },
-                    },
-                  },
-                  {
-                    getNextPageParam: (lastPage) => lastPage.nextPage,
-                    initialPageParam: 0,
-                    select: (data) => ({
-                      pages: [...data.pages].reverse(),
-                      pageParams: [...data.pageParams].reverse(),
-                    }),
-                  }
-              ),
-          { wrapper }
+        () =>
+          client.useInfiniteQuery(
+            "get",
+            "/paginated-data",
+            {
+              params: {
+                query: {
+                  limit: 3,
+                },
+              },
+            },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextPage,
+              initialPageParam: 0,
+              select: (data) => ({
+                pages: [...data.pages].reverse(),
+                pageParams: [...data.pageParams].reverse(),
+              }),
+            },
+          ),
+        { wrapper },
       );
 
       // Wait for initial query to complete
@@ -979,17 +978,17 @@ describe("client", () => {
       expect(result.current.data).toBeDefined();
 
       // Since pages are reversed, the second page will now come first
-      expect(result.current.data!.pages).toEqual([
+      expect(result.current.data?.pages).toEqual([
         { items: [4, 5, 6], nextPage: 2 },
         { items: [1, 2, 3], nextPage: 1 },
       ]);
 
       // Verify reversed pageParams
-      expect(result.current.data!.pageParams).toEqual([1, 0]);
+      expect(result.current.data?.pageParams).toEqual([1, 0]);
 
       // Verify all items from reversed pages
-      const allItems = result.current.data!.pages.flatMap((page) => page.items);
+      const allItems = result.current.data?.pages.flatMap((page) => page.items);
       expect(allItems).toEqual([4, 5, 6, 1, 2, 3]);
     });
-  })
+  });
 });

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -822,6 +822,7 @@ describe("client", () => {
       });
     });
   });
+  // >: {"tests": ["infiniteQuery"]}
   describe("useInfiniteQuery", () => {
     it("should fetch data correctly with pagination and include cursor", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
@@ -990,5 +991,92 @@ describe("client", () => {
       const allItems = result.current.data?.pages.flatMap((page) => page.items);
       expect(allItems).toEqual([4, 5, 6, 1, 2, 3]);
     });
+    it("should use custom cursor params", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      // First page request handler
+      const firstRequestHandler = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/paginated-data",
+        status: 200,
+        body: { items: [1, 2, 3], nextPage: 1 },
+      });
+
+      const { result, rerender } = renderHook(
+        () =>
+          client.useInfiniteQuery(
+            "get",
+            "/paginated-data",
+            {
+              params: {
+                query: {
+                  limit: 3,
+                },
+              },
+            },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextPage,
+              initialPageParam: 0,
+              pageParamName: "follow_cursor",
+            },
+          ),
+        { wrapper },
+      );
+
+      // Wait for initial query to complete
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // Verify first request
+      const firstRequestUrl = firstRequestHandler.getRequestUrl();
+      expect(firstRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(firstRequestUrl?.searchParams.get("follow_cursor")).toBe("0");
+
+      // Set up mock for second page before triggering next page fetch
+      const secondRequestHandler = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/paginated-data",
+        status: 200,
+        body: { items: [4, 5, 6], nextPage: 2 },
+      });
+
+      // Fetch next page
+      await act(async () => {
+        await result.current.fetchNextPage();
+        // Force a rerender to ensure state is updated
+        rerender();
+      });
+
+      // Wait for second page to be fetched and verify loading states
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.hasNextPage).toBe(true);
+        expect(result.current.data?.pages).toHaveLength(2);
+      });
+
+      // Verify second request
+      const secondRequestUrl = secondRequestHandler.getRequestUrl();
+      expect(secondRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(secondRequestUrl?.searchParams.get("follow_cursor")).toBe("1");
+
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.pages[0].nextPage).toBe(1);
+
+      expect(result.current.data).toBeDefined();
+      expect(result.current.data?.pages[1].nextPage).toBe(2);
+
+      // Verify the complete data structure
+      expect(result.current.data?.pages).toEqual([
+        { items: [1, 2, 3], nextPage: 1 },
+        { items: [4, 5, 6], nextPage: 2 },
+      ]);
+
+      // Verify we can access all items through pages
+      const allItems = result.current.data?.pages.flatMap((page) => page.items);
+      expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
+    });
   });
+  // <: {"tests": ["infiniteQuery"]}
 });

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -822,7 +822,6 @@ describe("client", () => {
       });
     });
   });
-  // >: {"tests": ["infiniteQuery"]}
   describe("useInfiniteQuery", () => {
     it("should fetch data correctly with pagination and include cursor", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
@@ -1078,5 +1077,4 @@ describe("client", () => {
       expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
     });
   });
-  // <: {"tests": ["infiniteQuery"]}
 });


### PR DESCRIPTION
## Changes

close https://github.com/openapi-ts/openapi-typescript/issues/1828

I added useInfiniteQuery() to openapi-react-query.

## How to Review

Any feedback is welcome. I'll review it and make updates!

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)

This is a continuation work of #1881 
