### PR TITLE
Add Vitest workspace config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[typescript][typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,3 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace(["packages/*"]);


### PR DESCRIPTION
## Changes

I added a [`vitest.workspace.ts`](https://vitest.dev/guide/workspace.html) file to the project root in order to help the [Vitest VSCode extension](https://github.com/vitest-dev/vscode) support running tests across the workspace.

Since this has no effect on package builds, I did not include a changeset.