### PR TITLE
Update @redocly/openapi-core to 1.28.0

### DIFF
--- a/.changeset/ninety-starfishes-speak.md
+++ b/.changeset/ninety-starfishes-speak.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Update @redocly/openapi-core to fix punycode deprecation bug

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.x"
   },
   "dependencies": {
-    "@redocly/openapi-core": "^1.27.2",
+    "@redocly/openapi-core": "^1.28.0",
     "ansi-colors": "^4.1.3",
     "change-case": "^5.4.4",
     "parse-json": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,8 @@ importers:
   packages/openapi-typescript:
     dependencies:
       '@redocly/openapi-core':
-        specifier: ^1.27.2
-        version: 1.27.2(supports-color@9.4.0)
+        specifier: ^1.28.0
+        version: 1.28.0(supports-color@9.4.0)
       ansi-colors:
         specifier: ^4.1.3
         version: 4.1.3
@@ -1288,9 +1288,9 @@ packages:
   '@redocly/config@0.20.2':
     resolution: {integrity: sha512-b9sP9IOV0AW6ZZGh+fgffhU9xvMRSvVodPLWzoW1GvoxhUja3ZbPOCrI54VBowPocZ+9a7pIqNt0Ge32Sh34pA==}
 
-  '@redocly/openapi-core@1.27.2':
-    resolution: {integrity: sha512-qVrDc27DHpeO2NRCMeRdb4299nijKQE3BY0wrA+WUHlOLScorIi/y7JzammLk22IaTvjR9Mv9aTAdjE1aUwJnA==}
-    engines: {node: '>=14.19.0', npm: '>=7.0.0'}
+  '@redocly/openapi-core@1.28.0':
+    resolution: {integrity: sha512-jnUsOFnz8w71l14Ww34Iswlj0AI4e/R0C5+K2W4v4GaY/sUkpH/145gHLJYlG4XV0neET4lNIptd4I8+yLyEHQ==}
+    engines: {node: '>=18.17.0', npm: '>=10.8.2'}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -6067,7 +6067,7 @@ snapshots:
 
   '@redocly/config@0.20.2': {}
 
-  '@redocly/openapi-core@1.27.2(supports-color@9.4.0)':
+  '@redocly/openapi-core@1.28.0(supports-color@9.4.0)':
     dependencies:
       '@redocly/ajv': 8.11.2
       '@redocly/config': 0.20.2
@@ -6076,11 +6076,9 @@ snapshots:
       js-levenshtein: 1.1.6
       js-yaml: 4.1.0
       minimatch: 5.1.6
-      node-fetch: 2.7.0
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   '@rollup/plugin-alias@5.1.1(rollup@4.31.0)':


### PR DESCRIPTION
## Changes

I updated `@redocly/openapi-core` to [v1.28.0](https://github.com/Redocly/redocly-cli/releases/tag/%40redocly%2Fopenapi-core%401.28.0). This update [removes](https://github.com/Redocly/redocly-cli/pull/1848) deprecated use of `punycode`, which should clean up everyone's log output when running `openapi-typescript` 🎉

Fixes #1939.