### PR TITLE
fix(openapi-typescript): missing jsdocs comment anyof nested schema

### DIFF
--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -29,6 +29,7 @@ export interface AnnotatedSchemaObject {
   deprecated?: boolean; // jsdoc without value
   description?: string; // jsdoc with value
   enum?: unknown[]; // jsdoc without value
+  anyOf?: unknown[]; // jsdoc without value
   example?: string; // jsdoc with value
   format?: string; // not jsdoc
   nullable?: boolean; // Node information
@@ -78,6 +79,16 @@ export function addJSDocComment(schemaObject: AnnotatedSchemaObject, node: ts.Pr
     const serialized =
       typeof schemaObject[field] === "object" ? JSON.stringify(schemaObject[field], null, 2) : schemaObject[field];
     output.push(`@${field} ${String(serialized).replace(LB_RE, "\n *     ")}`);
+  }
+
+  // anyOf
+  if (!schemaObject.description && Array.isArray(schemaObject.anyOf)) {
+    const anyOfDescriptions = schemaObject.anyOf
+      .map((subSchema: any) => subSchema.description)
+      .filter((description: string | undefined) => typeof description === "string" && description.trim() !== "");
+    if (anyOfDescriptions.length > 0) {
+      output.push(`@description ${anyOfDescriptions.join(" | ")}`);
+    }
   }
 
   // JSDoc 'Constant' without value

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -54,6 +54,18 @@ describe("addJSDocComment", () => {
     comment: boolean;
 }`);
   });
+
+  test("anyOf", () => {
+    const property = ts.factory.createPropertySignature(undefined, "comment", undefined, tsUnion([BOOLEAN, BOOLEAN]));
+    addJSDocComment(
+      { anyOf: [{ description: "This is the comment 1" }, { description: "This is the comment 2" }] },
+      property,
+    );
+    expect(astToString(ts.factory.createTypeLiteralNode([property])).trim()).toBe(`{
+    /** @description This is the comment 1 | This is the comment 2 */
+    comment: boolean;
+}`);
+  });
 });
 
 describe("oapiRef", () => {


### PR DESCRIPTION
## Changes

proposal fix for https://github.com/openapi-ts/openapi-typescript/issues/2142
_What does this PR change? Link to any related issue(s)._

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
