### PR TITLE
fix(openapi-typescript): --make-paths-enum renames the paths URL

### DIFF
--- a/.changeset/little-meals-hide.md
+++ b/.changeset/little-meals-hide.md
@@ -2,4 +2,4 @@
 "openapi-typescript": patch
 ---
 
-fix: --make-paths-enum renames the paths URL (:id instead of {id})
+- Fixed --make-paths-enum option transforming the paths URL (`:id` instead of `{id}`)

--- a/.changeset/little-meals-hide.md
+++ b/.changeset/little-meals-hide.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix: --make-paths-enum renames the paths URL (:id instead of {id})

--- a/packages/openapi-typescript/src/transform/paths-enum.ts
+++ b/packages/openapi-typescript/src/transform/paths-enum.ts
@@ -30,11 +30,7 @@ export default function makeApiPathsEnum(pathsObject: PathsObject): ts.EnumDecla
           })
           .join("");
       }
-
-      // Replace {parameters} with :parameters
-      const adaptedUrl = url.replace(/{(\w+)}/g, "{$1}");
-
-      enumKeys.push(adaptedUrl);
+      enumKeys.push(url);
       enumMetaData.push({
         name: pathName,
       });

--- a/packages/openapi-typescript/src/transform/paths-enum.ts
+++ b/packages/openapi-typescript/src/transform/paths-enum.ts
@@ -32,7 +32,7 @@ export default function makeApiPathsEnum(pathsObject: PathsObject): ts.EnumDecla
       }
 
       // Replace {parameters} with :parameters
-      const adaptedUrl = url.replace(/{(\w+)}/g, ":$1");
+      const adaptedUrl = url.replace(/{(\w+)}/g, "{$1}");
 
       enumKeys.push(adaptedUrl);
       enumMetaData.push({

--- a/packages/openapi-typescript/test/transform/paths-enum.test.ts
+++ b/packages/openapi-typescript/test/transform/paths-enum.test.ts
@@ -38,7 +38,7 @@ describe("transformPathsObjectToEnum", () => {
           },
         },
         want: `export enum ApiPaths {
-    GetApiV1User = "/api/v1/user/:user_id"
+    GetApiV1User = "/api/v1/user/{user_id}"
 }`,
       },
     ],
@@ -62,7 +62,7 @@ describe("transformPathsObjectToEnum", () => {
           },
         },
         want: `export enum ApiPaths {
-    GetUserById = "/api/v1/user/:user_id"
+    GetUserById = "/api/v1/user/{user_id}"
 }`,
       },
     ],
@@ -89,8 +89,8 @@ describe("transformPathsObjectToEnum", () => {
           },
         },
         want: `export enum ApiPaths {
-    GetUserById = "/api/v1/user/:user_id",
-    PostApiV1User = "/api/v1/user/:user_id"
+    GetUserById = "/api/v1/user/{user_id}",
+    PostApiV1User = "/api/v1/user/{user_id}"
 }`,
       },
     ],


### PR DESCRIPTION
## Changes

Fixes: https://github.com/openapi-ts/openapi-typescript/issues/2101, when the --make-paths-enum was reintroduced back it was reintroduced with previously fixed bug: https://github.com/openapi-ts/openapi-typescript/issues/950

## How to Review

It's straight-forward change :) 

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
