### PR TITLE
fix(openapi-fetch): fix overriding baseUrl per request without overriding default baseUrl

### DIFF
--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -54,8 +54,9 @@ export default function createClient(clientOptions) {
       body,
       ...init
     } = fetchOptions || {};
+    let finalBaseUrl = baseUrl;
     if (localBaseUrl) {
-      baseUrl = removeTrailingSlash(localBaseUrl);
+      finalBaseUrl = removeTrailingSlash(localBaseUrl) ?? baseUrl;
     }
 
     let querySerializer =
@@ -94,7 +95,10 @@ export default function createClient(clientOptions) {
 
     let id;
     let options;
-    let request = new CustomRequest(createFinalURL(schemaPath, { baseUrl, params, querySerializer }), requestInit);
+    let request = new CustomRequest(
+      createFinalURL(schemaPath, { baseUrl: finalBaseUrl, params, querySerializer }),
+      requestInit,
+    );
 
     /** Add custom parameters to Request object */
     for (const key in init) {
@@ -108,7 +112,7 @@ export default function createClient(clientOptions) {
 
       // middleware (request)
       options = Object.freeze({
-        baseUrl,
+        baseUrl: finalBaseUrl,
         fetch,
         parseAs,
         querySerializer,

--- a/packages/openapi-fetch/test/common/create-client.test.ts
+++ b/packages/openapi-fetch/test/common/create-client.test.ts
@@ -38,6 +38,25 @@ describe("createClient options", () => {
     expect(actualURL.href).toBe("https://api.foo.bar/v3/resources");
   });
 
+  test("baseUrl per request causes no override on default baseUrl", async () => {
+    let actualURL = new URL("https://fakeurl.example");
+    const client = createObservedClient<paths>({ baseUrl: "https://api.foo.bar/v2/" }, async (req) => {
+      actualURL = new URL(req.url);
+      return Response.json([]);
+    });
+
+    const localBaseUrl = "https://api.foo.bar/v3";
+    await client.GET("/resources", { baseUrl: localBaseUrl });
+
+    // assert baseUrl and path mesh as expected
+    expect(actualURL.href).toBe("https://api.foo.bar/v3/resources");
+
+    await client.GET("/resources");
+
+    // assert baseUrl and path mesh as expected
+    expect(actualURL.href).toBe("https://api.foo.bar/v2/resources");
+  });
+
   describe("content-type", () => {
     const BODY_ACCEPTING_METHODS = [["PUT"], ["POST"], ["DELETE"], ["OPTIONS"], ["PATCH"]] as const;
     const ALL_METHODS = [...BODY_ACCEPTING_METHODS, ["GET"], ["HEAD"]] as const;


### PR DESCRIPTION
## Changes

Fixes: https://github.com/openapi-ts/openapi-typescript/issues/2156

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
