### PR TITLE
Infer Return Type for `select` from `useInfiniteQuery`

### DIFF
--- a/.changeset/seven-monkeys-fetch.md
+++ b/.changeset/seven-monkeys-fetch.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": minor
+---
+
+[#2169](https://github.com/openapi-ts/openapi-typescript/pull/2169): Infer returned `data` type from `select` option when used with the `useInfiniteQuery` method.

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -74,7 +74,9 @@ export default defineConfig({
             { text: "useQuery", link: "/use-query" },
             { text: "useMutation", link: "/use-mutation" },
             { text: "useSuspenseQuery", link: "/use-suspense-query" },
+            { text: "useInfiniteQuery", link: "/use-infinite-query" },
             { text: "queryOptions", link: "/query-options" },
+            { text: "About", link: "/about" },
           ],
         },
         {

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -76,7 +76,6 @@ export default defineConfig({
             { text: "useSuspenseQuery", link: "/use-suspense-query" },
             { text: "useInfiniteQuery", link: "/use-infinite-query" },
             { text: "queryOptions", link: "/query-options" },
-            { text: "About", link: "/about" },
           ],
         },
         {

--- a/docs/openapi-react-query/use-infinite-query.md
+++ b/docs/openapi-react-query/use-infinite-query.md
@@ -105,6 +105,7 @@ const query = $api.useInfiniteQuery(
   - Only required if the OpenApi schema requires parameters.
   - The options `params` are used as key. See [Query Keys](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys) for more information.
 - `infiniteQueryOptions`
+  - `pageParamName` The query param name used for pagination, `"cursor"` by default.
   - The original `useInfiniteQuery` options.
   - [See more information](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery)
 - `queryClient`

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -125,7 +125,10 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
   init: InitWithUnknowns<Init>,
   options: Options,
   queryClient?: QueryClient,
-) => UseInfiniteQueryResult<InferSelectReturnType<InfiniteData<Response["data"]>, Options["select"]>, Response["error"]>;
+) => UseInfiniteQueryResult<
+  InferSelectReturnType<InfiniteData<Response["data"]>, Options["select"]>,
+  Response["error"]
+>;
 
 export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -110,7 +110,7 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
     UseInfiniteQueryOptions<
       Response["data"],
       Response["error"],
-      InfiniteData<Response["data"]>,
+      InferSelectReturnType<InfiniteData<Response["data"]>, Options["select"]>,
       Response["data"],
       QueryKey<Paths, Method, Path>,
       unknown
@@ -125,7 +125,7 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
   init: InitWithUnknowns<Init>,
   options: Options,
   queryClient?: QueryClient,
-) => UseInfiniteQueryResult<InfiniteData<Response["data"]>, Response["error"]>;
+) => UseInfiniteQueryResult<InferSelectReturnType<InfiniteData<Response["data"]>, Options["select"]>, Response["error"]>;
 
 export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
   Method extends HttpMethod,

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -1087,7 +1087,7 @@ describe("client", () => {
       const allItems = result.current.data?.pages.flatMap((page) => page.items);
       expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
     });
-    it('should use return type from select option', async () => {
+    it("should use return type from select option", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);
 


### PR DESCRIPTION
## Changes

Updates the types for `useInfiniteQuery` to infer the return type from the `select` option, if provided. Adds onto #2105 with recent addition of #2117.

Also adds the docs for `useInfiniteQuery` to the navigation in the docs site, it wasn't being linked to, and adds a note about customizing the query param name for pagination.

## How to Review

See previous PR for the type inference in #2105 and additional test added to the `useInfiniteQuery` suite to check the return type is correctly inferred and functionally sound from useInfiniteQuery.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
