### PR TITLE
Fix invalid $ref index into path

### DIFF
--- a/packages/openapi-typescript/src/transform/parameters-array.ts
+++ b/packages/openapi-typescript/src/transform/parameters-array.ts
@@ -92,7 +92,7 @@ export function transformParametersArray(
       }
       const subType =
         "$ref" in original
-          ? oapiRef(original.$ref)
+          ? oapiRef(original.$ref, resolved)
           : transformParameterObject(resolved as ParameterObject, {
               ...options,
               path: createRef([options.path, "parameters", resolved.in, resolved.name]),

--- a/packages/openapi-typescript/test/fixtures/parameters-test.yaml
+++ b/packages/openapi-typescript/test/fixtures/parameters-test.yaml
@@ -35,6 +35,9 @@ paths:
             type: string
         - $ref: "#/components/parameters/local_ref_b"
         - $ref: "./_parameters-test-partial.yaml#/remote_ref_b"
+  /endpoint2:
+    parameters: 
+      - $ref: "#/paths/~1endpoint/get/parameters/0"
 components:
   parameters:
     local_ref_a:

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -172,6 +172,25 @@ export type operations = Record<string, never>;`,
         patch?: never;
         trace?: never;
     };
+    "/endpoint2": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description This overrides parameters */
+                local_param_a: paths["/endpoint"]["get"]["parameters"]["path"]["local_param_a"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -65,14 +65,26 @@ describe("oapiRef", () => {
     expect(astToString(oapiRef("#/components/schemas/User")).trim()).toBe(`components["schemas"]["User"]`);
   });
 
-  test("removes inner `properties`", () => {
+  test("`properties` of component schema `properties`", () => {
     expect(astToString(oapiRef("#/components/schemas/User/properties/username")).trim()).toBe(
       `components["schemas"]["User"]["username"]`,
     );
   });
 
-  test("leaves final `properties` intact", () => {
+  test("component schema named `properties`", () => {
     expect(astToString(oapiRef("#/components/schemas/properties")).trim()).toBe(`components["schemas"]["properties"]`);
+  });
+
+  test("reference into paths parameters", () => {
+    expect(
+      astToString(
+        oapiRef("#/paths/~1endpoint/get/parameters/0", {
+          in: "query",
+          name: "boop",
+          required: true,
+        }),
+      ).trim(),
+    ).toBe('paths["/endpoint"]["get"]["parameters"]["query"]["boop"]');
   });
 });
 

--- a/packages/openapi-typescript/test/transform/webhooks-object.test.ts
+++ b/packages/openapi-typescript/test/transform/webhooks-object.test.ts
@@ -105,10 +105,10 @@ describe("transformWebhooksObject", () => {
                 schema: { type: "string" },
                 required: true,
               },
-              { $ref: "#/components/parameters/query/utm_source" },
-              { $ref: "#/components/parameters/query/utm_email" },
-              { $ref: "#/components/parameters/query/utm_campaign" },
-              { $ref: "#/components/parameters/path/version" },
+              { $ref: "#/components/parameters/utm_source" },
+              { $ref: "#/components/parameters/utm_email" },
+              { $ref: "#/components/parameters/utm_campaign" },
+              { $ref: "#/components/parameters/version" },
             ],
           },
         },
@@ -117,13 +117,13 @@ describe("transformWebhooksObject", () => {
         parameters: {
             query: {
                 signature: string;
-                utm_source?: components["parameters"]["query"]["utm_source"];
-                utm_email?: components["parameters"]["query"]["utm_email"];
-                utm_campaign?: components["parameters"]["query"]["utm_campaign"];
+                utm_source?: components["parameters"]["utm_source"];
+                utm_email?: components["parameters"]["utm_email"];
+                utm_campaign?: components["parameters"]["utm_campaign"];
             };
             header?: never;
             path: {
-                utm_campaign: components["parameters"]["path"]["version"];
+                utm_campaign: components["parameters"]["version"];
             };
             cookie?: never;
         };
@@ -141,28 +141,28 @@ describe("transformWebhooksObject", () => {
           ...DEFAULT_OPTIONS,
           resolve($ref) {
             switch ($ref) {
-              case "#/components/parameters/query/utm_source": {
+              case "#/components/parameters/utm_source": {
                 return {
                   in: "query",
                   name: "utm_source",
                   schema: { type: "string" },
                 };
               }
-              case "#/components/parameters/query/utm_email": {
+              case "#/components/parameters/utm_email": {
                 return {
                   in: "query",
                   name: "utm_email",
                   schema: { type: "string" },
                 };
               }
-              case "#/components/parameters/query/utm_campaign": {
+              case "#/components/parameters/utm_campaign": {
                 return {
                   in: "query",
                   name: "utm_campaign",
                   schema: { type: "string" },
                 };
               }
-              case "#/components/parameters/path/version": {
+              case "#/components/parameters/version": {
                 return {
                   in: "path",
                   name: "utm_campaign",


### PR DESCRIPTION
## ⚠️ The Error

Refs into the parameters array are turned into invalid indexes into the `paths` structure.

## 🗣️ Discussion

The problematic behavior is triggered using a $ref that points into the `parameters` array.
The problematic generated type then tries to index into `["parameters"]["0"]` as though it were an array, when in fact it should be indexing into `["parameters"]["query"]`.

This particular weird ref was generated when I bundled a big schema with [@apidevtools/json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser/blob/main/docs/ref-parser.md#the-refparser-class).

## :wrench: Fix

* While parsing `oapiRefs` from parameters arrays, pass the resolved ParameterObject and use its `in` method to index into `parameters` type.

This probably doesn't work for more complex $refs, but I think it does slightly improve the semantic awareness of `oapiRef`.