### PR TITLE
chore(docs): Update svelte urls and internal example link

### DIFF
--- a/packages/openapi-fetch/examples/sveltekit/README.md
+++ b/packages/openapi-fetch/examples/sveltekit/README.md
@@ -1,9 +1,9 @@
 # openapi-fetch + Svelte/ SvelteKit
 
-Example of using openapi-fetch in [Svelte](https://svelte.dev/) / [SvelteKit](https://kit.svelte.dev).
+Example of using openapi-fetch in [Svelte](https://svelte.dev/docs/svelte/overview) / [SvelteKit](https://svelte.dev/docs/kit/introduction).
 
 - [Svelte or clientside SvelteKit example](./src/routes/+page.svelte)
-- [SveleKit Page Data example](./src/routes/server/+page.svelte)
+- [SveleKit Page Data example](./src/routes/page-data/+page.svelte)
 
 ## Setup
 


### PR DESCRIPTION
## Changes
Docs. Broken links (or redirecting) and broken url to page example.

## How to Review

Just docs.

## Checklist
- [X] `docs/` updated (if necessary)
