### PR TITLE
Fix boolean props

### DIFF
--- a/.changeset/clever-worms-smile.md
+++ b/.changeset/clever-worms-smile.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix boolean object property schemas

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -29,6 +29,23 @@ describe("transformSchemaObject > object", () => {
       },
     ],
     [
+      "property > boolean",
+      {
+        given: {
+          type: "object",
+          required: ["truthy", "falsy"],
+          properties: {
+            truthy: true,
+            falsy: false,
+          },
+        },
+        want: `{
+    truthy: unknown;
+    falsy: never;
+}`,
+      },
+    ],
+    [
       "empty",
       {
         given: { type: "object" },


### PR DESCRIPTION
## Changes

This PR adds support for boolean property schemas, ie:
```json
{
  "type": "object",
  "properties": {
    "truthy": true,
    "falsy": false
  }
}
```

The PR changes the flow in the loop handling object properties to reach "edge-case" handling that was already present for boolean schemas. This was previously not reached due to an early error that was thrown if the property schema was not an object. Properties that were previously accessed directly from the schema object are now extracted conditionally before hand.

Closes #2198.

## How to Review

See the added test case for details.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
