### PR TITLE
fix(openapi-fetch): prevent body parsing for HEAD requests regardless of Content-Length

### DIFF
--- a/.changeset/breezy-bottles-mix.md
+++ b/.changeset/breezy-bottles-mix.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Fix HEAD method requests to prevent body parsing regardless of Content-Length header value

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -209,7 +209,7 @@ export default function createClient(clientOptions) {
     }
 
     // handle empty content
-    if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+    if (response.status === 204 || request.method === "HEAD" || response.headers.get("Content-Length") === "0") {
       return response.ok ? { data: undefined, response } : { error: undefined, response };
     }
 

--- a/packages/openapi-fetch/test/http-methods/head.test.ts
+++ b/packages/openapi-fetch/test/http-methods/head.test.ts
@@ -13,4 +13,16 @@ describe("HEAD", () => {
     await client.HEAD("/resources/{id}", { params: { path: { id: 123 } } });
     expect(method).toBe("HEAD");
   });
+
+  test("handles HEAD requests with non-zero Content-Length without parsing the body", async () => {
+    const client = createObservedClient<paths>({}, async () => {
+      return new Response(null, {
+        headers: { "Content-Length": "42", "Content-Type": "application/json" },
+        status: 200,
+      });
+    });
+    const result = await client.HEAD("/resources/{id}", { params: { path: { id: 123 } } });
+    expect(result.data).toBeUndefined();
+    expect(result.response.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Changes

- This PR fixes how HEAD method requests are handled in openapi-fetch by preventing body parsing regardless of the Content-Length header value.

- [According to RFC 9110,](https://httpwg.org/specs/rfc9110.html#HEAD) HEAD responses should have the same metadata as GET but must not include a body. 
Previously, the library only handled this correctly when Content-Length was "0", causing JSON parsing errors in other cases.

- Fixes #2195.

## How to Review

- Check that the condition now properly skips body parsing for HEAD requests
- Verify the new test case ensures HEAD requests with non-zero Content-Length are handled correctly

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary) - N/A
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript) - N/A
