### PR TITLE
docs(openapi-react-query) Update docs for useInfiniteQuery

### DIFF
--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -74,6 +74,7 @@ export default defineConfig({
             { text: "useQuery", link: "/use-query" },
             { text: "useMutation", link: "/use-mutation" },
             { text: "useSuspenseQuery", link: "/use-suspense-query" },
+            { text: "useInfiniteQuery", link: "/use-infinite-query" },
             { text: "queryOptions", link: "/query-options" },
           ],
         },

--- a/docs/openapi-react-query/use-infinite-query.md
+++ b/docs/openapi-react-query/use-infinite-query.md
@@ -105,6 +105,9 @@ const query = $api.useInfiniteQuery(
   - Only required if the OpenApi schema requires parameters.
   - The options `params` are used as key. See [Query Keys](https://tanstack.com/query/latest/docs/framework/react/guides/query-keys) for more information.
 - `infiniteQueryOptions`
+  - `pageParamName`
+    - The name of the page parameter to use in the query. This will override any value provided in `options.query`.
+    - Default: `"cursor"`.
   - The original `useInfiniteQuery` options.
   - [See more information](https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery)
 - `queryClient`


### PR DESCRIPTION
There were no (published) docs for `useInfiniteQuery`.

## Changes

1. Add missing link to useInfiniteQuery docs
2. Add pageParamName to docs

## How to Review

Check whether the docs are correct.

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
