### PR TITLE
Fix import paths in swr-openapi docs

### DIFF
--- a/docs/swr-openapi/use-immutable.md
+++ b/docs/swr-openapi/use-immutable.md
@@ -8,7 +8,7 @@ This hook has the same contracts as [`useQuery`](./use-query.md). However, inste
 
 ```ts
 import createClient from "openapi-fetch";
-import { createQueryHook } from "swr-openapi";
+import { createImmutableHook } from "swr-openapi";
 import type { paths } from "./my-schema";
 
 const useImmutable = createImmutableHook(client, "my-api");

--- a/docs/swr-openapi/use-infinite.md
+++ b/docs/swr-openapi/use-infinite.md
@@ -8,7 +8,7 @@ This hook is a typed wrapper over [`useSWRInfinite`][swr-infinite].
 
 ```ts
 import createClient from "openapi-fetch";
-import { createQueryHook } from "swr-openapi";
+import { createInfiniteHook } from "swr-openapi";
 import type { paths } from "./my-schema";
 
 const client = createClient<paths>(/* ... */);


### PR DESCRIPTION
## Changes

Fixes import paths in the example snippets

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
