### PR TITLE
React query handle 204 or zero content length

### DIFF
--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -191,9 +191,12 @@ export default function createClient<Paths extends {}, Media extends MediaType =
   }: QueryFunctionContext<QueryKey<Paths, Method, Path>>) => {
     const mth = method.toUpperCase() as Uppercase<typeof method>;
     const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
-    const { data, error } = await fn(path, { signal, ...(init as any) }); // TODO: find a way to avoid as any
+    const { data, error, response } = await fn(path, { signal, ...(init as any) }); // TODO: find a way to avoid as any
     if (error) {
       throw error;
+    }
+    if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+      return data ?? null;
     }
 
     return data;

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -315,7 +315,7 @@ describe("client", () => {
       expect(error).toBeNull();
     });
 
-    it("should resolve error properly and have undefined data when queryFn returns undefined", async () => {
+    it("handles undefined response with non-zero Content-Length (status 200) by setting error and undefined data", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);
 
@@ -324,6 +324,9 @@ describe("client", () => {
         method: "get",
         path: "/string-array",
         status: 200,
+        headers: {
+          "Content-Length": "10"
+        },
         body: undefined,
       });
 
@@ -335,6 +338,53 @@ describe("client", () => {
 
       expect(error).toBeInstanceOf(Error);
       expect(data).toBeUndefined();
+    });
+
+    it("handles undefined response with zero Content-Length by setting data and error to null", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
+        status: 200,
+        headers: {
+          "Content-Length": "0"
+        },
+        body: undefined,
+      });
+
+      const { result } = renderHook(() => client.useQuery("get", "/string-array"), { wrapper });
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      const { data, error } = result.current;
+
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("handles undefined response with 204 No Content status by setting data and error to null", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
+        status: 204,
+        body: undefined,
+      });
+
+      const { result } = renderHook(() => client.useQuery("get", "/string-array"), { wrapper });
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      const { data, error } = result.current;
+
+      expect(error).toBeNull();
+      expect(data).toBeNull();
     });
 
     it("should infer correct data and error type", async () => {

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -325,7 +325,7 @@ describe("client", () => {
         path: "/string-array",
         status: 200,
         headers: {
-          "Content-Length": "10"
+          "Content-Length": "10",
         },
         body: undefined,
       });
@@ -350,7 +350,7 @@ describe("client", () => {
         path: "/string-array",
         status: 200,
         headers: {
-          "Content-Length": "0"
+          "Content-Length": "0",
         },
         body: undefined,
       });


### PR DESCRIPTION
## Changes

I created an issue about how 204 status codes are handled and an error that's thrown by react-query due to data being returned as undefined (Something that react-query does not support for it's queryFn's).

Issue: https://github.com/openapi-ts/openapi-typescript/issues/2234

This PR handles 204 or zero Content-Length header by returning data as null in the queryFn.

## How to Review

Use the useQuery hook towards an API endpoint that returns a 204 status or zero value in the Content-Length header, the data should be set to null and no error should be thrown.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
