### PR TITLE
Replacing `any` with `unknown` in the `ReadonlyArray` type declaration.

### DIFF
--- a/.changeset/wet-cougars-behave.md
+++ b/.changeset/wet-cougars-behave.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Replacing `any` with `unknown` in the `ReadonlyArray` type declaration.

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -508,7 +508,7 @@ export function tsReadonlyArray(type: ts.TypeNode, injectFooter?: ts.Node[]): ts
     !injectFooter.some((node) => ts.isTypeAliasDeclaration(node) && node?.name?.escapedText === "ReadonlyArray")
   ) {
     const helper = stringToAST(
-      "type ReadonlyArray<T> = [Exclude<T, undefined>] extends [any[]] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;",
+      "type ReadonlyArray<T> = [Exclude<T, undefined>] extends [unknown[]] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;",
     )[0] as any;
     injectFooter.push(helper);
   }

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -833,7 +833,7 @@ export type $defs = Record<string, never>;
 type ReadonlyArray<T> = [
     Exclude<T, undefined>
 ] extends [
-    any[]
+    unknown[]
 ] ? Readonly<Exclude<T, undefined>> : Readonly<Exclude<T, undefined>[]>;
 export const pathsUrlGetParametersQueryStatusValues: ReadonlyArray<paths["/url"]["get"]["parameters"]["query"]["status"]> = ["active", "inactive"];
 export const statusValues: ReadonlyArray<components["schemas"]["Status"]> = ["active", "inactive"];


### PR DESCRIPTION
## Changes

The current declaration of the enhanced `ReadonlyArray` type uses the [undesired](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#any) `any` type instead of the more appropriate `unknown` type.

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
