### PR TITLE
feat: Attach fetch response to SWR data/error

### DIFF
--- a/packages/swr-openapi/src/query-base.ts
+++ b/packages/swr-openapi/src/query-base.ts
@@ -4,6 +4,8 @@ import type { Fetcher, SWRHook } from "swr";
 import type { TypesForGetRequest } from "./types.js";
 import { useCallback, useDebugValue, useMemo } from "react";
 
+export const RESPONSE = Symbol.for('response');
+
 /**
  * @private
  */
@@ -35,7 +37,17 @@ export function configureBaseQueryHook(useHook: SWRHook) {
           // @ts-expect-error TODO: Improve internal init types
           const res = await client.GET(path, init);
           if (res.error) {
+            Object.defineProperty(res.error, RESPONSE, {
+              value: res.response,
+              enumerable: false,
+            });
             throw res.error;
+          }
+          if (res.data) {
+            Object.defineProperty(res.data, RESPONSE, {
+              value: res.response,
+              enumerable: false,
+            });
           }
           return res.data as Data;
         },


### PR DESCRIPTION
## Changes
It is useful to have the original fetch response available in the hook result. For instance to distinguish the HTTP status code in case of an `error`. Since SWR only returns `error` / `data` properties, this provides an escape hatch to be able to access to original `fetch` response, as returned by the `openapi-fetch` client.

https://github.com/openapi-ts/openapi-typescript/issues/2238

## Checklist

I was unable to run the test suite, making it hard to add / update unit tests for me.