### PR TITLE
fix(openapi-typescript): Add missing changeset for #2248

### DIFF
--- a/.changeset/lazy-bulldogs-kiss.md
+++ b/.changeset/lazy-bulldogs-kiss.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add jsdoc comments to response object


### PR DESCRIPTION
## Changes

Adds changeset that should have been in #2248.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
