### PR TITLE
fix: get post types with "post" option

### DIFF
--- a/packages/swr-openapi/src/mutate.ts
+++ b/packages/swr-openapi/src/mutate.ts
@@ -46,7 +46,7 @@ export function createMutateHook<Paths extends {}, IMediaType extends MediaType>
 
     return useCallback(
       function mutate<
-        Path extends PathsWithMethod<Paths, "get">,
+        Path extends PathsWithMethod<Paths, "post">,
         R extends TypesForGetRequest<Paths, Path>,
         Init extends R["Init"],
       >(


### PR DESCRIPTION
## Changes

Change the type of return

## How to Review

Generate a post open-api file and filter by path.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
