### PR TITLE
fix(openapi-fetch): dynamic access to methods using wrapAsPathBasedClient

### DIFF
--- a/.changeset/heavy-onions-bake.md
+++ b/.changeset/heavy-onions-bake.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+fix dynamic access to methods using wrapAsPathBasedClient

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -298,28 +298,28 @@ class PathCallForwarder {
     this.url = url;
   }
 
-  GET(init) {
+  GET = (init) => {
     return this.client.GET(this.url, init);
   }
-  PUT(init) {
+  PUT = (init) => {
     return this.client.PUT(this.url, init);
   }
-  POST(init) {
+  POST = (init) => {
     return this.client.POST(this.url, init);
   }
-  DELETE(init) {
+  DELETE = (init) => {
     return this.client.DELETE(this.url, init);
   }
-  OPTIONS(init) {
+  OPTIONS = (init) => {
     return this.client.OPTIONS(this.url, init);
   }
-  HEAD(init) {
+  HEAD = (init) => {
     return this.client.HEAD(this.url, init);
   }
-  PATCH(init) {
+  PATCH = (init) => {
     return this.client.PATCH(this.url, init);
   }
-  TRACE(init) {
+  TRACE = (init) => {
     return this.client.TRACE(this.url, init);
   }
 }

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -300,28 +300,28 @@ class PathCallForwarder {
 
   GET = (init) => {
     return this.client.GET(this.url, init);
-  }
+  };
   PUT = (init) => {
     return this.client.PUT(this.url, init);
-  }
+  };
   POST = (init) => {
     return this.client.POST(this.url, init);
-  }
+  };
   DELETE = (init) => {
     return this.client.DELETE(this.url, init);
-  }
+  };
   OPTIONS = (init) => {
     return this.client.OPTIONS(this.url, init);
-  }
+  };
   HEAD = (init) => {
     return this.client.HEAD(this.url, init);
-  }
+  };
   PATCH = (init) => {
     return this.client.PATCH(this.url, init);
-  }
+  };
   TRACE = (init) => {
     return this.client.TRACE(this.url, init);
-  }
+  };
 }
 
 class PathClientProxyHandler {

--- a/packages/openapi-fetch/test/path-based-client/path-based-client.test.ts
+++ b/packages/openapi-fetch/test/path-based-client/path-based-client.test.ts
@@ -86,15 +86,13 @@ describe("createPathBasedClient", () => {
         return Response.json({});
       });
 
-      const getMethodByPathAndMethod = (path: "/posts", method: 'GET') => {
+      const getMethodByPathAndMethod = (path: "/posts", method: "GET") => {
         return client[path][method];
-      }
+      };
 
       await getMethodByPathAndMethod("/posts", "GET")();
-      
+
       expect(method).toBe("GET");
     });
   });
 });
-
-

--- a/packages/openapi-fetch/test/path-based-client/path-based-client.test.ts
+++ b/packages/openapi-fetch/test/path-based-client/path-based-client.test.ts
@@ -1,5 +1,5 @@
 import type { MediaType } from "openapi-typescript-helpers";
-import { createExpect, describe, expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import { createPathBasedClient, type PathBasedClient } from "../../src/index.js";
 import type { paths } from "./schemas/path-based-client.js";
 
@@ -78,5 +78,23 @@ describe("createPathBasedClient", () => {
         expect(data.title).toBe("Blog post title");
       }
     });
+
+    test('properly binds "this" inside PathCallForwarder', async () => {
+      let method = "";
+      const client = createObservedPathBasedClient<paths>({}, async (req) => {
+        method = req.method;
+        return Response.json({});
+      });
+
+      const getMethodByPathAndMethod = (path: "/posts", method: 'GET') => {
+        return client[path][method];
+      }
+
+      await getMethodByPathAndMethod("/posts", "GET")();
+      
+      expect(method).toBe("GET");
+    });
   });
 });
+
+


### PR DESCRIPTION
## Changes

When using `wrapAsPathBasedClient` to access methods of client dynamically it was throwing an error as `this` context was not assigned to `PathCallForwarder` class.
Rewriting `PathCallForwarder` to use arrow function fixes the issue.

## How to Review

I've added a test case which has example how `wrapAsPathBasedClient` can be used in generic function to retrieve methods, which also verifies the fix.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
