### PR TITLE
Align package.json `main` fields to point to CommonJS bundles

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/cjs/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/openapi-react-query/package.json
+++ b/packages/openapi-react-query/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/openapi-typescript-helpers/package.json
+++ b/packages/openapi-typescript-helpers/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "./index.js",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
   "exports": {
     ".": {

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -11,7 +11,7 @@
     "openapi-typescript": "bin/cli.js"
   },
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
Hello!

This PR targets backwards-compatibility for these packages. We found that, in my work's legacy build system, Jest falls down on the `openapi-fetch` package because of the reported syntax error:

```
/[path]/node_modules/openapi-fetch/dist/index.js:8
export function randomID() {
^^^^^

SyntaxError: Unexpected token 'export'
```

This is a symptom of Jest expecting to find CommonJS syntax and unexpectedly finding ES Module sytanx.

Jest can handle CommonJS  when specified in `main` or ES Module syntax when specified in `module`, but it isn't resilient to receiving ES Module syntax from `main` where its expecting CommonJS. 

The goal for this change is to improve backwards compatibility with legacy resolution. Most more recent systems will prefer the paths in `exports`, which all of these packages already have specified.

There are other options for improving the legacy Jest case, but this is the lowest-churn way, without changing build systems or holistically modifying resolution for the package. 

## Caveat
I'm not certain this is an official standard - that `main` corresponds to CJS. It's hard to find concrete recommendations saying this directly, the closest thing I can find is that the Node JS documentation says about the `main` field: 
> It also defines the script that is used when the package directory is loaded via require()

where `require` is a CommonJS syntax.
[reference](https://nodejs.org/api/packages.html#main)


## Changes

Align the existing `main` fields in this repository's package.json files on their CommonJS bundles.
 
## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
Confirm the `main` fields are aligned with `exports.require` and make a philosophical call about whether that's consistent with their understanding of the `main` field in package.json. 😬  For reference, the `openapi-metadata` package is already aligned, but the `swr-openapi` package takes another strategy of specifying `"type": "module"` (I think).

## Checklist

- [n/a] Unit tests updated
- [n/a] `docs/` updated (if necessary)
- [n/a] `pnpm run update:examples` run (only applicable for openapi-typescript)
