### PR TITLE
chore: remove Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Changes

Node 18 is end-of-life as of April 30. Remove from CI.

This doesn’t mean we’re dropping support per se—it should continue to work for a while. But don’t spend CI minutes testing it.

## How to Review

- CI will catch errors

## Checklist

- [x] Tests updated