### PR TITLE
Feat: Add support for pattern properties

### DIFF
--- a/.changeset/eleven-shoes-mate.md
+++ b/.changeset/eleven-shoes-mate.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add support for patternProperties

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -548,7 +548,9 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
       const hasExplicitAdditionalProperties =
         typeof schemaObject.additionalProperties === "object" && Object.keys(schemaObject.additionalProperties).length;
       const hasImplicitAdditionalProperties =
-      schemaObject.additionalProperties === true || (typeof schemaObject.additionalProperties === "object" && Object.keys(schemaObject.additionalProperties).length === 0);
+        schemaObject.additionalProperties === true ||
+        (typeof schemaObject.additionalProperties === "object" &&
+          Object.keys(schemaObject.additionalProperties).length === 0);
       const hasExplicitPatternProperties =
         typeof schemaObject.patternProperties === "object" && Object.keys(schemaObject.patternProperties).length;
       const addlTypes = [];
@@ -564,7 +566,9 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
         }
       }
 
-      if (addlTypes.length === 0) return;
+      if (addlTypes.length === 0) {
+        return;
+      }
 
       const addlType = tsUnion(addlTypes);
 

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -502,6 +502,7 @@ export interface ObjectSubtype {
   type: "object" | ["object", "null"];
   properties?: { [name: string]: SchemaObject | ReferenceObject };
   additionalProperties?: boolean | Record<string, never> | SchemaObject | ReferenceObject;
+  patternProperties?: Record<string, SchemaObject | ReferenceObject>;
   required?: string[];
   allOf?: (SchemaObject | ReferenceObject)[];
   anyOf?: (SchemaObject | ReferenceObject)[];

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -138,7 +138,11 @@ describe("transformSchemaObject > object", () => {
     [
       "patternProperties > additional and patterns",
       {
-        given: { type: "object", additionalProperties: { type: "number" }, patternProperties: { "^a": { type: "string" } } },
+        given: {
+          type: "object",
+          additionalProperties: { type: "number" },
+          patternProperties: { "^a": { type: "string" } },
+        },
         want: `{
     [key: string]: number | string;
 }`,

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -103,7 +103,7 @@ describe("transformSchemaObject > object", () => {
       "patternProperties > empty object",
       {
         given: { type: "object", patternProperties: {} },
-        want: `Record<string, never>`,
+        want: "Record<string, never>",
       },
     ],
     [
@@ -113,10 +113,10 @@ describe("transformSchemaObject > object", () => {
         want: `{
     [key: string]: unknown;
 }`,
-      options: {
-        ...DEFAULT_OPTIONS,
-        ctx: { ...DEFAULT_CTX, additionalProperties: true },
-      }
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_CTX, additionalProperties: true },
+        },
       },
     ],
     [
@@ -182,10 +182,10 @@ describe("transformSchemaObject > object", () => {
         want: `{
     [key: string]: unknown | string;
 }`,
-      options: {
-        ...DEFAULT_OPTIONS,
-        ctx: { ...DEFAULT_CTX, additionalProperties: true },
-      }
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: { ...DEFAULT_CTX, additionalProperties: true },
+        },
       },
     ],
     [

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -103,9 +103,20 @@ describe("transformSchemaObject > object", () => {
       "patternProperties > empty object",
       {
         given: { type: "object", patternProperties: {} },
+        want: `Record<string, never>`,
+      },
+    ],
+    [
+      "patternProperties > empty object with options.additionalProperties=true",
+      {
+        given: { type: "object", patternProperties: {} },
         want: `{
     [key: string]: unknown;
 }`,
+      options: {
+        ...DEFAULT_OPTIONS,
+        ctx: { ...DEFAULT_CTX, additionalProperties: true },
+      }
       },
     ],
     [
@@ -136,6 +147,19 @@ describe("transformSchemaObject > object", () => {
       },
     ],
     [
+      "patternProperties > additional=true and patterns",
+      {
+        given: {
+          type: "object",
+          additionalProperties: true,
+          patternProperties: { "^a": { type: "string" } },
+        },
+        want: `{
+    [key: string]: unknown | string;
+}`,
+      },
+    ],
+    [
       "patternProperties > additional and patterns",
       {
         given: {
@@ -146,6 +170,22 @@ describe("transformSchemaObject > object", () => {
         want: `{
     [key: string]: number | string;
 }`,
+      },
+    ],
+    [
+      "patternProperties > patterns with options.additionalProperties=true",
+      {
+        given: {
+          type: "object",
+          patternProperties: { "^a": { type: "string" } },
+        },
+        want: `{
+    [key: string]: unknown | string;
+}`,
+      options: {
+        ...DEFAULT_OPTIONS,
+        ctx: { ...DEFAULT_CTX, additionalProperties: true },
+      }
       },
     ],
     [

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -100,6 +100,51 @@ describe("transformSchemaObject > object", () => {
       },
     ],
     [
+      "patternProperties > empty object",
+      {
+        given: { type: "object", patternProperties: {} },
+        want: `{
+    [key: string]: unknown;
+}`,
+      },
+    ],
+    [
+      "patternProperties > basic",
+      {
+        given: { type: "object", patternProperties: { "^a": { type: "string" } } },
+        want: `{
+    [key: string]: string;
+}`,
+      },
+    ],
+    [
+      "patternProperties > enum",
+      {
+        given: { type: "object", patternProperties: { "^a": { type: "string", enum: ["a", "b", "c"] } } },
+        want: `{
+    [key: string]: "a" | "b" | "c";
+}`,
+      },
+    ],
+    [
+      "patternProperties > multiple patterns",
+      {
+        given: { type: "object", patternProperties: { "^a": { type: "string" }, "^b": { type: "number" } } },
+        want: `{
+    [key: string]: string | number;
+}`,
+      },
+    ],
+    [
+      "patternProperties > additional and patterns",
+      {
+        given: { type: "object", additionalProperties: { type: "number" }, patternProperties: { "^a": { type: "string" } } },
+        want: `{
+    [key: string]: number | string;
+}`,
+      },
+    ],
+    [
       "nullable",
       {
         given: {


### PR DESCRIPTION
## Changes

Add support for patternProperties in addition to additionalProperties (#754).
Building on the work of @gzm0 in [1901](https://github.com/openapi-ts/openapi-typescript/pull/1901) by adding tests

Ran the command `pnpm run update:examples` which created 129 new files and updated 69, none of which seemed related to this change. Let me know if you wan't me to do it anyways.

## How to Review

Refer to comments in original [PR 1901](https://github.com/openapi-ts/openapi-typescript/pull/1901)
Validate tests are satisfactory

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
