### PR TITLE
Improve header handling

### DIFF
--- a/.changeset/bumpy-parrots-lie.md
+++ b/.changeset/bumpy-parrots-lie.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": patch
+---
+
+Improve header handling

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "size-limit": "^11.2.0",
     "turbo": "^2.5.2",
     "typescript": "^5.8.3",
-    "vitest": "^3.0.0"
+    "vitest": "^3.1.3"
   },
   "size-limit": [
     {

--- a/packages/openapi-metadata/package.json
+++ b/packages/openapi-metadata/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.3",
-    "@vitest/coverage-v8": "^3.0.0",
+    "@vitest/coverage-v8": "^3.1.3",
     "reflect-metadata": "^0.2.2",
     "typescript": "^5.8.3",
     "unbuild": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^3.0.0
+        specifier: ^3.1.3
         version: 3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.2(@types/node@22.15.17)(typescript@5.8.3))(yaml@2.7.1)
 
   docs:
@@ -221,7 +221,7 @@ importers:
         specifier: ^22.15.3
         version: 22.15.17
       '@vitest/coverage-v8':
-        specifier: ^3.0.0
+        specifier: ^3.1.3
         version: 3.1.3(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.15.17)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.2(@types/node@22.15.17)(typescript@5.8.3))(yaml@2.7.1))
       reflect-metadata:
         specifier: ^0.2.2


### PR DESCRIPTION
## Changes

Followup from #2096, also passes in mergedHeaders to the bodySerializer so we’re not dropping user-set headers.

## How to Review

- Tests should pass

## Checklist

No tests updated; this should be an invisible change