### PR TITLE
feat(openapi-react-query): add prefixQueryKey option

### DIFF
--- a/.changeset/good-buttons-bake.md
+++ b/.changeset/good-buttons-bake.md
@@ -1,0 +1,5 @@
+---
+'openapi-react-query': minor
+---
+
+Add `prefixQueryKey` to `createClient` to avoid query key collision between different openapi-fetch clients.

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -239,7 +239,35 @@ describe("client", () => {
       });
       const client = createClient(fetchClient);
 
-      expect(client.queryOptions("get", "/foo").queryKey.length).toBe(2);
+      expect(client.queryOptions("get", "/foo").queryKey.length).toBe(3);
+    });
+
+    it("should differentiate queries by prefixQueryKey", async () => {
+      const fetchClient1 = createFetchClient<minimalGetPaths>({ baseUrl, fetch: fetchInfinite });
+      const fetchClient2 = createFetchClient<minimalGetPaths>({ baseUrl, fetch: fetchInfinite });
+      const client1 = createClient(fetchClient1);
+      const client11 = createClient(fetchClient1);
+      const client2 = createClient(fetchClient2, { prefixQueryKey: ["cache2"] as const });
+
+      renderHook(
+        () => {
+          useQueries({
+            queries: [
+              client1.queryOptions("get", "/foo"),
+              client11.queryOptions("get", "/foo"),
+              client2.queryOptions("get", "/foo"),
+            ],
+          });
+        },
+        { wrapper },
+      );
+
+      expectTypeOf(client1.queryOptions("get", "/foo").queryKey[0]).toEqualTypeOf<unknown>();
+      expectTypeOf(client2.queryOptions("get", "/foo").queryKey[0]).toEqualTypeOf<readonly ["cache2"]>();
+
+      // client1 and client11 have the same query key, so 3 - 1 = 2
+      expect(queryClient.isFetching()).toBe(2);
+      expect(client2.queryOptions("get", "/foo").queryKey).toEqual([["cache2"], "get", "/foo"]);
     });
   });
 


### PR DESCRIPTION
## Background

Close #1979.

Current openapi-react-query has a potential issue because `useQuery` calls from different clients are assigned the same key, even though they're querying different endpoints.

For example:
```ts
import { default as createFetchClient } from 'openapi-fetch'
import createClient from 'openapi-react-query'

const client1 = createClient(createFetchClient({ baseUrl: 'https://api1.example.com' }))
const client2 = createClient(createFetchClient({ baseUrl: 'https://api2.example.com' }))

function useSomething() {
  return [client1.useQuery('get', '/a'), client2.useQuery('get', '/a')]
}
```

Here, both queries receive the same key, even though they are querying different sources.

This try to resolve the problem.

## Changes

- Added a `prefixQueryKey` parameter to differentiate cache identities.

## How to Review

- I haven't changed the documentation, but if you think it's necessary, please comment.
- I got [the comment about prefixQueryKey's type](https://github.com/openapi-ts/openapi-typescript/pull/1981#issuecomment-2474948667), and I ended up using `unknown` type.
See `packages/openapi-react-query/test/index.test.tsx:270`, and feel free to leave a comment if you have any other thoughts.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
