### PR TITLE
feat(openapi-fetch): add support for pathSerializer option

### DIFF
--- a/.changeset/late-moments-build.md
+++ b/.changeset/late-moments-build.md
@@ -1,0 +1,5 @@
+---
+"openapi-fetch": minor
+---
+
+Added support for setting a custom path serializers either globally or per request. This allows you to customize how path parameters are serialized in the URL. E.g. you can use a custom serializer to prevent encoding of a path parameter, if you need to pass a value that should not be encoded.

--- a/packages/openapi-fetch/src/index.d.ts
+++ b/packages/openapi-fetch/src/index.d.ts
@@ -23,6 +23,8 @@ export interface ClientOptions extends Omit<RequestInit, "headers"> {
   querySerializer?: QuerySerializer<unknown> | QuerySerializerOptions;
   /** global bodySerializer */
   bodySerializer?: BodySerializer<unknown>;
+  /** global pathSerializer */
+  pathSerializer?: PathSerializer;
   headers?: HeadersOptions;
   /** RequestInit extension object to pass as 2nd argument to fetch when supported (defaults to undefined) */
   requestInitExt?: Record<string, unknown>;
@@ -63,6 +65,8 @@ export type QuerySerializerOptions = {
 };
 
 export type BodySerializer<T> = (body: OperationRequestBodyContent<T>) => any;
+
+export type PathSerializer = (pathname: string, pathParams: Record<string, unknown>) => string;
 
 type BodyType<T = unknown> = {
   json: T;
@@ -117,6 +121,7 @@ export type RequestOptions<T> = ParamsOption<T> &
     baseUrl?: string;
     querySerializer?: QuerySerializer<T> | QuerySerializerOptions;
     bodySerializer?: BodySerializer<T>;
+    pathSerializer?: PathSerializer;
     parseAs?: ParseAs;
     fetch?: ClientOptions["fetch"];
     headers?: HeadersOptions;
@@ -127,6 +132,7 @@ export type MergedOptions<T = unknown> = {
   parseAs: ParseAs;
   querySerializer: QuerySerializer<T>;
   bodySerializer: BodySerializer<T>;
+  pathSerializer: PathSerializer;
   fetch: typeof globalThis.fetch;
 };
 
@@ -323,6 +329,7 @@ export declare function createFinalURL<O>(
       path?: Record<string, unknown>;
     };
     querySerializer: QuerySerializer<O>;
+    pathSerializer: PathSerializer;
   },
 ): string;
 

--- a/packages/openapi-fetch/src/index.js
+++ b/packages/openapi-fetch/src/index.js
@@ -28,6 +28,7 @@ export default function createClient(clientOptions) {
     fetch: baseFetch = globalThis.fetch,
     querySerializer: globalQuerySerializer,
     bodySerializer: globalBodySerializer,
+    pathSerializer: globalPathSerializer,
     headers: baseHeaders,
     requestInitExt = undefined,
     ...baseOptions
@@ -51,6 +52,7 @@ export default function createClient(clientOptions) {
       parseAs = "json",
       querySerializer: requestQuerySerializer,
       bodySerializer = globalBodySerializer ?? defaultBodySerializer,
+      pathSerializer: requestPathSerializer,
       body,
       ...init
     } = fetchOptions || {};
@@ -72,6 +74,8 @@ export default function createClient(clientOptions) {
               ...requestQuerySerializer,
             });
     }
+
+    const pathSerializer = requestPathSerializer || globalPathSerializer || defaultPathSerializer;
 
     const serializedBody =
       body === undefined
@@ -110,7 +114,7 @@ export default function createClient(clientOptions) {
     let id;
     let options;
     let request = new CustomRequest(
-      createFinalURL(schemaPath, { baseUrl: finalBaseUrl, params, querySerializer }),
+      createFinalURL(schemaPath, { baseUrl: finalBaseUrl, params, querySerializer, pathSerializer }),
       requestInit,
     );
     let response;
@@ -132,6 +136,7 @@ export default function createClient(clientOptions) {
         parseAs,
         querySerializer,
         bodySerializer,
+        pathSerializer,
       });
       for (const m of middlewares) {
         if (m && typeof m === "object" && typeof m.onRequest === "function") {
@@ -615,7 +620,7 @@ export function defaultBodySerializer(body, headers) {
 export function createFinalURL(pathname, options) {
   let finalURL = `${options.baseUrl}${pathname}`;
   if (options.params?.path) {
-    finalURL = defaultPathSerializer(finalURL, options.params.path);
+    finalURL = options.pathSerializer(finalURL, options.params.path);
   }
   let search = options.querySerializer(options.params.query ?? {});
   if (search.startsWith("?")) {


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

This PR adds support for setting path serializers yourself, either globally or per request. Similar to how bodySerializers & querySerializers work.

resolves #1660 

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
