### PR TITLE
feat(openapi-typescript): support JSDoc examples from JSON schema examples array

### DIFF
--- a/.changeset/seven-eyes-lie.md
+++ b/.changeset/seven-eyes-lie.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add JSDoc support for the recommended examples array on JSON Schema objects.

--- a/packages/openapi-typescript/examples/simple-example.ts
+++ b/packages/openapi-typescript/examples/simple-example.ts
@@ -151,7 +151,16 @@ export interface webhooks {
 }
 export interface components {
     schemas: {
-        /** @description schema for a rfc7807 */
+        /**
+         * @description schema for a rfc7807
+         * @example {
+         *       "type": "https://developer.acme.com/codes/404",
+         *       "title": "Not Found",
+         *       "status": 404,
+         *       "instance": "https://status.api.acme.com/errorinstance/23d243c1-1c94-4696-8798-c71aa45c92ff",
+         *       "detail": "The User requested was not found"
+         *     }
+         */
         Problem: {
             /**
              * Format: uri
@@ -172,6 +181,7 @@ export interface components {
             id: number;
             name: string;
             none?: null;
+            /** @example 123 */
             tag?: null | string | number;
             arr?: unknown[];
             either?: string | null;
@@ -186,7 +196,10 @@ export interface components {
             three?: string | null;
             /** @description array with no items */
             four?: unknown[];
-            /** @description singular example */
+            /**
+             * @description singular example
+             * @example exampleValue
+             */
             five?: string;
             /** @description exclusiveMinimum true */
             six?: unknown;

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -32,6 +32,7 @@ export interface AnnotatedSchemaObject {
   description?: string; // jsdoc with value
   enum?: unknown[]; // jsdoc without value
   example?: string; // jsdoc with value
+  examples?: unknown[];
   format?: string; // not jsdoc
   nullable?: boolean; // Node information
   summary?: string; // not jsdoc
@@ -80,6 +81,13 @@ export function addJSDocComment(schemaObject: AnnotatedSchemaObject, node: ts.Pr
     const serialized =
       typeof schemaObject[field] === "object" ? JSON.stringify(schemaObject[field], null, 2) : schemaObject[field];
     output.push(`@${field} ${String(serialized).replace(LB_RE, "\n *     ")}`);
+  }
+
+  if (Array.isArray(schemaObject.examples)) {
+    for (const example of schemaObject.examples) {
+      const serialized = typeof example === "object" ? JSON.stringify(example, null, 2) : example;
+      output.push(`@example ${String(serialized).replace(LB_RE, "\n *     ")}`);
+    }
   }
 
   // JSDoc 'Constant' without value

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -32,7 +32,7 @@ export interface AnnotatedSchemaObject {
   description?: string; // jsdoc with value
   enum?: unknown[]; // jsdoc without value
   example?: string; // jsdoc with value
-  examples?: unknown[];
+  examples?: unknown;
   format?: string; // not jsdoc
   nullable?: boolean; // Node information
   summary?: string; // not jsdoc

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -90,7 +90,7 @@ describe("addJSDocComment", () => {
     const property = ts.factory.createPropertySignature(undefined, "comment", undefined, BOOLEAN);
     addJSDocComment(
       {
-        example: 'old-example',
+        example: "old-example",
         examples: ["an-example", "another-example"],
       },
       property,
@@ -112,11 +112,11 @@ describe("addJSDocComment", () => {
         examples: [
           {
             foo: "bar",
-            results: [1, true, "abc"]
+            results: [1, true, "abc"],
           },
           {
             foo: "bat",
-            results: [5, false, "def"]
+            results: [5, false, "def"],
           },
         ],
       },
@@ -143,7 +143,7 @@ describe("addJSDocComment", () => {
      */
     comment: boolean;
 }`);
-  });    
+  });
 });
 
 describe("oapiRef", () => {

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -54,6 +54,96 @@ describe("addJSDocComment", () => {
     comment: boolean;
 }`);
   });
+
+  test("single example", () => {
+    const property = ts.factory.createPropertySignature(undefined, "comment", undefined, BOOLEAN);
+    addJSDocComment(
+      {
+        example: "an-example",
+      },
+      property,
+    );
+    expect(astToString(ts.factory.createTypeLiteralNode([property])).trim()).toBe(`{
+    /** @example an-example */
+    comment: boolean;
+}`);
+  });
+
+  test("array of examples", () => {
+    const property = ts.factory.createPropertySignature(undefined, "comment", undefined, BOOLEAN);
+    addJSDocComment(
+      {
+        examples: ["an-example", "another-example"],
+      },
+      property,
+    );
+    expect(astToString(ts.factory.createTypeLiteralNode([property])).trim()).toBe(`{
+    /**
+     * @example an-example
+     * @example another-example
+     */
+    comment: boolean;
+}`);
+  });
+
+  test("single example and array of examples", () => {
+    const property = ts.factory.createPropertySignature(undefined, "comment", undefined, BOOLEAN);
+    addJSDocComment(
+      {
+        example: 'old-example',
+        examples: ["an-example", "another-example"],
+      },
+      property,
+    );
+    expect(astToString(ts.factory.createTypeLiteralNode([property])).trim()).toBe(`{
+    /**
+     * @example old-example
+     * @example an-example
+     * @example another-example
+     */
+    comment: boolean;
+}`);
+  });
+
+  test("complex examples", () => {
+    const property = ts.factory.createPropertySignature(undefined, "comment", undefined, BOOLEAN);
+    addJSDocComment(
+      {
+        examples: [
+          {
+            foo: "bar",
+            results: [1, true, "abc"]
+          },
+          {
+            foo: "bat",
+            results: [5, false, "def"]
+          },
+        ],
+      },
+      property,
+    );
+    expect(astToString(ts.factory.createTypeLiteralNode([property])).trim()).toBe(`{
+    /**
+     * @example {
+     *       "foo": "bar",
+     *       "results": [
+     *         1,
+     *         true,
+     *         "abc"
+     *       ]
+     *     }
+     * @example {
+     *       "foo": "bat",
+     *       "results": [
+     *         5,
+     *         false,
+     *         "def"
+     *       ]
+     *     }
+     */
+    comment: boolean;
+}`);
+  });    
 });
 
 describe("oapiRef", () => {


### PR DESCRIPTION
## Changes

Implements https://github.com/openapi-ts/openapi-typescript/issues/2371

Add JSDoc support for the recommended `examples` array on JSON Schema objects. Previously, only examples in the singular `example` property were added to the JSDoc, and now all examples in the `examples` array are also added as separate examples.

## How to Review

The code change was very minor, but since many of the example specs used `examples` already, the snapshots were updated in many places.

## Checklist

- [x] Unit tests updated
- [n/a] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
