### PR TITLE
Narrow excess-property acceptance for query init types in swr-openapi

### DIFF
--- a/packages/swr-openapi/src/__test__/types.test-d.ts
+++ b/packages/swr-openapi/src/__test__/types.test-d.ts
@@ -39,6 +39,46 @@ const useMutate = createMutateHook(
 const mutate = useMutate();
 
 describe("types", () => {
+  describe("excess property checks", () => {
+    describe("useQuery", () => {
+      it("rejects extra properties in query params", () => {
+        useQuery("/pet/findByStatus", {
+          params: {
+            query: {
+              status: "available",
+              // @ts-expect-error extra property should be rejected
+              invalid_property: "nope",
+            },
+          },
+        });
+      });
+
+      it("rejects extra properties in path params", () => {
+        useQuery("/pet/{petId}", {
+          params: {
+            path: {
+              petId: 5,
+              // @ts-expect-error extra property should be rejected
+              invalid_path_param: "nope",
+            },
+          },
+        });
+      });
+
+      it("rejects extra properties in header params", () => {
+        useQuery("/pet/findByStatus", {
+          params: {
+            header: {
+              "X-Example": "test",
+              // @ts-expect-error extra property should be rejected
+              "Invalid-Header": "nope",
+            },
+          },
+        });
+      });
+    });
+  });
+
   describe("key types", () => {
     describe("useQuery", () => {
       it("accepts config", () => {

--- a/packages/swr-openapi/src/query-base.ts
+++ b/packages/swr-openapi/src/query-base.ts
@@ -17,13 +17,14 @@ export function configureBaseQueryHook(useHook: SWRHook) {
     return function useQuery<
       Path extends PathsWithMethod<Paths, "get">,
       R extends TypesForGetRequest<Paths, Path>,
-      Init extends R["Init"],
       Data extends R["Data"],
       Error extends R["Error"] | FetcherError,
       Config extends R["SWRConfig"],
     >(
       path: Path,
-      ...[init, config]: RequiredKeysOf<Init> extends never ? [(Init | null)?, Config?] : [Init | null, Config?]
+      ...[init, config]: RequiredKeysOf<R["Init"]> extends never
+        ? [(R["Init"] | null)?, Config?]
+        : [R["Init"] | null, Config?]
     ) {
       useDebugValue(`${prefix} - ${path as string}`);
 


### PR DESCRIPTION
## Changes

Closes #2410

### Summary
This PR tightens TypeScript excess-property checks for request init objects in `swr-openapi`:

- Enforces excess-property checking for `useQuery` init objects by using the concrete inferred type in the function signature.
- Adds regression tests to prevent future drift.
- Updates docs to show DX-friendly patterns for exact param shapes with `useInfinite`.

No runtime behavior changes.

### Motivation
Previously, TypeScript accepted extra keys in `params.query`/`params.path` without error which could hide mistakes

### What changed

- `packages/swr-openapi/src/query-base.ts`
  - Changed `useQuery` signature to use `R["Init"]` directly in the parameter tuple:
    - Excess properties in object literals now trigger errors.
    - Optional/required init behavior still determined via `RequiredKeysOf<R["Init"]>`.

- `packages/swr-openapi/src/__test__/types.test-d.ts`
  - Added “excess property checks” tests:
    - `useQuery`: rejects extra properties in `params.query`, `params.path`, `params.header`.
    - `useInfinite`: rejects extra properties in `params.query` and `params.path` when returning an explicitly typed `Init` value (the most reliable way to trigger TS’s excess property checks for callbacks).

- `docs/swr-openapi/use-infinite.md`
  - Added “Enforcing exact param shapes” section showing two minimal patterns:
    - Typed variable with `TypesForRequest<paths, "get", "...">["Init"]`
    - Inline `satisfies` with the same type

### Before/After

- useQuery (before): extra keys could pass type-check in some cases.
- useQuery (after): passing an object literal with extra keys now errors reliably.

```ts
useQuery("/pet/findByStatus", {
  params: {
    query: {
      status: "available",
      // now correctly rejected
      invalid_property: "nope",
    },
  },
});
```

- useInfinite loader (recommended patterns to force exact shape):

```ts
// Option 1: typed variable
type FindByStatus = TypesForRequest<paths, "get", "/pet/findByStatus">;
const init: FindByStatus["Init"] = {
  params: { query: { status: "available" } },
  // extra properties here are rejected by TS
};
useInfinite("/pet/findByStatus", () => init);

// Option 2: satisfies
useInfinite(
  "/pet/findByStatus",
  () =>
    ({
      params: { query: { status: "available" } },
      // extra properties here are rejected by TS
    }) satisfies TypesForRequest<paths, "get", "/pet/findByStatus">["Init"]
);
```

### Tests
- Added type-only tests to assert excess property checks for both `useQuery` and `useInfinite` (query + path).
- All tests pass.

### Docs
- Documented strict param patterns for infinite loaders in `docs/swr-openapi/use-infinite.md`.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
