### PR TITLE
docs: fix typo in example

### DIFF
--- a/docs/openapi-fetch/api.md
+++ b/docs/openapi-fetch/api.md
@@ -203,7 +203,7 @@ const { data, error } = await client.POST("/tokens", {
     clientSecret: "someClientSecret",
   },
   headers: {
-    "Content-Type": "application/x-www-form-encoded",
+    "Content-Type": "application/x-www-form-urlencoded",
   },
 });
 ```


### PR DESCRIPTION
This PR fixes a typo in example of using `application/x-www-form-urlencoded` content type.