### PR TITLE
support conditional ts enums

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,6 +113,7 @@ The following flags are supported in the CLI:
 | `--empty-objects-unknown`          |       | `false`  | Allow arbitrary properties for schema objects with no specified properties, and no specified `additionalProperties` |
 | `--enum`                           |       | `false`  | Generate true [TS enums](https://www.typescriptlang.org/docs/handbook/enums.html) rather than string unions.        |
 | `--enum-values`                    |       | `false`  | Export enum values as arrays.                                                                                       |
+| `--conditional-enums`              |       | `false`  | Only generate true TS enums when the `x-enum-*` metadata is available. Requires `--enum=true` to be enabled.        |
 | `--dedupe-enums`                   |       | `false`  | Dedupe enum types when `--enum=true` is set                                                                         |
 | `--check`                          |       | `false`  | Check that the generated types are up-to-date.                                                                      |
 | `--exclude-deprecated`             |       | `false`  | Exclude deprecated fields from types                                                                                |

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -17,6 +17,7 @@ Options
   --output, -o               Specify output file (if not specified in redocly.yaml)
   --enum                     Export true TS enums instead of unions
   --enum-values              Export enum values as arrays
+  --conditional-enums        Only generate true TS enums when enum metadata is available (default: false)
   --dedupe-enums             Dedupe enum types when \`--enum=true\` is set
   --check                    Check that the generated types are up-to-date. (default: false)
   --export-type, -t          Export top-level \`type\` instead of \`interface\`
@@ -74,6 +75,7 @@ const flags = parser(args, {
     "emptyObjectsUnknown",
     "enum",
     "enumValues",
+    "conditionalEnums",
     "dedupeEnums",
     "check",
     "excludeDeprecated",
@@ -139,6 +141,7 @@ async function generateSchema(schema, { redocly, silent = false }) {
       emptyObjectsUnknown: flags.emptyObjectsUnknown,
       enum: flags.enum,
       enumValues: flags.enumValues,
+      conditionalEnums: flags.conditionalEnums,
       dedupeEnums: flags.dedupeEnums,
       excludeDeprecated: flags.excludeDeprecated,
       exportType: flags.exportType,

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -75,6 +75,7 @@ export default async function openapiTS(
     emptyObjectsUnknown: options.emptyObjectsUnknown ?? false,
     enum: options.enum ?? false,
     enumValues: options.enumValues ?? false,
+    conditionalEnums: options.conditionalEnums ?? false,
     dedupeEnums: options.dedupeEnums ?? false,
     excludeDeprecated: options.excludeDeprecated ?? false,
     exportType: options.exportType ?? false,

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -96,10 +96,7 @@ export function transformSchemaObjectWithComposition(
     !("additionalProperties" in schemaObject)
   ) {
     // hoist enum to top level if string/number enum and option is enabled
-    if (
-      options.ctx.enum &&
-      schemaObject.enum.every((v) => typeof v === "string" || typeof v === "number" || v === null)
-    ) {
+    if (shouldTransformToTsEnum(options, schemaObject)) {
       let enumName = parseRef(options.path ?? "").pointer.join("/");
       // allow #/components/schemas to have simpler names
       enumName = enumName.replace("components/schemas", "");
@@ -268,6 +265,35 @@ export function transformSchemaObjectWithComposition(
   }
 
   return finalType;
+}
+
+/**
+ * Check if the given OAPI enum should be transformed to a TypeScript enum
+ */
+function shouldTransformToTsEnum(options: TransformNodeOptions, schemaObject: SchemaObject): boolean {
+  // Enum conversion not enabled
+  if (!options.ctx.enum) {
+    return false;
+  }
+
+  // Enum must have string, number or null values
+  if (!schemaObject.enum?.every((v) => typeof v === "string" || typeof v === "number" || v === null)) {
+    return false;
+  }
+
+  // If conditionalEnums is enabled, only convert if x-enum-* metadata is present
+  if (options.ctx.conditionalEnums) {
+    const hasEnumMetadata =
+      Array.isArray(schemaObject["x-enum-varnames"]) ||
+      Array.isArray(schemaObject["x-enumNames"]) ||
+      Array.isArray(schemaObject["x-enum-descriptions"]) ||
+      Array.isArray(schemaObject["x-enumDescriptions"]);
+    if (!hasEnumMetadata) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -651,6 +651,8 @@ export interface OpenAPITSOptions {
   enum?: boolean;
   /** Export union values as arrays */
   enumValues?: boolean;
+  /** Only generate TS Enums when `x-enum-*` metadata is available */
+  conditionalEnums?: boolean;
   /** Dedupe enum values */
   dedupeEnums?: boolean;
   /** (optional) Substitute path parameter names with their respective types */
@@ -688,6 +690,7 @@ export interface GlobalContext {
   emptyObjectsUnknown: boolean;
   enum: boolean;
   enumValues: boolean;
+  conditionalEnums: boolean;
   dedupeEnums: boolean;
   excludeDeprecated: boolean;
   exportType: boolean;

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CTX: GlobalContext = {
   emptyObjectsUnknown: false,
   enum: false,
   enumValues: false,
+  conditionalEnums: false,
   dedupeEnums: false,
   excludeDeprecated: false,
   exportType: false,

--- a/packages/openapi-typescript/test/transform/schema-object/enum.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/enum.test.ts
@@ -1,0 +1,276 @@
+import { fileURLToPath } from "node:url";
+import { transformSchema } from "../../../src/index.js";
+import { astToString } from "../../../src/lib/ts.js";
+import type { GlobalContext } from "../../../src/types.js";
+import { DEFAULT_CTX, type TestCase } from "../../test-helpers.js";
+
+const DEFAULT_OPTIONS = DEFAULT_CTX;
+
+const schema = {
+  openapi: "3.0.0",
+  info: {
+    title: "Status API",
+    version: "1.0.0",
+  },
+  paths: {
+    "/status": {
+      get: {
+        summary: "Get current status",
+        responses: {
+          "200": {
+            description: "Status response",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    required: {
+                      "status": true,
+                      "statusEnum": true,
+                    },
+                    status: {
+                      $ref: "#/components/schemas/StatusResponse",
+                    },
+                    statusEnum: {
+                      $ref: "#/components/schemas/StatusEnumResponse",
+                    }
+                  }
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      StatusResponse: {
+        type: "object",
+        properties: {
+          status: {
+            $ref: "#/components/schemas/Status",
+          },
+        },
+      },
+      Status: {
+        type: "string",
+        enum: ["pending", "active", "done"],
+      },
+      StatusEnumResponse: {
+        type: "object",
+        properties: {
+          status: {
+            $ref: "#/components/schemas/StatusEnum",
+          },
+        },
+      },
+      StatusEnum: {
+        type: "string",
+        enum: ["pending", "active", "done"],
+        "x-enum-varnames": ["Pending", "Active", "Done"],
+        "x-enum-descriptions": [
+          "The task is pending",
+          "The task is active",
+          "The task is done",
+        ],
+      },
+    },
+  },
+};
+
+describe("transformComponentsObject", () => {
+  const tests: TestCase<any, GlobalContext>[] = [
+    [
+      "options > enum: true and conditionalEnums: false",
+      {
+        given: schema,
+        want: `export interface paths {
+    "/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current status */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Status response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            required?: unknown;
+                            status?: components["schemas"]["StatusResponse"];
+                            statusEnum?: components["schemas"]["StatusEnumResponse"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        StatusResponse: {
+            status?: components["schemas"]["Status"];
+        };
+        /** @enum {string} */
+        Status: Status;
+        StatusEnumResponse: {
+            status?: components["schemas"]["StatusEnum"];
+        };
+        /** @enum {string} */
+        StatusEnum: StatusEnum;
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export enum Status {
+    pending = "pending",
+    active = "active",
+    done = "done"
+}
+export enum StatusEnum {
+    // The task is pending
+    Pending = "pending",
+    // The task is active
+    Active = "active",
+    // The task is done
+    Done = "done"
+}
+export type operations = Record<string, never>;`,
+        options: { ...DEFAULT_OPTIONS, enum: true, conditionalEnums: false },
+      },
+    ],
+    [
+      "options > enum: true and conditionalEnums: true",
+      {
+        given: schema,
+        want: `export interface paths {
+    "/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current status */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Status response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            required?: unknown;
+                            status?: components["schemas"]["StatusResponse"];
+                            statusEnum?: components["schemas"]["StatusEnumResponse"];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        StatusResponse: {
+            status?: components["schemas"]["Status"];
+        };
+        /** @enum {string} */
+        Status: "pending" | "active" | "done";
+        StatusEnumResponse: {
+            status?: components["schemas"]["StatusEnum"];
+        };
+        /** @enum {string} */
+        StatusEnum: StatusEnum;
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export enum Status {
+    pending = "pending",
+    active = "active",
+    done = "done"
+}
+export enum StatusEnum {
+    // The task is pending
+    Pending = "pending",
+    // The task is active
+    Active = "active",
+    // The task is done
+    Done = "done"
+}
+export enum StatusEnum {
+    // The task is pending
+    Pending = "pending",
+    // The task is active
+    Active = "active",
+    // The task is done
+    Done = "done"
+}
+export type operations = Record<string, never>;`,
+        options: { ...DEFAULT_OPTIONS, enum: true, conditionalEnums: true },
+      },
+    ],
+  ];
+
+  for (const [testName, { given, want, options, ci }] of tests) {
+    test.skipIf(ci?.skipIf)(
+      testName,
+      async () => {
+        const result = astToString(transformSchema(given, options ?? DEFAULT_OPTIONS));
+        if (want instanceof URL) {
+          await expect(result).toMatchFileSnapshot(fileURLToPath(want));
+        } else {
+          expect(result.trim()).toBe(want.trim());
+        }
+      },
+      ci?.timeout,
+    );
+  }
+});


### PR DESCRIPTION
## Changes

Adds support (via optional flag) for generating TS Enums _only where there is relevant metadata_.

TS Enums can provide useful mappings in specific circumstances:
```ts
enum ThingId {
  Variant1: 'f49c3b85-5cfe-473a-8ce7-f876788d211a',
  Variant2: '50f5ddfc-217c-4507-a875-165a5bbf5a41',
  Variant3: '41b85275-8018-4398-9c4f-379dbf198fc8',
}
```
but is also entirely redundant in many others:
```ts
enum Status {
  ok: 'ok',
  pending: 'pending',
  error: 'error',
}
```

This PR provides an optional `--conditional-enums` flag to only create TS Enums where relevant mapping metadata has been explicitly added:
```yaml
components:
  schemas:
    Status:
      type: string
      enum: [pending, active, done]
    StatusEnum:
      type: string
      enum: [pending, active, done]
      x-enum-varnames: [Pending, Active, Done]
      x-enum-descriptions: [
        "The task is pending",
        "The task is active",
        "The task is done",
      ]
```

The particular use case I am targeting is for established code bases that rely 95% on simple type unions, but may occasionally wish to store enum mappings in OAPI where appropriate.

This feature would assist in cases such as https://github.com/openapi-ts/openapi-typescript/issues/941 and https://github.com/openapi-ts/openapi-typescript/issues/2366.


## How to Review

1. Prepare an OAPI schema with two kinds of enums, one with metadata and one without (see above `Status` / `StatusEnum` example).

2. Test generating typings with the `enum` flag enabled, and then toggle the `conditionalEnums` to compare the differences in result.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
