### PR TITLE
Switch Renovate config to `config:js-lib`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:js-lib"
   ]
 }


### PR DESCRIPTION


## Changes

In practice, this adds `:pinOnlyDevDependencies`.

https://docs.renovatebot.com/presets-config/#configjs-lib
https://docs.renovatebot.com/presets-default/#pinonlydevdependencies

## How to Review

Have a look at the Renovate docs to see if this is appropriate.

## Checklist

- [ ] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
