### PR TITLE
fix(openapi-typescript): avoid duplicate allOf discriminator enums

### DIFF
--- a/.changeset/calm-pugs-count.md
+++ b/.changeset/calm-pugs-count.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+fix duplicate discriminator enums when explicit allOf mappings override implicit oneOf inference

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -157,14 +157,31 @@ export function resolveRef<T>(
   return node;
 }
 
+const GENERATED_DISCRIMINATOR_DESCRIPTION = "discriminator enum property added by openapi-typescript";
+
 function createDiscriminatorEnum(values: string[], prevSchema?: SchemaObject): SchemaObject {
+  const prevDescription = prevSchema?.description;
   return {
     type: "string",
     enum: values,
-    description: prevSchema?.description
-      ? `${prevSchema.description} (enum property replaced by openapi-typescript)`
-      : "discriminator enum property added by openapi-typescript",
+    description:
+      prevDescription && !prevDescription.includes(GENERATED_DISCRIMINATOR_DESCRIPTION)
+        ? `${prevDescription} (enum property replaced by openapi-typescript)`
+        : GENERATED_DISCRIMINATOR_DESCRIPTION,
   };
+}
+
+function isGeneratedDiscriminatorObject(item: SchemaObject | ReferenceObject, propertyName: string): item is SchemaObject {
+  if ("$ref" in item || item.type !== "object" || !item.properties || Object.keys(item.properties).length !== 1) {
+    return false;
+  }
+
+  const propertySchema = item.properties[propertyName];
+  if (!propertySchema || typeof propertySchema !== "object" || "$ref" in propertySchema) {
+    return false;
+  }
+
+  return propertySchema.description === GENERATED_DISCRIMINATOR_DESCRIPTION;
 }
 
 /** Adds or replaces the discriminator enum with the passed `values` in a schema defined by `ref` */
@@ -181,6 +198,37 @@ function patchDiscriminatorEnum(
   });
 
   if (resolvedSchema?.allOf) {
+    const generatedDiscriminatorIndices = resolvedSchema.allOf
+      .map((item, index) => (isGeneratedDiscriminatorObject(item, discriminator.propertyName) ? index : -1))
+      .filter((index) => index !== -1);
+
+    if (generatedDiscriminatorIndices.length) {
+      const keepIndex = generatedDiscriminatorIndices.at(-1) as number;
+      const existingDiscriminatorObject = resolvedSchema.allOf[keepIndex] as SchemaObject;
+
+      if (generatedDiscriminatorIndices.length > 1) {
+        resolvedSchema.allOf = resolvedSchema.allOf.filter(
+          (_, index) => !generatedDiscriminatorIndices.includes(index) || index === keepIndex,
+        );
+      }
+
+      // A schema may already have been patched from an inferred oneOf mapping.
+      // Replace that injected enum instead of intersecting a duplicate property.
+      if (!existingDiscriminatorObject.required) {
+        existingDiscriminatorObject.required = [discriminator.propertyName];
+      } else if (!existingDiscriminatorObject.required.includes(discriminator.propertyName)) {
+        existingDiscriminatorObject.required.push(discriminator.propertyName);
+      }
+
+      existingDiscriminatorObject.properties ??= {};
+      existingDiscriminatorObject.properties[discriminator.propertyName] = createDiscriminatorEnum(
+        values,
+        existingDiscriminatorObject.properties[discriminator.propertyName] as SchemaObject,
+      );
+
+      return true;
+    }
+
     // if the schema is an allOf, we can append a new schema object to the allOf array
     resolvedSchema.allOf.push({
       type: "object",

--- a/packages/openapi-typescript/test/discriminators.test.ts
+++ b/packages/openapi-typescript/test/discriminators.test.ts
@@ -627,6 +627,244 @@ export type $defs = Record<string, never>;
 export type operations = Record<string, never>;`,
       },
     ],
+    [
+      "implicit oneOf mapping does not duplicate explicit allOf discriminator enum",
+      {
+        given: {
+          openapi: "3.1.0",
+          info: {
+            title: "test",
+            version: 1,
+          },
+          components: {
+            schemas: {
+              PaymentRequest: {
+                type: "object",
+                properties: {
+                  confirmation: {
+                    oneOf: [
+                      {
+                        $ref: "#/components/schemas/ConfirmationDataRedirect",
+                      },
+                      {
+                        $ref: "#/components/schemas/ConfirmationDataExternal",
+                      },
+                    ],
+                    discriminator: {
+                      propertyName: "type",
+                    },
+                  },
+                },
+              },
+              ConfirmationDataType: {
+                type: "string",
+                enum: ["redirect", "external"],
+              },
+              ConfirmationData: {
+                type: "object",
+                required: ["type"],
+                properties: {
+                  type: {
+                    $ref: "#/components/schemas/ConfirmationDataType",
+                  },
+                },
+                discriminator: {
+                  propertyName: "type",
+                  mapping: {
+                    redirect: "#/components/schemas/ConfirmationDataRedirect",
+                    external: "#/components/schemas/ConfirmationDataExternal",
+                  },
+                },
+              },
+              ConfirmationDataRedirect: {
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/ConfirmationData",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      return_url: {
+                        type: "string",
+                      },
+                    },
+                  },
+                ],
+              },
+              ConfirmationDataExternal: {
+                type: "object",
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/ConfirmationData",
+                  },
+                  {
+                    type: "object",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        want: `export type paths = Record<string, never>;
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        PaymentRequest: {
+            confirmation?: components["schemas"]["ConfirmationDataRedirect"] | components["schemas"]["ConfirmationDataExternal"];
+        };
+        /** @enum {string} */
+        ConfirmationDataType: "redirect" | "external";
+        ConfirmationData: {
+            type: components["schemas"]["ConfirmationDataType"];
+        };
+        ConfirmationDataRedirect: Omit<components["schemas"]["ConfirmationData"], "type"> & {
+            return_url?: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "redirect";
+        };
+        ConfirmationDataExternal: Omit<components["schemas"]["ConfirmationData"], "type"> & Record<string, never> & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "external";
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
+    [
+      "implicit oneOf mapping updates injected allOf enum without rewriting inline discriminator property",
+      {
+        given: {
+          openapi: "3.1.0",
+          info: {
+            title: "test",
+            version: 1,
+          },
+          components: {
+            schemas: {
+              PaymentRequest: {
+                type: "object",
+                properties: {
+                  confirmation: {
+                    oneOf: [
+                      {
+                        $ref: "#/components/schemas/ConfirmationDataRedirect",
+                      },
+                      {
+                        $ref: "#/components/schemas/ConfirmationDataExternal",
+                      },
+                    ],
+                    discriminator: {
+                      propertyName: "type",
+                    },
+                  },
+                },
+              },
+              ConfirmationDataType: {
+                type: "string",
+                enum: ["redirect", "external"],
+              },
+              ConfirmationData: {
+                type: "object",
+                required: ["type"],
+                properties: {
+                  type: {
+                    $ref: "#/components/schemas/ConfirmationDataType",
+                  },
+                },
+                discriminator: {
+                  propertyName: "type",
+                  mapping: {
+                    redirect: "#/components/schemas/ConfirmationDataRedirect",
+                    external: "#/components/schemas/ConfirmationDataExternal",
+                  },
+                },
+              },
+              ConfirmationDataRedirect: {
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/ConfirmationData",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      type: {
+                        $ref: "#/components/schemas/ConfirmationDataType",
+                      },
+                      return_url: {
+                        type: "string",
+                      },
+                    },
+                  },
+                ],
+              },
+              ConfirmationDataExternal: {
+                type: "object",
+                allOf: [
+                  {
+                    $ref: "#/components/schemas/ConfirmationData",
+                  },
+                  {
+                    type: "object",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        want: `export type paths = Record<string, never>;
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        PaymentRequest: {
+            confirmation?: components["schemas"]["ConfirmationDataRedirect"] | components["schemas"]["ConfirmationDataExternal"];
+        };
+        /** @enum {string} */
+        ConfirmationDataType: "redirect" | "external";
+        ConfirmationData: {
+            type: components["schemas"]["ConfirmationDataType"];
+        };
+        ConfirmationDataRedirect: Omit<components["schemas"]["ConfirmationData"], "type"> & {
+            type?: components["schemas"]["ConfirmationDataType"];
+            return_url?: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "redirect";
+        };
+        ConfirmationDataExternal: Omit<components["schemas"]["ConfirmationData"], "type"> & Record<string, never> & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "external";
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options, ci }] of tests) {


### PR DESCRIPTION
## Changes

Fixes #2775.

When an `allOf` discriminator mapping runs after an implicit `oneOf` discriminator has already injected a generated enum for the same schema, `patchDiscriminatorEnum()` appends a second generated `type` intersection instead of replacing the injected one. On the YooKassa schema from the issue, that produces `ConfirmationDataExternal` with both `type: "ConfirmationDataExternal"` and `type: "external"`, which collapses the generated type to `never`.

This updates the `allOf` patch path to retarget previously generated discriminator-only members instead of appending duplicates, and adds regressions for the YooKassa-style repro plus a case where another inline `allOf` member also defines the discriminator property.

Validation:

- `pnpm --filter openapi-typescript exec vitest run test/discriminators.test.ts`
- `pnpm --filter openapi-typescript test`
- Re-ran the YooKassa schema repro from #2775 and confirmed `ConfirmationDataExternal` now emits only `type: "external"`

## How to Review

- Review `packages/openapi-typescript/src/lib/utils.ts`, especially the `patchDiscriminatorEnum()` `allOf` branch
- Review the new cases in `packages/openapi-typescript/test/discriminators.test.ts`
- Optionally rerun the YooKassa schema repro from #2775 to verify the generated output no longer contains duplicate `type` intersections

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)
