### PR TITLE
Fix empty string enum members with --enum

### DIFF
--- a/.changeset/fix-empty-string-enum-members.md
+++ b/.changeset/fix-empty-string-enum-members.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Generate valid TypeScript enum members for empty string enum values when using `--enum`.

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -408,20 +408,24 @@ function sanitizeMemberName(name: string) {
 export function tsEnumMember(value: string | number, metadata: { name?: string; description?: string | null } = {}) {
   let name = metadata.name ?? String(value);
   if (!JS_PROPERTY_INDEX_RE.test(name)) {
-    if (Number(name[0]) >= 0) {
-      name = `Value${name}`.replace(".", "_"); // don't forged decimals;
-    } else if (name[0] === "-") {
-      name = `ValueMinus${name.slice(1)}`;
-    }
+    if (name === "") {
+      name = `"${name}"`;
+    } else {
+      if (Number(name[0]) >= 0) {
+        name = `Value${name}`.replace(".", "_"); // don't forged decimals;
+      } else if (name[0] === "-") {
+        name = `ValueMinus${name.slice(1)}`;
+      }
 
-    const invalidCharMatch = name.match(JS_PROPERTY_INDEX_INVALID_CHARS_RE);
-    if (invalidCharMatch) {
-      if (invalidCharMatch[0] === name) {
-        name = `"${name}"`;
-      } else {
-        name = name.replace(JS_PROPERTY_INDEX_INVALID_CHARS_RE, (s) => {
-          return s in SPECIAL_CHARACTER_MAP ? SPECIAL_CHARACTER_MAP[s] : "_";
-        });
+      const invalidCharMatch = name.match(JS_PROPERTY_INDEX_INVALID_CHARS_RE);
+      if (invalidCharMatch) {
+        if (invalidCharMatch[0] === name) {
+          name = `"${name}"`;
+        } else {
+          name = name.replace(JS_PROPERTY_INDEX_INVALID_CHARS_RE, (s) => {
+            return s in SPECIAL_CHARACTER_MAP ? SPECIAL_CHARACTER_MAP[s] : "_";
+          });
+        }
       }
     }
   }

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -218,6 +218,14 @@ describe("tsEnum", () => {
 }`);
   });
 
+  test("empty string member", () => {
+    expect(astToString(tsEnum("type", ["", "foo", "bar"])).trim()).toBe(`enum Type {
+    "" = "",
+    foo = "foo",
+    bar = "bar"
+}`);
+  });
+
   test("number members", () => {
     expect(astToString(tsEnum(".Error.code.", [100, 101, 102, -100])).trim()).toBe(`enum ErrorCode {
     Value100 = 100,

--- a/packages/openapi-typescript/test/transform/schema-object/enum.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/enum.test.ts
@@ -237,6 +237,62 @@ export type operations = Record<string, never>;`,
       options: { ctx: createTestContext({ enum: true, conditionalEnums: true }) },
     },
   ],
+  [
+    "options > enum: true with empty string enum member",
+    {
+      given: mockEmptyStringEnumSchema(),
+      want: `export interface paths {
+    "/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Test */
+        get: operations["test"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export type components = Record<string, never>;
+export type $defs = Record<string, never>;
+export interface operations {
+    test: {
+        parameters: {
+            query?: {
+                type?: PathsTestGetParametersQueryType;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+}
+export enum PathsTestGetParametersQueryType {
+    "" = "",
+    foo = "foo",
+    bar = "bar"
+}`,
+      options: { ctx: createTestContext({ enum: true }) },
+    },
+  ],
 ];
 
 describe("transformComponentsObject", () => {
@@ -318,6 +374,42 @@ function mockSchema() {
           enum: ["pending", "active", "done"],
           "x-enum-varnames": ["Pending", "Active", "Done"],
           "x-enum-descriptions": ["The task is pending", "The task is active", "The task is done"],
+        },
+      },
+    },
+  };
+}
+
+function mockEmptyStringEnumSchema() {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Test",
+      version: "0.1.0",
+    },
+    paths: {
+      "/test": {
+        get: {
+          summary: "Test",
+          operationId: "test",
+          parameters: [
+            {
+              name: "type",
+              in: "query",
+              required: false,
+              schema: {
+                enum: ["", "foo", "bar"],
+                type: "string",
+                default: "",
+                title: "Type",
+              },
+            },
+          ],
+          responses: {
+            200: {
+              description: "OK",
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
## Changes

Fixes #2807.

When `--enum` encounters an empty string enum value, the enum member name is now emitted as a string-literal member (`"" = ""`) instead of an empty identifier.

Added regression coverage for both the low-level `tsEnum` helper and a schema transform matching the reported query-parameter enum case.

## How to Review

Check `tsEnumMember()` handling for empty member names and the new enum transform regression. The generated enum should be valid TypeScript:

```ts
export enum PathsTestGetParametersQueryType {
    "" = "",
    foo = "foo",
    bar = "bar"
}
```

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (not necessary)
- [x] `pnpm run update:examples` run (not applicable; no example snapshots changed)
