### PR TITLE
fix(openapi-react-query): propagate undefined errors from openapi-fetch

### DIFF
--- a/.changeset/fix-propagate-undefined-errors.md
+++ b/.changeset/fix-propagate-undefined-errors.md
@@ -1,0 +1,7 @@
+---
+"openapi-react-query": patch
+---
+
+fix(openapi-react-query): propagate undefined errors from openapi-fetch
+
+Use `!response.ok` instead of `error` truthiness check to properly handle cases where openapi-fetch returns `error: undefined` for non-OK responses with empty bodies.

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -200,7 +200,7 @@ export default function createClient<Paths extends {}, Media extends MediaType =
     const mth = method.toUpperCase() as Uppercase<typeof method>;
     const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
     const { data, error, response } = await fn(path, { signal, ...(init as any) }); // TODO: find a way to avoid as any
-    if (error) {
+    if (!response.ok) {
       throw error;
     }
     if (response.status === 204 || response.headers.get("Content-Length") === "0") {
@@ -247,8 +247,8 @@ export default function createClient<Paths extends {}, Media extends MediaType =
               },
             };
 
-            const { data, error } = await fn(path, mergedInit as any);
-            if (error) {
+            const { data, error, response } = await fn(path, mergedInit as any);
+            if (!response.ok) {
               throw error;
             }
             return data;
@@ -265,8 +265,8 @@ export default function createClient<Paths extends {}, Media extends MediaType =
           mutationFn: async (init) => {
             const mth = method.toUpperCase() as Uppercase<typeof method>;
             const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
-            const { data, error } = await fn(path, init as InitWithUnknowns<typeof init>);
-            if (error) {
+            const { data, error, response } = await fn(path, init as InitWithUnknowns<typeof init>);
+            if (!response.ok) {
               throw error;
             }
 

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -336,6 +336,33 @@ describe("client", () => {
       expect(data).toBeUndefined();
     });
 
+    it("should propagate error when response is not ok with empty body", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/string-array",
+        status: 500,
+        headers: {
+          "Content-Length": "0",
+        },
+        body: undefined,
+      });
+
+      const { result } = renderHook(() => client.useQuery("get", "/string-array"), {
+        wrapper,
+      });
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+      const { data, error } = result.current;
+
+      expect(error).toBeUndefined();
+      expect(data).toBeUndefined();
+    });
+
     it("should resolve data properly and have error as null when queryFn returns null", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);


### PR DESCRIPTION
## Summary
- Use `!response.ok` instead of `error` truthiness check in queryFn, useInfiniteQuery, and useMutation
- Properly handle cases where openapi-fetch returns `error: undefined` for non-OK responses with empty bodies

## Why
When openapi-fetch receives a non-OK response (e.g., 500) with an empty body, it returns `{ error: undefined, response }`. The previous `if (error)` check was falsy for `undefined`, causing the error to be silently swallowed. This fix checks `!response.ok` instead, ensuring errors are always propagated.

## Validation
- Ran `pnpm test --filter openapi-react-query` — all 38 tests pass (37 existing + 1 new)
- Added test case for 500 response with empty body

## Related
Closes #2070