### PR TITLE
feat(openapi-typescript): flow-style YAML support

### DIFF
--- a/packages/openapi-typescript/src/lib/redoc.ts
+++ b/packages/openapi-typescript/src/lib/redoc.ts
@@ -64,7 +64,7 @@ export async function parseSchema(schema: unknown, { absoluteRef, resolver }: Pa
       });
     }
     // JSON
-    if (schema[0] === "{") {
+    if (/^\{\s*"/.test(schema.trimStart())) {
       return {
         source: new Source(absoluteRef, schema, "application/json"),
         parsed: parseJson(schema),

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -34,6 +34,25 @@ export type operations = Record<string, never>;`,
       // options: DEFAULT_OPTIONS,
     ],
     [
+      "input > string > YAML > flow-style",
+      {
+        given: `{ openapi: "3.1", info: { title: test, version: "1.0" } }`,
+        want: `export type paths = Record<string, never>;
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+      // options: DEFAULT_OPTIONS,
+    ],
+    [
       "input > string > JSON",
       {
         given: JSON.stringify({


### PR DESCRIPTION
## Changes

This PR adds support for [flow-style YAML](https://www.yaml.info/learn/flowstyle.html). The format is often used to ship OpenAPI schemas in a reduced size.

Without this patch, the `openapi-typescript` package assumes that flow-style YAML is JSON & fails to parse the document with a JSON parse error.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)
