### PR TITLE
fix(types): declare types condition in exports for ESM consumers

### DIFF
--- a/packages/openapi-fetch/package.json
+++ b/packages/openapi-fetch/package.json
@@ -11,6 +11,7 @@
   "main": "./dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"

--- a/packages/openapi-typescript/package.json
+++ b/packages/openapi-typescript/package.json
@@ -14,6 +14,7 @@
   "main": "./dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"


### PR DESCRIPTION
## Problem

Under modern TypeScript / tsgo (Go-rewritten compiler), packages with `"type": "module"` and no explicit `exports.types` condition fail to resolve types because the legacy sibling-`.d.ts` fallback is being removed.

Both `openapi-fetch` and `openapi-typescript` currently have no `"types"` condition in their `exports` map, causing TypeScript consumers to potentially see type resolution issues as tsgo tightens its module resolution.

## Fix

One line added to each package's `package.json`:
- `packages/openapi-fetch/package.json`: `"types": "./dist/index.d.ts"` as first condition in `exports."."`
- `packages/openapi-typescript/package.json`: `"types": "./dist/index.d.ts"` as first condition in `exports."."`

Both point at the `.d.ts` declaration files the packages already ship in `dist/`. The `"types"` condition must come first (TypeScript's resolver reads conditions in declared order).

## Impact

- No behavioral change — pure manifest fix, two lines
- TypeScript / tsgo consumers can now resolve types deterministically
- ESM consumers (both `import` and `default` conditions) benefit from the same declaration file