### PR TITLE
feat: add $dynamicRef and $dynamicAnchor support (OpenAPI 3.1 / JSON Schema 2020-12)

### DIFF
--- a/.changeset/dynamic-ref-support.md
+++ b/.changeset/dynamic-ref-support.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add `$dynamicRef` and `$dynamicAnchor` support (JSON Schema Draft 2020-12 / OpenAPI 3.1)

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -157,6 +157,67 @@ export function resolveRef<T>(
   return node;
 }
 
+export function collectDynamicAnchors(
+  schemaObject: Record<string, any>,
+): Record<string, SchemaObject | ReferenceObject> | undefined {
+  if (!schemaObject.$defs || typeof schemaObject.$defs !== "object") {
+    return undefined;
+  }
+  const anchors: Record<string, SchemaObject | ReferenceObject> = {};
+  let found = false;
+  for (const def of Object.values(schemaObject.$defs) as (SchemaObject | ReferenceObject)[]) {
+    if (def && typeof def === "object" && "$dynamicAnchor" in def && typeof def.$dynamicAnchor === "string") {
+      const { $dynamicAnchor, ...rest } = def as SchemaObject & { $dynamicAnchor: string };
+      const schemaValue = Object.keys(rest).length > 0 ? (rest as SchemaObject | ReferenceObject) : def;
+      anchors[$dynamicAnchor] = schemaValue;
+      found = true;
+    }
+  }
+  return found ? anchors : undefined;
+}
+
+export function resolveDynamicAnchor(
+  anchorName: string,
+  options: { dynamicAnchors?: Record<string, SchemaObject | ReferenceObject>; path?: string },
+  schemaObject: SchemaObject,
+): SchemaObject | ReferenceObject | undefined {
+  if (options.dynamicAnchors && anchorName in options.dynamicAnchors) {
+    return options.dynamicAnchors[anchorName];
+  }
+  const defs = (schemaObject as Record<string, unknown>).$defs as
+    | Record<string, SchemaObject | ReferenceObject>
+    | undefined;
+  if (defs && typeof defs === "object") {
+    for (const def of Object.values(defs)) {
+      if (def && typeof def === "object" && "$dynamicAnchor" in def && (def as any).$dynamicAnchor === anchorName) {
+        const { $dynamicAnchor, ...rest } = def as SchemaObject & { $dynamicAnchor: string };
+        if (Object.keys(rest).length > 0) {
+          return rest as SchemaObject | ReferenceObject;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+export function schemaContainsDynamicRef(schema: unknown): boolean {
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+  const obj = schema as Record<string, unknown>;
+  if ("$dynamicRef" in obj && typeof obj.$dynamicRef === "string") {
+    return true;
+  }
+  for (const val of Object.values(obj)) {
+    if (val && typeof val === "object") {
+      if (schemaContainsDynamicRef(val)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function createDiscriminatorEnum(values: string[], prevSchema?: SchemaObject): SchemaObject {
   return {
     type: "string",

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -24,7 +24,14 @@ import {
   UNDEFINED,
   UNKNOWN,
 } from "../lib/ts.js";
-import { createDiscriminatorProperty, createRef, getEntries } from "../lib/utils.js";
+import {
+  collectDynamicAnchors,
+  createDiscriminatorProperty,
+  createRef,
+  getEntries,
+  resolveDynamicAnchor,
+  schemaContainsDynamicRef,
+} from "../lib/utils.js";
 import type { ReferenceObject, SchemaObject, TransformNodeOptions } from "../types.js";
 
 /**
@@ -77,7 +84,59 @@ export function transformSchemaObjectWithComposition(
    * ReferenceObject
    */
   if ("$ref" in schemaObject) {
+    const localAnchors = collectDynamicAnchors(schemaObject as unknown as Record<string, unknown>);
+    const inheritedAnchors = options.dynamicAnchors;
+    const allAnchors: Record<string, SchemaObject | ReferenceObject> = {
+      ...(inheritedAnchors ?? {}),
+      ...(localAnchors ?? {}),
+    };
+    if (Object.keys(allAnchors).length > 0) {
+      const resolved = options.ctx.resolve<SchemaObject>(schemaObject.$ref);
+      if (resolved && typeof resolved === "object" && schemaContainsDynamicRef(resolved)) {
+        return transformSchemaObjectWithComposition(resolved, {
+          ...options,
+          dynamicAnchors: allAnchors,
+        });
+      }
+    }
     return oapiRef(schemaObject.$ref);
+  }
+
+  /**
+   * $dynamicRef (JSON Schema Draft 2020-12 / OpenAPI 3.1)
+   */
+  if ("$dynamicRef" in schemaObject && typeof (schemaObject as any).$dynamicRef === "string") {
+    const ref = (schemaObject as any).$dynamicRef as string;
+    const anchorName = ref.startsWith("#") ? ref.slice(1) : ref;
+    const override = resolveDynamicAnchor(
+      anchorName,
+      { dynamicAnchors: options.dynamicAnchors, path: options.path },
+      schemaObject as SchemaObject,
+    );
+    if (override) {
+      if ("$ref" in override) {
+        return oapiRef(override.$ref);
+      }
+      return transformSchemaObject(override, {
+        ...options,
+        path: options.path,
+      });
+    }
+    return UNKNOWN;
+  }
+
+  const localAnchors = collectDynamicAnchors(schemaObject as unknown as Record<string, unknown>);
+  if (localAnchors) {
+    options = { ...options, dynamicAnchors: { ...localAnchors, ...(options.dynamicAnchors ?? {}) } };
+  }
+
+  if ("$dynamicAnchor" in schemaObject && typeof (schemaObject as any).$dynamicAnchor === "string" && options.path) {
+    const anchorName = (schemaObject as any).$dynamicAnchor as string;
+    const selfRef: ReferenceObject = { $ref: options.path };
+    const existing = options.dynamicAnchors;
+    if (!existing || !(anchorName in existing)) {
+      options = { ...options, dynamicAnchors: { ...(existing ?? {}), [anchorName]: selfRef } };
+    }
   }
 
   /**

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -443,6 +443,8 @@ export type SchemaObject = {
   allOf?: (SchemaObject | ReferenceObject)[];
   anyOf?: (SchemaObject | ReferenceObject)[];
   required?: string[];
+  $dynamicRef?: string;
+  $dynamicAnchor?: string;
   [key: `x-${string}`]: any;
 } & (
   | StringSubtype
@@ -733,4 +735,5 @@ export interface TransformNodeOptions {
   path?: string;
   schema?: SchemaObject | ReferenceObject;
   ctx: GlobalContext;
+  dynamicAnchors?: Record<string, SchemaObject | ReferenceObject>;
 }

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -1111,6 +1111,284 @@ export type $defs = Record<string, never>;
 export type operations = Record<string, never>;`,
       },
     ],
+    [
+      "$dynamicRef > paginated response resolves concrete item type",
+      {
+        given: {
+          openapi: "3.1",
+          info: { title: "Test", version: "1.0" },
+          paths: {
+            "/users": {
+              get: {
+                operationId: "listUsers",
+                responses: {
+                  200: {
+                    description: "ok",
+                    content: {
+                      "application/json": {
+                        schema: { $ref: "#/components/schemas/PaginatedUserResponse" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              User: {
+                type: "object",
+                properties: {
+                  id: { type: "integer" },
+                  name: { type: "string" },
+                },
+              },
+              PaginatedTemplate: {
+                type: "object",
+                properties: {
+                  items: {
+                    type: "array",
+                    items: { $dynamicRef: "#itemType" },
+                  },
+                  total: { type: "integer" },
+                },
+                $defs: {
+                  itemType: {
+                    $dynamicAnchor: "itemType",
+                    not: {},
+                  },
+                },
+              },
+              PaginatedUserResponse: {
+                $ref: "#/components/schemas/PaginatedTemplate",
+                $defs: {
+                  itemType: {
+                    $dynamicAnchor: "itemType",
+                    $ref: "#/components/schemas/User",
+                  },
+                },
+              },
+            },
+          },
+        },
+        want: `export interface paths {
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["listUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        User: {
+            id?: number;
+            name?: string;
+        };
+        PaginatedTemplate: {
+            items?: unknown[];
+            total?: number;
+            $defs: {
+                itemType: unknown;
+            };
+        };
+        PaginatedUserResponse: {
+            items?: components["schemas"]["User"][];
+            total?: number;
+            $defs: {
+                itemType: unknown;
+            };
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    listUsers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description ok */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedUserResponse"];
+                };
+            };
+        };
+    };
+}`,
+      },
+    ],
+    [
+      "$dynamicRef > recursive allOf with $dynamicAnchor (LocalizedSpeciesCategory pattern)",
+      {
+        given: {
+          openapi: "3.1",
+          info: { title: "Test", version: "1.0" },
+          paths: {},
+          components: {
+            schemas: {
+              BaseCategory: {
+                $dynamicAnchor: "nodeType",
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  children: {
+                    type: "array",
+                    items: { $dynamicRef: "#nodeType" },
+                  },
+                },
+              },
+              LocalizedCategory: {
+                $dynamicAnchor: "nodeType",
+                allOf: [
+                  { $ref: "#/components/schemas/BaseCategory" },
+                  {
+                    type: "object",
+                    properties: {
+                      locale: { type: "string" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        want: `export type paths = Record<string, never>;
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        BaseCategory: {
+            name?: string;
+            children?: components["schemas"]["BaseCategory"][];
+        };
+        LocalizedCategory: {
+            name?: string;
+            children?: components["schemas"]["LocalizedCategory"][];
+        } & {
+            locale?: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
+    [
+      "$dynamicRef > multiple dynamic anchors with oneOf (shelter-folder pattern)",
+      {
+        given: {
+          openapi: "3.1",
+          info: { title: "Test", version: "1.0" },
+          paths: {},
+          components: {
+            schemas: {
+              Document: {
+                type: "object",
+                properties: {
+                  kind: { type: "string", const: "document" },
+                  title: { type: "string" },
+                },
+              },
+              FolderTemplate: {
+                type: "object",
+                properties: {
+                  children: {
+                    type: "array",
+                    items: {
+                      oneOf: [{ $ref: "#/components/schemas/Document" }, { $dynamicRef: "#folderType" }],
+                    },
+                  },
+                  tags: {
+                    type: "array",
+                    items: { $dynamicRef: "#tagType" },
+                  },
+                },
+                $defs: {
+                  folderType: { $dynamicAnchor: "folderType", not: {} },
+                  tagType: { $dynamicAnchor: "tagType", not: {} },
+                },
+              },
+              CustomFolder: {
+                $ref: "#/components/schemas/FolderTemplate",
+                $defs: {
+                  folderType: {
+                    $dynamicAnchor: "folderType",
+                    $ref: "#/components/schemas/CustomFolder",
+                  },
+                  tagType: {
+                    $dynamicAnchor: "tagType",
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+        },
+        want: `export type paths = Record<string, never>;
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        Document: {
+            /** @constant */
+            kind?: "document";
+            title?: string;
+        };
+        FolderTemplate: {
+            children?: (components["schemas"]["Document"] | unknown)[];
+            tags?: unknown[];
+            $defs: {
+                folderType: unknown;
+                tagType: unknown;
+            };
+        };
+        CustomFolder: {
+            children?: (components["schemas"]["Document"] | components["schemas"]["CustomFolder"])[];
+            tags?: string[];
+            $defs: {
+                folderType: unknown;
+                tagType: unknown;
+            };
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;`,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options, ci }] of tests) {

--- a/packages/openapi-typescript/test/lib/utils.test.ts
+++ b/packages/openapi-typescript/test/lib/utils.test.ts
@@ -1,4 +1,10 @@
-import { createRef, getEntries } from "../../src/lib/utils.js";
+import {
+  collectDynamicAnchors,
+  createRef,
+  getEntries,
+  resolveDynamicAnchor,
+  schemaContainsDynamicRef,
+} from "../../src/lib/utils.js";
 
 describe("getEntries", () => {
   test("operates like Object.entries()", () => {
@@ -51,5 +57,140 @@ describe("createRef", () => {
     expect(createRef(["#/paths/~1foo~1{bar}", "parameters", "query", "page"])).toBe(
       "#/paths/~1foo~1{bar}/parameters/query/page",
     );
+  });
+});
+
+describe("schemaContainsDynamicRef", () => {
+  test("returns false for null", () => {
+    expect(schemaContainsDynamicRef(null)).toBe(false);
+  });
+  test("returns false for undefined", () => {
+    expect(schemaContainsDynamicRef(undefined)).toBe(false);
+  });
+  test("returns false for primitive", () => {
+    expect(schemaContainsDynamicRef("string")).toBe(false);
+    expect(schemaContainsDynamicRef(42)).toBe(false);
+  });
+  test("returns false for empty object", () => {
+    expect(schemaContainsDynamicRef({})).toBe(false);
+  });
+  test("returns false for object with no $dynamicRef", () => {
+    expect(schemaContainsDynamicRef({ type: "string" })).toBe(false);
+  });
+  test("returns true for object with shallow $dynamicRef", () => {
+    expect(schemaContainsDynamicRef({ $dynamicRef: "#itemType" })).toBe(true);
+  });
+  test("returns true for object with nested $dynamicRef in properties", () => {
+    expect(
+      schemaContainsDynamicRef({
+        type: "object",
+        properties: {
+          items: { type: "array", items: { $dynamicRef: "#itemType" } },
+        },
+      }),
+    ).toBe(true);
+  });
+  test("returns true for object with $dynamicRef in allOf", () => {
+    expect(schemaContainsDynamicRef({ allOf: [{ $dynamicRef: "#itemType" }] })).toBe(true);
+  });
+  test("returns true for object with $dynamicRef deeply nested in $defs", () => {
+    expect(
+      schemaContainsDynamicRef({
+        $defs: {
+          nested: {
+            properties: {
+              child: { $dynamicRef: "#deep" },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("collectDynamicAnchors", () => {
+  test("returns undefined for schema without $defs", () => {
+    expect(collectDynamicAnchors({ type: "string" })).toBeUndefined();
+  });
+  test("returns undefined for schema with null $defs", () => {
+    expect(collectDynamicAnchors({ $defs: null })).toBeUndefined();
+  });
+  test("returns undefined for schema with non-object $defs", () => {
+    expect(collectDynamicAnchors({ $defs: "not-an-object" })).toBeUndefined();
+  });
+  test("returns undefined for $defs with no $dynamicAnchor entries", () => {
+    expect(collectDynamicAnchors({ $defs: { helper: { type: "string" } } })).toBeUndefined();
+  });
+  test("collects single anchor from $defs", () => {
+    const result = collectDynamicAnchors({
+      $defs: { itemType: { $dynamicAnchor: "itemType", type: "string" } },
+    });
+    expect(result).toEqual({ itemType: { type: "string" } });
+  });
+  test("collects multiple anchors from $defs", () => {
+    const result = collectDynamicAnchors({
+      $defs: {
+        itemType: { $dynamicAnchor: "itemType", type: "string" },
+        metaType: { $dynamicAnchor: "metaType", type: "integer" },
+        helper: { type: "boolean" },
+      },
+    });
+    expect(result).toEqual({
+      itemType: { type: "string" },
+      metaType: { type: "integer" },
+    });
+  });
+  test("bare $dynamicAnchor with no other properties returns full def", () => {
+    const result = collectDynamicAnchors({
+      $defs: { bare: { $dynamicAnchor: "bare" } },
+    });
+    expect(result).toEqual({ bare: { $dynamicAnchor: "bare" } });
+  });
+  test("strips $dynamicAnchor from anchor value when other properties exist", () => {
+    const result = collectDynamicAnchors({
+      $defs: { itemType: { $dynamicAnchor: "itemType", $ref: "#/components/schemas/User" } },
+    });
+    expect(result).toEqual({ itemType: { $ref: "#/components/schemas/User" } });
+    expect(result?.itemType).not.toHaveProperty("$dynamicAnchor");
+  });
+});
+
+describe("resolveDynamicAnchor", () => {
+  const makeOpts = (dynamicAnchors?: Record<string, any>) => ({ dynamicAnchors });
+  const baseSchema: any = {};
+
+  test("returns override from dynamicAnchors when present", () => {
+    const override = { $ref: "#/components/schemas/User" };
+    const result = resolveDynamicAnchor("itemType", makeOpts({ itemType: override }), baseSchema);
+    expect(result).toBe(override);
+  });
+  test("returns undefined when no dynamicAnchors and no $defs", () => {
+    const result = resolveDynamicAnchor("itemType", makeOpts(), baseSchema);
+    expect(result).toBeUndefined();
+  });
+  test("returns undefined when $defs has no matching anchor", () => {
+    const result = resolveDynamicAnchor("itemType", makeOpts(), {
+      $defs: { other: { $dynamicAnchor: "other", type: "string" } },
+    } as any);
+    expect(result).toBeUndefined();
+  });
+  test("returns fallback from $defs when no dynamicAnchors match", () => {
+    const result = resolveDynamicAnchor("itemType", makeOpts(), {
+      $defs: { itemType: { $dynamicAnchor: "itemType", type: "number" } },
+    } as any);
+    expect(result).toEqual({ type: "number" });
+  });
+  test("dynamicAnchors override takes precedence over $defs fallback", () => {
+    const override = { type: "string" };
+    const result = resolveDynamicAnchor("itemType", makeOpts({ itemType: override }), {
+      $defs: { itemType: { $dynamicAnchor: "itemType", type: "number" } },
+    } as any);
+    expect(result).toBe(override);
+  });
+  test("returns undefined for bare $dynamicAnchor in $defs (no other properties)", () => {
+    const result = resolveDynamicAnchor("bare", makeOpts(), {
+      $defs: { bare: { $dynamicAnchor: "bare" } },
+    } as any);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/openapi-typescript/test/transform/schema-object/dynamic-ref.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/dynamic-ref.test.ts
@@ -1,0 +1,674 @@
+import { fileURLToPath } from "node:url";
+import { astToString } from "../../../src/lib/ts.js";
+import transformSchemaObject from "../../../src/transform/schema-object.js";
+import { DEFAULT_CTX, type TestCase } from "../../test-helpers.js";
+
+const DEFAULT_OPTIONS = {
+  path: "#/components/schemas/schema-object",
+  ctx: { ...DEFAULT_CTX },
+};
+
+describe("$dynamicRef", () => {
+  const tests: TestCase[] = [
+    [
+      "$dynamicRef > no override → fallback to unknown",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+        },
+        want: "unknown",
+      },
+    ],
+    [
+      "$dynamicRef > with dynamicAnchors override providing $ref",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+        },
+        want: 'components["schemas"]["User"]',
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            itemType: { $ref: "#/components/schemas/User" },
+          },
+        },
+      },
+    ],
+    [
+      "$dynamicRef > with dynamicAnchors override providing inline type",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+        },
+        want: "string",
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            itemType: { type: "string" },
+          },
+        },
+      },
+    ],
+    [
+      "$dynamicRef > with fallback in schema $defs",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "number",
+            },
+          },
+        },
+        want: "number",
+      },
+    ],
+    [
+      "$dynamicRef > dynamicAnchors override takes precedence over $defs fallback",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "number",
+            },
+          },
+        },
+        want: "string",
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            itemType: { type: "string" },
+          },
+        },
+      },
+    ],
+    [
+      "$ref + $defs with $dynamicAnchor > resolves template with override",
+      {
+        given: {
+          $ref: "#/components/schemas/PaginatedTemplate",
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              $ref: "#/components/schemas/User",
+            },
+          },
+        },
+        want: `{
+    items?: components["schemas"]["User"][];
+    $defs: {
+        itemType: unknown;
+    };
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/PaginatedTemplate") {
+                return {
+                  type: "object",
+                  properties: {
+                    items: {
+                      type: "array",
+                      items: {
+                        $dynamicRef: "#itemType",
+                      },
+                    },
+                  },
+                  $defs: {
+                    itemType: {
+                      $dynamicAnchor: "itemType",
+                      not: {},
+                    },
+                  },
+                };
+              }
+              if ($ref === "#/components/schemas/User") {
+                return { type: "object", properties: { id: { type: "integer" }, name: { type: "string" } } };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$ref + $defs with $dynamicAnchor > recursive self-reference",
+      {
+        given: {
+          $ref: "#/components/schemas/BaseCategory",
+          $defs: {
+            childType: {
+              $dynamicAnchor: "childType",
+              $ref: "#/components/schemas/LocalizedCategory",
+            },
+          },
+        },
+        want: `{
+    name?: string;
+    children?: components["schemas"]["LocalizedCategory"][];
+    $defs: {
+        childType: unknown;
+    };
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/BaseCategory") {
+                return {
+                  type: "object",
+                  properties: {
+                    name: { type: "string" },
+                    children: {
+                      type: "array",
+                      items: {
+                        $dynamicRef: "#childType",
+                      },
+                    },
+                  },
+                  $defs: {
+                    childType: {
+                      $dynamicAnchor: "childType",
+                      not: {},
+                    },
+                  },
+                };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$ref without $dynamicAnchor $defs > normal $ref behavior",
+      {
+        given: {
+          $ref: "#/components/schemas/User",
+        },
+        want: 'components["schemas"]["User"]',
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/User") {
+                return { type: "object", properties: { name: { type: "string" } } };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$ref + $defs without $dynamicAnchor > normal $ref behavior",
+      {
+        given: {
+          $ref: "#/components/schemas/User",
+          $defs: {
+            helper: { type: "string" },
+          },
+        },
+        want: 'components["schemas"]["User"]',
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/User") {
+                return { type: "object", properties: { name: { type: "string" } } };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$dynamicAnchor on schema > self-registers and resolves $dynamicRef in child properties",
+      {
+        given: {
+          $dynamicAnchor: "nodeType",
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            children: {
+              type: "array",
+              items: {
+                $dynamicRef: "#nodeType",
+              },
+            },
+          },
+        },
+        want: `{
+    name?: string;
+    children?: components["schemas"]["schema-object"][];
+}`,
+      },
+    ],
+    [
+      "$defs with $dynamicAnchor on parent schema > resolves child $dynamicRef",
+      {
+        given: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: {
+                $dynamicRef: "#itemType",
+              },
+            },
+          },
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "string",
+            },
+          },
+        },
+        want: `{
+    items?: string[];
+    $defs: {
+        itemType: string;
+    };
+}`,
+      },
+    ],
+    [
+      "$dynamicAnchor on schema > child override takes precedence over self-registration",
+      {
+        given: {
+          $dynamicAnchor: "nodeType",
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            children: {
+              type: "array",
+              items: {
+                $dynamicRef: "#nodeType",
+              },
+            },
+          },
+        },
+        want: `{
+    name?: string;
+    children?: components["schemas"]["CustomNode"][];
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            nodeType: { $ref: "#/components/schemas/CustomNode" },
+          },
+        },
+      },
+    ],
+    [
+      "$ref with inherited dynamicAnchors but resolved target has no $dynamicRef > falls through to oapiRef",
+      {
+        given: {
+          $ref: "#/components/schemas/User",
+        },
+        want: 'components["schemas"]["User"]',
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            unrelatedAnchor: { type: "string" },
+          },
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/User") {
+                return { type: "object", properties: { name: { type: "string" } } };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$ref with inherited dynamicAnchors and resolved target contains $dynamicRef > concretizes",
+      {
+        given: {
+          $ref: "#/components/schemas/Template",
+        },
+        want: `{
+    items?: string[];
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            itemType: { type: "string" },
+          },
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/Template") {
+                return {
+                  type: "object",
+                  properties: {
+                    items: {
+                      type: "array",
+                      items: { $dynamicRef: "#itemType" },
+                    },
+                  },
+                };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "collectDynamicAnchors > bare $dynamicAnchor with no other properties",
+      {
+        given: {
+          $dynamicRef: "#bare",
+          $defs: {
+            bare: {
+              $dynamicAnchor: "bare",
+            },
+          },
+        },
+        want: "unknown",
+      },
+    ],
+    [
+      "multiple dynamic anchors in single $defs",
+      {
+        given: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: { $dynamicRef: "#itemType" },
+            },
+            meta: { $dynamicRef: "#metaType" },
+          },
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "integer",
+            },
+            metaType: {
+              $dynamicAnchor: "metaType",
+              type: "string",
+            },
+          },
+        },
+        want: `{
+    items?: number[];
+    meta?: string;
+    $defs: {
+        itemType: number;
+        metaType: string;
+    };
+}`,
+      },
+    ],
+    [
+      "schemaContainsDynamicRef guard > $ref with local $defs anchors but resolved target has no $dynamicRef",
+      {
+        given: {
+          $ref: "#/components/schemas/Simple",
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "string",
+            },
+          },
+        },
+        want: 'components["schemas"]["Simple"]',
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/Simple") {
+                return { type: "object", properties: { id: { type: "integer" } } };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "$dynamicRef with non-# URI > uses full string as anchor name",
+      {
+        given: {
+          $dynamicRef: "itemType",
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "boolean",
+            },
+          },
+        },
+        want: "boolean",
+      },
+    ],
+    [
+      "$dynamicAnchor without options.path > self-registration skipped",
+      {
+        given: {
+          $dynamicAnchor: "nodeType",
+          type: "object",
+          properties: {
+            children: {
+              type: "array",
+              items: { $dynamicRef: "#nodeType" },
+            },
+          },
+        },
+        want: `{
+    children?: unknown[];
+}`,
+        options: {
+          ctx: { ...DEFAULT_CTX },
+        },
+      },
+    ],
+    [
+      "$dynamicRef inside allOf > resolves with parent $defs anchors",
+      {
+        given: {
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                items: {
+                  type: "array",
+                  items: { $dynamicRef: "#itemType" },
+                },
+              },
+            },
+          ],
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "string",
+            },
+          },
+        },
+        want: `{
+    $defs: {
+        itemType: string;
+    };
+} & {
+    items?: string[];
+}`,
+      },
+    ],
+    [
+      "$dynamicRef inside oneOf > resolves with parent $defs anchors",
+      {
+        given: {
+          oneOf: [{ $dynamicRef: "#itemType" }, { type: "null" }],
+          $defs: {
+            itemType: {
+              $dynamicAnchor: "itemType",
+              type: "integer",
+            },
+          },
+        },
+        want: `{
+    $defs: {
+        itemType: number;
+    };
+} | number | null`,
+      },
+    ],
+    [
+      "$dynamicRef and $dynamicAnchor on same schema > $dynamicRef returns early before self-registration",
+      {
+        given: {
+          $dynamicRef: "#anchor",
+          $dynamicAnchor: "anchor",
+          $defs: {
+            anchor: {
+              $dynamicAnchor: "anchor",
+              type: "number",
+            },
+          },
+        },
+        want: "number",
+      },
+    ],
+    [
+      "$ref with both inherited and local anchors > both are merged and passed to resolved template",
+      {
+        given: {
+          $ref: "#/components/schemas/PairTemplate",
+          $defs: {
+            secondType: {
+              $dynamicAnchor: "secondType",
+              type: "boolean",
+            },
+          },
+        },
+        want: `{
+    first?: string;
+    second?: boolean;
+}`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          dynamicAnchors: {
+            firstType: { type: "string" },
+          },
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            resolve($ref: string) {
+              if ($ref === "#/components/schemas/PairTemplate") {
+                return {
+                  type: "object",
+                  properties: {
+                    first: { $dynamicRef: "#firstType" },
+                    second: { $dynamicRef: "#secondType" },
+                  },
+                };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "resolveDynamicAnchor skips non-matching anchor names in $defs",
+      {
+        given: {
+          $dynamicRef: "#target",
+          $defs: {
+            other: {
+              $dynamicAnchor: "other",
+              type: "number",
+            },
+            target: {
+              $dynamicAnchor: "target",
+              type: "string",
+            },
+          },
+        },
+        want: "string",
+      },
+    ],
+    [
+      "collectDynamicAnchors > $defs with mixed entries (some with $dynamicAnchor, some without)",
+      {
+        given: {
+          type: "object",
+          properties: {
+            data: { $dynamicRef: "#myType" },
+          },
+          $defs: {
+            helper: { type: "string" },
+            myType: {
+              $dynamicAnchor: "myType",
+              type: "integer",
+            },
+          },
+        },
+        want: `{
+    data?: number;
+    $defs: {
+        helper: string;
+        myType: number;
+    };
+}`,
+      },
+    ],
+    [
+      "collectDynamicAnchors > non-object $defs returns undefined > no anchors collected",
+      {
+        given: {
+          $dynamicRef: "#itemType",
+          $defs: "not-an-object",
+        },
+        want: "unknown",
+      },
+    ],
+    [
+      "$dynamicAnchor self-registration > nested $dynamicRef resolves through self-ref",
+      {
+        given: {
+          $dynamicAnchor: "tree",
+          type: "object",
+          properties: {
+            value: { type: "string" },
+            left: { $dynamicRef: "#tree" },
+            right: { $dynamicRef: "#tree" },
+          },
+        },
+        want: `{
+    value?: string;
+    left?: components["schemas"]["schema-object"];
+    right?: components["schemas"]["schema-object"];
+}`,
+      },
+    ],
+  ];
+
+  for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {
+    test.skipIf(ci?.skipIf)(
+      testName,
+      async () => {
+        const result = astToString(transformSchemaObject(given, options));
+        if (want instanceof URL) {
+          await expect(result).toMatchFileSnapshot(fileURLToPath(want));
+        } else {
+          expect(result).toBe(`${want}\n`);
+        }
+      },
+      ci?.timeout,
+    );
+  }
+});


### PR DESCRIPTION
Closes #2029

## Summary

Implements `$dynamicRef` and `$dynamicAnchor` support (JSON Schema Draft 2020-12 / OpenAPI 3.1), enabling generic/template schema patterns like `PaginatedResponse<T>` and recursive type hierarchies.

### What it does

When a schema uses `$ref` to a template with `$dynamicRef` placeholders, and the caller provides `$defs` with `$dynamicAnchor` overrides, the generated TypeScript types are concretized — each override produces a distinct type with the correct substituted types instead of `unknown`.

**Example input:**
```yaml
PaginatedTemplate:
  type: object
  properties:
    items:
      type: array
      items: { $dynamicRef: "#itemType" }
  $defs:
    itemType: { $dynamicAnchor: "itemType", not: {} }

PaginatedPetItems:
  $ref: "#/components/schemas/PaginatedTemplate"
  $defs:
    itemType: { $dynamicAnchor: "itemType", $ref: "#/components/schemas/Pet" }
```

**Output:**
```typescript
PaginatedTemplate: { items?: unknown[]; ... }        // standalone: no override → unknown
PaginatedPetItems: { items?: components["schemas"]["Pet"][]; ... }  // concretized with Pet
```

### Supported patterns

| Pattern | Example |
|---------|---------|
| Generic/template schemas via `$ref` + `$defs` | `PaginatedResponse<T>` |
| Recursive self-reference via `$dynamicAnchor` on schema | `BaseCategory { children: Self[] }` |
| Child override of parent anchor | `LocalizedCategory` overrides `children: LocalizedCategory[]` |
| Multiple dynamic anchors | `ShelterFolder` with `folderType` + `resourceType` |
| `$dynamicRef` inside `allOf`/`oneOf`/`anyOf` | Nested composition |
| Chained templates | `ApiEnvelope > PaginatedResponse > Pet` |

### Implementation

- **`SchemaObject`** — Added `$dynamicRef?: string` and `$dynamicAnchor?: string`
- **`TransformNodeOptions`** — Added `dynamicAnchors` for scope propagation through recursive transforms
- **`collectDynamicAnchors()`** — Collects `$dynamicAnchor` entries from `$defs`, stripping the anchor keyword
- **`resolveDynamicAnchor()`** — Resolves anchor name: checks parent scope first (override), then local `$defs` (fallback)
- **`schemaContainsDynamicRef()`** — Guards `$ref` concretization to only inline when the target actually uses `$dynamicRef`
- **`$ref` handler** — When `$defs` provide dynamic anchors AND the resolved target contains `$dynamicRef`, concretizes inline with merged anchors
- **`$dynamicRef` handler** — Resolves to override type, returns `oapiRef()` for `$ref` overrides (prevents infinite recursion), transforms inline for schema overrides
- **`$dynamicAnchor` handler** — Self-registers schema as anchor for recursive type generation
- **Parent `$defs` propagation** — Non-`$ref` schemas with `$defs` anchors pass them to child transforms

### Testing

- **336 tests total** (43 new)
  - 27 unit tests in `dynamic-ref.test.ts` covering every branch in the transform logic
  - 16 direct utility tests in `utils.test.ts` for `schemaContainsDynamicRef`, `collectDynamicAnchors`, `resolveDynamicAnchor`
  - 3 integration tests in `index.test.ts` with full OpenAPI documents (paginated response, recursive allOf, multiple anchors with oneOf)
- All pre-existing tests continue to pass (293 → 336)
- Lint clean, TypeScript type-check clean

### Files changed

| File | Change |
|------|--------|
| `src/types.ts` | Add `$dynamicRef`, `$dynamicAnchor` to `SchemaObject`; add `dynamicAnchors` to `TransformNodeOptions` |
| `src/lib/utils.ts` | Add `collectDynamicAnchors()`, `resolveDynamicAnchor()`, `schemaContainsDynamicRef()` |
| `src/transform/schema-object.ts` | Add `$dynamicRef` handler, `$dynamicAnchor` self-registration, `$ref` concretization with dynamic anchors, parent `$defs` propagation |
| `test/transform/schema-object/dynamic-ref.test.ts` | 27 new unit tests (new file) |
| `test/lib/utils.test.ts` | 16 new direct utility tests |
| `test/index.test.ts` | 3 new integration tests |