### PR TITLE
Fix optional null request body properties

### DIFF
--- a/.changeset/silver-null-bodies.md
+++ b/.changeset/silver-null-bodies.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+Preserve optional null properties when filtering request body readOnly markers.

--- a/packages/openapi-fetch/test/types.test.ts
+++ b/packages/openapi-fetch/test/types.test.ts
@@ -1,7 +1,55 @@
 import type { ErrorResponse, GetResponseContent, OkStatus, SuccessResponse } from "openapi-typescript-helpers";
 import { assertType, describe, test } from "vitest";
+import createClient from "../src/index.js";
 
 describe("types", () => {
+  describe("request body", () => {
+    interface Paths {
+      "/": {
+        post: {
+          parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+          };
+          requestBody: {
+            content: {
+              "application/json": Components["schemas"]["T"];
+            };
+          };
+          responses: {
+            200: {
+              headers: {
+                [name: string]: unknown;
+              };
+              content: {
+                "application/json": unknown;
+              };
+            };
+          };
+        };
+      };
+    }
+
+    interface Components {
+      schemas: {
+        T: {
+          x?: null;
+        };
+      };
+    }
+
+    test("allows optional null request body properties", () => {
+      const demo = (body: Components["schemas"]["T"]) => {
+        const client = createClient<Paths>();
+        return client.POST("/", { body });
+      };
+
+      assertType<(body: Components["schemas"]["T"]) => Promise<unknown>>(demo);
+    });
+  });
+
   describe("GetResponseContent", () => {
     describe("MixedResponses", () => {
       interface MixedResponses {

--- a/packages/openapi-typescript-helpers/src/index.ts
+++ b/packages/openapi-typescript-helpers/src/index.ts
@@ -210,6 +210,9 @@ export type $Read<T> = { readonly $read: T };
 /** Marker type for writeOnly properties (excluded from response bodies) */
 export type $Write<T> = { readonly $write: T };
 
+type HasReadMarker<T> = [NonNullable<T>] extends [never] ? false : NonNullable<T> extends $Read<any> ? true : false;
+type HasWriteMarker<T> = [NonNullable<T>] extends [never] ? false : NonNullable<T> extends $Write<any> ? true : false;
+
 /**
  * Resolve type for reading (responses): strips $Write properties, unwraps $Read
  * - $Read<T> → T (readable), continues recursion
@@ -224,7 +227,7 @@ export type Readable<T> =
       : T extends (infer E)[]
         ? Readable<E>[]
         : T extends object
-          ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> }
+          ? { [K in keyof T as HasWriteMarker<T[K]> extends true ? never : K]: Readable<T[K]> }
           : T;
 
 /**
@@ -241,7 +244,7 @@ export type Writable<T> =
       : T extends (infer E)[]
         ? Writable<E>[]
         : T extends object
-          ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & {
-              [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never;
+          ? { [K in keyof T as HasReadMarker<T[K]> extends true ? never : K]: Writable<T[K]> } & {
+              [K in keyof T as HasReadMarker<T[K]> extends true ? K : never]?: never;
             }
           : T;


### PR DESCRIPTION
## Changes

- Fixes #2717
- Preserve optional `null` properties when `Writable<T>` filters readOnly markers for request bodies.
- Adds an `openapi-fetch` regression type test for `{ x?: null }` request bodies.

## How to Review

- The marker helpers now treat `never` from `NonNullable<null | undefined>` as no marker, so optional null properties are retained.
- Existing readOnly/writeOnly request and response behavior is covered by the focused test run.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary; not necessary for this type-only bugfix)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript; not applicable)

Verification:

- `pnpm --filter openapi-typescript-helpers run lint`
- `pnpm --filter openapi-fetch run lint`
- `pnpm --filter openapi-fetch run test`
