### PR TITLE
Fix undefined initial page param in useInfiniteQuery

### DIFF
--- a/.changeset/early-cursors-sip.md
+++ b/.changeset/early-cursors-sip.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+Fix `useInfiniteQuery` to omit the page parameter when `initialPageParam` is `undefined`.

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -232,7 +232,7 @@ export default function createClient<Paths extends {}, Media extends MediaType =
       return useInfiniteQuery(
         {
           queryKey,
-          queryFn: async ({ queryKey: [method, path, init], pageParam = 0, signal }) => {
+          queryFn: async ({ queryKey: [method, path, init], pageParam, signal }) => {
             const mth = method.toUpperCase() as Uppercase<typeof method>;
             const fn = client[mth] as ClientMethod<Paths, typeof method, Media>;
             const mergedInit = {
@@ -242,7 +242,7 @@ export default function createClient<Paths extends {}, Media extends MediaType =
                 ...(init?.params || {}),
                 query: {
                   ...(init?.params as { query?: DefaultParamsOption })?.query,
-                  [pageParamName]: pageParam,
+                  ...(pageParam !== undefined ? { [pageParamName]: pageParam } : {}),
                 },
               },
             };

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -1036,6 +1036,66 @@ describe("client", () => {
       const allItems = result.current.data?.pages.flatMap((page) => page.items);
       expect(allItems).toEqual([1, 2, 3, 4, 5, 6]);
     });
+    it("should omit cursor from the initial request when initialPageParam is undefined", async () => {
+      const fetchClient = createFetchClient<paths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      const firstRequestHandler = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/paginated-data",
+        status: 200,
+        body: { items: [1, 2, 3], nextPage: 1 },
+      });
+
+      const { result, rerender } = renderHook(
+        () =>
+          client.useInfiniteQuery(
+            "get",
+            "/paginated-data",
+            {
+              params: {
+                query: {
+                  limit: 3,
+                },
+              },
+            },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextPage,
+              initialPageParam: undefined,
+            },
+          ),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const firstRequestUrl = firstRequestHandler.getRequestUrl();
+      expect(firstRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(firstRequestUrl?.searchParams.get("cursor")).toBeNull();
+
+      const secondRequestHandler = useMockRequestHandler({
+        baseUrl,
+        method: "get",
+        path: "/paginated-data",
+        status: 200,
+        body: { items: [4, 5, 6], nextPage: 2 },
+      });
+
+      await act(async () => {
+        await result.current.fetchNextPage();
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isFetching).toBe(false);
+        expect(result.current.data?.pages).toHaveLength(2);
+      });
+
+      const secondRequestUrl = secondRequestHandler.getRequestUrl();
+      expect(secondRequestUrl?.searchParams.get("limit")).toBe("3");
+      expect(secondRequestUrl?.searchParams.get("cursor")).toBe("1");
+    });
     it("should reverse pages and pageParams when using the select option", async () => {
       const fetchClient = createFetchClient<paths>({ baseUrl });
       const client = createClient(fetchClient);


### PR DESCRIPTION
## Changes

Fixes #2715

- omit the configured page query parameter when TanStack supplies an undefined initial page param
- keep explicit page params, including 0, in requests
- add a regression test for undefined `initialPageParam` followed by `fetchNextPage()`
- add a patch changeset for `openapi-react-query`

## How to Review

Check `packages/openapi-react-query/src/index.ts` and the new `useInfiniteQuery` regression test. The first request should keep existing query params like `limit` while omitting `cursor`; the second request should include the next cursor.

## Checklist

- [x] Unit tests updated
- [x] `docs/` updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)

Validation:

- `pnpm run build`
- `pnpm --filter openapi-react-query exec vitest run test/index.test.tsx -t "should omit cursor"`
- `pnpm --filter openapi-react-query test`
- `pnpm --filter openapi-react-query lint`