### PR TITLE
Fix empty string enum member output

### DIFF
--- a/.changeset/empty-enums-smile.md
+++ b/.changeset/empty-enums-smile.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix `--enum` output for schemas that include an empty string enum value by emitting a valid string-literal enum member name.

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -406,8 +406,10 @@ function sanitizeMemberName(name: string) {
 
 /** Sanitize TS enum member expression */
 export function tsEnumMember(value: string | number, metadata: { name?: string; description?: string | null } = {}) {
-  let name = metadata.name ?? String(value);
-  if (!JS_PROPERTY_INDEX_RE.test(name)) {
+  let name: string | ts.StringLiteral = metadata.name ?? String(value);
+  if (name === "") {
+    name = ts.factory.createStringLiteral(name);
+  } else if (!JS_PROPERTY_INDEX_RE.test(name)) {
     if (Number(name[0]) >= 0) {
       name = `Value${name}`.replace(".", "_"); // don't forged decimals;
     } else if (name[0] === "-") {

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -187,6 +187,14 @@ describe("tsEnum", () => {
 }`);
   });
 
+  test("empty string member", () => {
+    expect(astToString(tsEnum("/my/enum/", ["", "foo", "bar"])).trim()).toBe(`enum MyEnum {
+    "" = "",
+    foo = "foo",
+    bar = "bar"
+}`);
+  });
+
   test("with setting: export", () => {
     expect(
       astToString(


### PR DESCRIPTION
Fixes #2807.

## Summary
- emit empty string enum values as quoted enum member names instead of a missing identifier
- add a `tsEnum` regression for `["", "foo", "bar"]`

## Validation
- `corepack pnpm --filter openapi-typescript exec vitest run test/lib/ts.test.ts -t "empty string member"`
- `corepack pnpm --filter openapi-typescript exec vitest run test/lib/ts.test.ts`
- `corepack pnpm --filter openapi-typescript build`
- `corepack pnpm --filter openapi-typescript test:js`
- `corepack pnpm --filter openapi-typescript lint:ts`
- `corepack pnpm --filter openapi-typescript lint:js` (passes with existing Biome warnings)
