### PR TITLE
fix: handle property names with percent signs in JSON Pointers

### DIFF
--- a/.changeset/percent-sign-property-name.md
+++ b/.changeset/percent-sign-property-name.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix crash (`URIError: URI malformed`) when a schema has a property name containing a literal percent sign (e.g. `"25%"`) that resolves to an object. JSON Pointer segments are now parsed resiliently, falling back to the raw segment when `decodeURIComponent` fails instead of throwing.

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -1,7 +1,37 @@
 import type { OasRef, Referenced } from "@redocly/openapi-core";
-import { parseRef } from "@redocly/openapi-core/lib/ref-utils.js";
+import { parseRef as redoclyParseRef } from "@redocly/openapi-core/lib/ref-utils.js";
 import ts, { type LiteralTypeNode, type TypeLiteralNode } from "typescript";
 import type { ParameterObject } from "../types.js";
+
+/**
+ * Parse a $ref / JSON Pointer into its URI and pointer segments.
+ *
+ * This is a resilient wrapper around Redocly’s `parseRef`. Redocly unescapes each
+ * pointer segment with `decodeURIComponent`, which throws a `URIError` on a literal,
+ * un-encoded `%` (e.g. a schema property named `"25%"`). Property names are valid
+ * pointer segments and shouldn’t crash codegen, so when decoding fails we fall back
+ * to the raw, un-decoded segment (matching the asymmetry of `escapePointer`, which
+ * does not percent-encode).
+ */
+export function parseRef(ref: string): ReturnType<typeof redoclyParseRef> {
+  try {
+    return redoclyParseRef(ref);
+  } catch {
+    const [uri, rawPointer = ""] = ref.split("#/");
+    const pointer = rawPointer
+      .split("/")
+      .map((fragment) => {
+        const unescaped = fragment.replace(/~1/g, "/").replace(/~0/g, "~");
+        try {
+          return decodeURIComponent(unescaped);
+        } catch {
+          return unescaped;
+        }
+      })
+      .filter(Boolean);
+    return { uri: (uri.endsWith("#") ? uri.slice(0, -1) : uri) || null, pointer };
+  }
+}
 
 export const JS_PROPERTY_INDEX_RE = /^[A-Za-z_$][A-Za-z_$0-9]*$/;
 export const JS_ENUM_INVALID_CHARS_RE = /[^A-Za-z_$0-9]+(.)?/g;

--- a/packages/openapi-typescript/src/lib/utils.ts
+++ b/packages/openapi-typescript/src/lib/utils.ts
@@ -1,9 +1,9 @@
-import { escapePointer, parseRef } from "@redocly/openapi-core/lib/ref-utils.js";
+import { escapePointer } from "@redocly/openapi-core/lib/ref-utils.js";
 import c from "ansi-colors";
 import supportsColor from "supports-color";
 import ts from "typescript";
 import type { DiscriminatorObject, OpenAPI3, OpenAPITSOptions, ReferenceObject, SchemaObject } from "../types.js";
-import { tsLiteral, tsModifiers, tsPropertyIndex } from "./ts.js";
+import { parseRef, tsLiteral, tsModifiers, tsPropertyIndex } from "./ts.js";
 
 if (!supportsColor.stdout || supportsColor.stdout.hasBasic === false) {
   c.enabled = false;

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -1,4 +1,3 @@
-import { parseRef } from "@redocly/openapi-core/lib/ref-utils.js";
 import ts from "typescript";
 import {
   addJSDocComment,
@@ -7,6 +6,7 @@ import {
   NULL,
   NUMBER,
   oapiRef,
+  parseRef,
   QUESTION_TOKEN,
   STRING,
   tsArrayLiteralExpression,

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -6,6 +6,7 @@ import {
   NULL,
   NUMBER,
   oapiRef,
+  parseRef,
   STRING,
   tsArrayLiteralExpression,
   tsEnum,
@@ -14,6 +15,21 @@ import {
   tsPropertyIndex,
   tsUnion,
 } from "../../src/lib/ts.js";
+
+describe("parseRef", () => {
+  test("parses pointer segments", () => {
+    expect(parseRef("#/components/schemas/Foo").pointer).toEqual(["components", "schemas", "Foo"]);
+  });
+
+  test("decodes percent-encoded segments", () => {
+    expect(parseRef("#/paths/~1users~1%7Bid%7D/get").pointer).toEqual(["paths", "/users/{id}", "get"]);
+  });
+
+  test("does not throw on a literal percent sign (#2251)", () => {
+    expect(() => parseRef("#/components/schemas/response/25%")).not.toThrow();
+    expect(parseRef("#/components/schemas/response/25%").pointer).toEqual(["components", "schemas", "response", "25%"]);
+  });
+});
 
 describe("addJSDocComment", () => {
   test("single-line comment", () => {

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -624,6 +624,33 @@ describe("transformSchemaObject > object", () => {
         },
       },
     ],
+    [
+      "property name with percent sign (nested object)",
+      {
+        // a property key containing a literal "%" must not crash codegen when it
+        // holds a nested object — the path is fed back through parseRef, which
+        // would otherwise throw a URIError via decodeURIComponent. See #2251.
+        given: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            "25%": {
+              type: "object",
+              properties: {
+                color: { type: "string" },
+              },
+            },
+          },
+        },
+        want: `{
+    id?: string;
+    "25%"?: {
+        color?: string;
+    };
+}`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
   ];
 
   for (const [testName, { given, want, options = DEFAULT_OPTIONS, ci }] of tests) {


### PR DESCRIPTION
## Changes

Fixes #2251.

A schema property name containing a literal percent sign (e.g. `"25%"`) crashes codegen with `URIError: URI malformed` whenever that property resolves to an object:

```yaml
components:
  schemas:
    response:
      type: object
      properties:
        "25%":
          type: object
          properties:
            color:
              type: string
```

### Root cause

`createRef` builds JSON Pointer paths by escaping each segment with Redocly's `escapePointer`, which escapes `~` and `/` but does **not** percent-encode. When a nested object is transformed, the accumulated path (e.g. `#/components/schemas/response/25%`) is fed back into `parseRef`, whose `unescapePointer` runs `decodeURIComponent` on each segment. `decodeURIComponent("25%")` throws `URIError: URI malformed`, crashing the whole run.

The same `parseRef` round-trip is used in several places (`createRef`, `oapiRef`, enum-name generation, discriminator property inference), so any of them could hit this with a `%`-containing key.

### Fix

Add a small resilient `parseRef` wrapper (in `src/lib/ts.ts`) that delegates to Redocly's `parseRef`, but on failure falls back to parsing the pointer without `decodeURIComponent` — and per segment, only decodes when it can, otherwise returns the raw segment. This mirrors the asymmetry of `escapePointer` (which never percent-encodes), so:

- Literal `%` segments (e.g. `25%`) pass through unchanged instead of throwing.
- Legitimately percent-encoded segments (e.g. `%7Bid%7D` -> `{id}`) still decode correctly.

All internal `parseRef` call sites now use this wrapper.

## How to Review

- The behavioral regression test is in `test/transform/schema-object/object.test.ts` ("property name with percent sign (nested object)"). It throws `URIError: URI malformed` on `main` and passes with this change.
- Unit tests for the wrapper are in `test/lib/ts.test.ts` (`describe("parseRef")`): confirms normal parsing, percent-decoding, and no-throw on a bare `%`.
- `pnpm test` passes for the `openapi-typescript` package.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary) — n/a
- [ ] `pnpm run update:examples` run — n/a (no example schema output changes)
- [x] Changeset added (`.changeset/percent-sign-property-name.md`)