### PR TITLE
chore: align Biome config with pinned 2.4.14 and modern folder-ignore syntax

### DIFF
--- a/.changeset/chatty-coins-spend.md
+++ b/.changeset/chatty-coins-spend.md
@@ -1,0 +1,8 @@
+---
+"openapi-fetch": patch
+"openapi-react-query": patch
+"openapi-typescript-helpers": patch
+"openapi-typescript": patch
+---
+
+chore: align Biome config with pinned 2.4.14 and modern folder-ignore syntax

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "root": true,
   "files": {
     "includes": ["**", "!**/dist", "!**/package.json"]

--- a/packages/openapi-fetch/biome.json
+++ b/packages/openapi-fetch/biome.json
@@ -1,9 +1,9 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "extends": "//",
   "files": {
-    "includes": ["src/**", "test/**", "!**/examples/**", "!test/**/schemas/**", "!test/bench/**/*.min.js"]
+    "includes": ["src/**", "test/**", "!**/examples", "!test/**/schemas", "!test/bench/**/*.min.js"]
   },
   "linter": {
     "rules": {

--- a/packages/openapi-react-query/biome.json
+++ b/packages/openapi-react-query/biome.json
@@ -1,9 +1,9 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "extends": "//",
   "files": {
-    "includes": ["**", "!dist/**", "!test/fixtures/**"]
+    "includes": ["**", "!dist", "!test/fixtures"]
   },
   "linter": {
     "rules": {

--- a/packages/openapi-typescript-helpers/biome.json
+++ b/packages/openapi-typescript-helpers/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "extends": "//",
   "files": {
     "includes": ["**/*"]

--- a/packages/openapi-typescript/biome.json
+++ b/packages/openapi-typescript/biome.json
@@ -1,8 +1,8 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "extends": "//",
   "files": {
-    "includes": ["bin/**", "!examples/**", "src/**", "test/**", "!**/fixtures/**/*"]
+    "includes": ["bin/**", "!examples", "src/**", "test/**", "!**/fixtures/**/*"]
   }
 }


### PR DESCRIPTION
## What and why

The repo pins `@biomejs/biome` to **2.4.14** (see `package.json`), but every `biome.json` still declares the **2.3.14** `$schema` and uses the pre-2.2.0 `!folder/**` ignore syntax. Running the pinned CLI on a clean checkout surfaces config drift:

- 5x schema-version-mismatch notices (`The configuration schema version does not match the CLI version 2.4.14` -> `Run the command biome migrate`)
- 5x `lint/suspicious/useBiomeIgnoreFolder` warnings (`Since version 2.2.0, ignoring folders doesn't require the trailing /**`)

This is the same lint surface contributor PRs hit (e.g. the `biome check` step in CI), so cleaning it up keeps the signal clean.

## Changes

- Bump `$schema` to `2.4.14` in the root config and all four package configs — exactly what `biome migrate` emits.
- Adopt the new folder-ignore syntax via Biome's own **safe** fix:
  - `openapi-fetch`: `!**/examples/**` -> `!**/examples`, `!test/**/schemas/**` -> `!test/**/schemas`
  - `openapi-react-query`: `!dist/**` -> `!dist`, `!test/fixtures/**` -> `!test/fixtures`
  - `openapi-typescript`: `!examples/**` -> `!examples`
  - File-glob negations (`!test/bench/**/*.min.js`, `!**/fixtures/**/*`) are intentionally left unchanged.

Config-only; no source or ignore-semantics change (folder ignores keep the same meaning per Biome's safe fix).

## Validation

```
$ npx @biomejs/biome@2.4.14 check biome.json packages/*/biome.json
# before: Found 5 warnings. Found 5 infos.
# after:  Checked 5 files. No fixes applied.   (clean)
```

The fixes were generated with `biome check --write` + `biome migrate` (schema bump), not hand-edited.
