### PR TITLE
fix(openapi-typescript): emit \ as optional property (#2664)

### DIFF
--- a/.changeset/defs-optional-property.md
+++ b/.changeset/defs-optional-property.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Emit the generated `$defs` container as an optional property so schemas that declare `$defs` are no longer required to provide it when used as input types. `$refs` that index into `$defs` continue to resolve.

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -655,7 +655,7 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
         ts.factory.createPropertySignature(
           /* modifiers     */ undefined,
           /* name          */ tsPropertyIndex("$defs"),
-          /* questionToken */ undefined,
+          /* questionToken */ QUESTION_TOKEN,
           /* type          */ ts.factory.createTypeLiteralNode(defKeys),
         ),
       );

--- a/packages/openapi-typescript/test/index.test.ts
+++ b/packages/openapi-typescript/test/index.test.ts
@@ -590,18 +590,18 @@ export interface components {
             rootDef?: $defs["StringType"];
             nestedDef?: components["schemas"]["OtherObject"]["$defs"]["nestedDef"];
             remoteDef?: components["schemas"]["remoteDef"];
-            $defs: {
+            $defs?: {
                 hasDefs: boolean;
             };
         };
         ArrayOfDefs: $defs["StringType"][];
         OtherObject: {
-            $defs: {
+            $defs?: {
                 nestedDef: boolean;
             };
         };
         RemoteDefs: {
-            $defs: {
+            $defs?: {
                 remoteDef: components["schemas"]["remoteDef"];
             };
         };

--- a/packages/openapi-typescript/test/transform/schema-object/object.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/object.test.ts
@@ -340,7 +340,7 @@ describe("transformSchemaObject > object", () => {
         },
         want: `{
     foo?: string;
-    $defs: {
+    $defs?: {
         /** @enum {string} */
         defEnum: "one" | "two" | "three";
     };
@@ -612,7 +612,7 @@ describe("transformSchemaObject > object", () => {
         },
         want: `{
     foo?: string;
-    $defs: {
+    $defs?: {
         readOnlyDef: $Read<string>;
         writeOnlyDef: $Write<number>;
         normalDef: boolean;


### PR DESCRIPTION
## Changes

Fixes #2664.

The generated `$defs` container is currently emitted as a **required** property of the surrounding object type. Because `$defs` only hosts reusable subschema definitions (it never appears in actual request/response data), requiring it forces consumers to supply a `$defs` value whenever they use the generated schema as an **input** type, producing spurious type errors.

This change marks the emitted `$defs` property as **optional** (adds a `?` question token). `$ref`s that index into `$defs` (e.g. `components["schemas"]["OtherObject"]["$defs"]["nestedDef"]`) continue to resolve, because indexed-access types work identically on optional properties — so ref resolution is fully preserved.

### Before
```ts
Object: {
    rootDef?: $defs["StringType"];
    $defs: {            // required — must be supplied on input
        hasDefs: boolean;
    };
};
```

### After
```ts
Object: {
    rootDef?: $defs["StringType"];
    $defs?: {           // optional — no longer required on input
        hasDefs: boolean;
    };
};
```

## How to review

- `packages/openapi-typescript/src/transform/schema-object.ts` — the emitted `$defs` `PropertySignature` now uses `QUESTION_TOKEN` instead of `undefined`.
- Existing snapshots in `test/transform/schema-object/object.test.ts` and `test/index.test.ts` (including the `JSONSchema > $defs are respected` case that exercises refs into `$defs`) updated from `$defs:` to `$defs?:`. These assertions only pass with the fix in place.

## Tests run

- `vitest run test/transform/schema-object/object.test.ts test/index.test.ts` → **56 passed**
- `vitest run test/transform test/discriminators.test.ts test/node-api.test.ts` → **194 passed** (validated before submission)
- `biome check` on the changed files → clean

A changeset (`openapi-typescript` patch) is included.
