### PR TITLE
Fix invalid enum output when x-enum-descriptions contains a line break

### DIFF
--- a/.changeset/enum-description-line-break.md
+++ b/.changeset/enum-description-line-break.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Keep multi-line `x-enum-descriptions` on a single comment line. A description containing a line break previously ended the `//` comment early and pushed the remaining text onto its own line as code, producing an invalid `enum` (only relevant with the `enum` option).

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -446,7 +446,12 @@ export function tsEnumMember(value: string | number, metadata: { name?: string; 
     return member;
   }
 
-  return ts.addSyntheticLeadingComment(member, ts.SyntaxKind.SingleLineCommentTrivia, ` ${trimmedDescription}`, true);
+  return ts.addSyntheticLeadingComment(
+    member,
+    ts.SyntaxKind.SingleLineCommentTrivia,
+    ` ${trimmedDescription.replace(LB_RE, " ")}`,
+    true,
+  );
 }
 
 /** Create an intersection type */

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -326,6 +326,23 @@ describe("tsEnum", () => {
     Etc_GMT_1 = "Etc/GMT-1"
 }`);
   });
+
+  test("multi-line x-enum-descriptions stay on a single comment line", () => {
+    expect(
+      astToString(
+        tsEnum(
+          ".Error.code.",
+          [100, 101],
+          [{ description: "Code 100\nspanning two lines" }, { description: "Code 101" }],
+        ),
+      ).trim(),
+    ).toBe(`enum ErrorCode {
+    // Code 100 spanning two lines
+    Value100 = 100,
+    // Code 101
+    Value101 = 101
+}`);
+  });
 });
 
 describe("tsArrayLiteralExpression", () => {


### PR DESCRIPTION
When the `enum` option is enabled, each member's `//` comment is taken from `x-enum-descriptions` / `x-enumDescriptions`. The description is handed to `addSyntheticLeadingComment` as single-line comment trivia, so a value that contains a line break ends the `//` comment at the first newline and the remaining text is printed as code. The generated enum then fails to parse.

For example, an `x-enum-descriptions` entry of `"Code 100\nspanning two lines"` currently produces:

```ts
enum ErrorCode {
    // Code 100
spanning two lines
    Value100 = 100,
}
```

`addJSDocComment` already handles this for property descriptions by running them through `LB_RE` (and escaping `*/`), but `tsEnumMember` was the one comment path that skipped it. This change collapses internal line breaks in the enum-member description with the same `LB_RE`, so it stays on the single `//` line:

```ts
enum ErrorCode {
    // Code 100 spanning two lines
    Value100 = 100,
}
```

Single-line descriptions are unaffected.

Verification: added a `tsEnum` unit test in `test/lib/ts.test.ts`. It fails on `main` (the second line lands outside the comment) and passes with this change; the remaining `ts.test.ts` cases and the enum transform tests still pass.
