### PR TITLE
Preserve tuples in readable and writable types

### DIFF
--- a/.changeset/bright-helpers-smile.md
+++ b/.changeset/bright-helpers-smile.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript-helpers": patch
+---
+
+Preserve tuple arity when deriving readable and writable types.

--- a/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
+++ b/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
@@ -5,10 +5,10 @@ import type { paths } from "./schemas/read-write.js";
 
 describe("readOnly/writeOnly", () => {
   test("preserves tuple arity in readable and writable types", () => {
-    type Availability = ["digital", "print"] | ["digital", "print", "presentation"];
+    type Tuple = ["a", "b"] | ["a", "b", "c"];
 
-    expectTypeOf<Readable<Availability>>().toEqualTypeOf<Availability>();
-    expectTypeOf<Writable<Availability>>().toEqualTypeOf<Availability>();
+    expectTypeOf<Readable<Tuple>>().toEqualTypeOf<Tuple>();
+    expectTypeOf<Writable<Tuple>>().toEqualTypeOf<Tuple>();
   });
 
   describe("deeply nested $Read unwrapping through $Read<Object>", () => {

--- a/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
+++ b/packages/openapi-fetch/test/read-write-visibility/read-write.test.ts
@@ -1,8 +1,16 @@
+import type { Readable, Writable } from "openapi-typescript-helpers";
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { createObservedClient } from "../helpers.js";
 import type { paths } from "./schemas/read-write.js";
 
 describe("readOnly/writeOnly", () => {
+  test("preserves tuple arity in readable and writable types", () => {
+    type Availability = ["digital", "print"] | ["digital", "print", "presentation"];
+
+    expectTypeOf<Readable<Availability>>().toEqualTypeOf<Availability>();
+    expectTypeOf<Writable<Availability>>().toEqualTypeOf<Availability>();
+  });
+
   describe("deeply nested $Read unwrapping through $Read<Object>", () => {
     test("$Read should continue recursion when unwrapping $Read<ObjectWithReadProperties>", async () => {
       // This tests the fix for a bug where Readable<$Read<U>> returned U directly

--- a/packages/openapi-typescript-helpers/src/index.ts
+++ b/packages/openapi-typescript-helpers/src/index.ts
@@ -221,8 +221,8 @@ export type Readable<T> =
     ? never
     : T extends $Read<infer U>
       ? Readable<U>
-      : T extends (infer E)[]
-        ? Readable<E>[]
+      : T extends readonly unknown[]
+        ? { [K in keyof T]: Readable<T[K]> }
         : T extends object
           ? { [K in keyof T as NonNullable<T[K]> extends $Write<any> ? never : K]: Readable<T[K]> }
           : T;
@@ -238,8 +238,8 @@ export type Writable<T> =
     ? never
     : T extends $Write<infer U>
       ? Writable<U>
-      : T extends (infer E)[]
-        ? Writable<E>[]
+      : T extends readonly unknown[]
+        ? { [K in keyof T]: Writable<T[K]> }
         : T extends object
           ? { [K in keyof T as NonNullable<T[K]> extends $Read<any> ? never : K]: Writable<T[K]> } & {
               [K in keyof T as NonNullable<T[K]> extends $Read<any> ? K : never]?: never;


### PR DESCRIPTION
Readable and writable OpenAPI client types now retain tuple length and element positions, so fixed-length response contracts remain compatible with generated schemas.

Previously, tuple responses were widened to generic arrays while filtering read-only and write-only fields.