### PR TITLE
feat(openapi-typescript): add --no-lint flag to skip Redocly linting

### DIFF
--- a/.changeset/forty-parks-double.md
+++ b/.changeset/forty-parks-double.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": minor
+---
+
+Add --no-lint flag to skip Redocly styleguide linting

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,6 +127,7 @@ The following flags are supported in the CLI:
 | `--make-paths-enum`                |       | `false`  | Generate ApiPaths enum for all paths                                                                                |
 | `--generate-path-params`           |       | `false`  | Generate path parameters for all paths where they are undefined by schema                                           |
 | `--read-write-markers`             |       | `false`  | Generate `$Read<T>`/`$Write<T>` markers for readOnly/writeOnly properties                                           |
+| `--no-lint`                        |       |  `false` | Skip Redocly styleguide linting                                                                                       |
 
 ### pathParamsAsTypes
 

--- a/packages/openapi-typescript/bin/cli.js
+++ b/packages/openapi-typescript/bin/cli.js
@@ -38,6 +38,7 @@ Options
   --root-types-keep-casing   Keep casing of root types (should only be used with --root-types)
   --make-paths-enum          Generate ApiPaths enum for all paths
   --read-write-markers       Generate $Read/$Write markers for readOnly/writeOnly properties
+  --no-lint       Generate the types without linting
 `;
 
 const OUTPUT_FILE = "FILE";
@@ -96,6 +97,7 @@ const BOOLEAN_FLAGS = [
   "rootTypes",
   "rootTypesKeepCasing",
   "rootTypesNoSchemaPrefix",
+  "lint",
 ];
 
 const flags = parser(args, {

--- a/packages/openapi-typescript/src/index.ts
+++ b/packages/openapi-typescript/src/index.ts
@@ -64,6 +64,7 @@ export default async function openapiTS(
     redoc,
     cwd: options.cwd instanceof URL ? options.cwd : new URL(`file://${options.cwd ?? process.cwd()}/`),
     silent: options.silent ?? false,
+    lint: options.lint ?? true,
   });
 
   const ctx: GlobalContext = {

--- a/packages/openapi-typescript/src/lib/redoc.ts
+++ b/packages/openapi-typescript/src/lib/redoc.ts
@@ -19,6 +19,7 @@ export interface ValidateAndBundleOptions {
   redoc: RedoclyConfig;
   silent: boolean;
   cwd?: URL;
+  lint?: boolean;
 }
 
 interface ParseSchemaOptions {
@@ -142,12 +143,14 @@ export async function validateAndBundle(
 
   // 2. lint
   const redocLintT = performance.now();
-  const problems = await lintDocument({
-    document,
-    config: options.redoc.styleguide,
-    externalRefResolver: resolver,
-  });
-  _processProblems(problems, options);
+  if (options.lint !== false) {
+    const problems = await lintDocument({
+      document,
+      config: options.redoc.styleguide,
+      externalRefResolver: resolver,
+    });
+    _processProblems(problems, options);
+  }
   debug("Linted schema", "lint", performance.now() - redocLintT);
 
   // 3. bundle

--- a/packages/openapi-typescript/src/types.ts
+++ b/packages/openapi-typescript/src/types.ts
@@ -623,6 +623,8 @@ export type SecurityRequirementObject = {
 };
 
 export interface OpenAPITSOptions {
+  /** Run Redocly styleguide linting (default: true) */
+  lint?: boolean;
   /** Treat all objects as if they have `additionalProperties: true` by default (default: false) */
   additionalProperties?: boolean;
   /** Alphabetize all keys? (default: false) */

--- a/packages/openapi-typescript/test/cli.test.ts
+++ b/packages/openapi-typescript/test/cli.test.ts
@@ -136,6 +136,16 @@ describe("CLI", () => {
   });
 
   describe("Redocly config", () => {
+    test("--no-lint skips styleguide errors", async () => {
+      const fixtureDir = new URL("./fixtures/redocly-lint-error/", import.meta.url);
+      const outputFile = new URL("./output/openapi.ts", fixtureDir);
+      fs.rmSync(outputFile, { force: true });
+      await execa(cmd, ["--redocly", "test/fixtures/redocly-lint-error/redocly.yaml", "--no-lint"], {
+        cwd,
+      });
+      expect(fs.existsSync(outputFile)).toBe(true);
+      expect(fs.readFileSync(outputFile, "utf8")).toContain("export interface paths");
+    });
     test.skipIf(os.platform() === "win32")("automatic config", async () => {
       const cwd = new URL("./fixtures/redocly/", import.meta.url);
 


### PR DESCRIPTION
## Changes

Adds a `--no-lint` CLI flag (and `lint: false` Node API option) to skip Redocly styleguide linting during type generation.

Redocly is still used for parsing, bundling, and `$ref` resolution — only the styleguide lint step is skipped.

Closes #2840

## How to Review

1. Run the CLI on `packages/openapi-typescript/test/fixtures/redocly-lint-error/` **without** `--no-lint` — should fail with lint errors (e.g. "Servers must be present")
2. Run with `--no-lint` — should succeed and write `output/openapi.ts`
3. Check `test/cli.test.ts` — new test `--no-lint skips styleguide errors`

## Checklist

- [x] Unit tests updated
- [x] docs/ updated (if necessary)
- [ ] `pnpm run update:examples` run (only applicable for openapi-typescript)