### PR TITLE
Handle required-only allOf constraints

### DIFF
--- a/.changeset/clean-allof-required.md
+++ b/.changeset/clean-allof-required.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Generate required composed properties from required-only `allOf` members instead of intersecting them with an empty object type.

--- a/.changeset/clean-allof-required.md
+++ b/.changeset/clean-allof-required.md
@@ -2,4 +2,4 @@
 "openapi-typescript": patch
 ---
 
-Generate required composed properties from required-only `allOf` members instead of intersecting them with an empty object type.
+Generate required composed properties from required-only `allOf` members, including typed object constraints when custom transforms are configured.

--- a/packages/openapi-typescript/examples/digital-ocean-api.ts
+++ b/packages/openapi-typescript/examples/digital-ocean-api.ts
@@ -7065,7 +7065,7 @@ export interface components {
             total?: number;
         };
         meta: {
-            meta: components["schemas"]["meta_properties"] & unknown;
+            meta: WithRequired<components["schemas"]["meta_properties"], "total">;
         };
         region: {
             /**
@@ -11632,15 +11632,15 @@ export interface components {
              */
             tag?: string | null;
         };
-        domain_record_a: components["schemas"]["domain_record"] & unknown;
-        domain_record_aaaa: components["schemas"]["domain_record"] & unknown;
-        domain_record_caa: components["schemas"]["domain_record"] & unknown;
-        domain_record_cname: components["schemas"]["domain_record"] & unknown;
-        domain_record_mx: components["schemas"]["domain_record"] & unknown;
-        domain_record_ns: components["schemas"]["domain_record"] & unknown;
-        domain_record_soa: components["schemas"]["domain_record"] & unknown;
-        domain_record_srv: components["schemas"]["domain_record"] & unknown;
-        domain_record_txt: components["schemas"]["domain_record"] & unknown;
+        domain_record_a: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data">;
+        domain_record_aaaa: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data">;
+        domain_record_caa: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data" | "flags" | "tag">;
+        domain_record_cname: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data">;
+        domain_record_mx: WithRequired<components["schemas"]["domain_record"], "type" | "data" | "priority">;
+        domain_record_ns: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data" | "flags" | "tag">;
+        domain_record_soa: WithRequired<components["schemas"]["domain_record"], "type" | "ttl">;
+        domain_record_srv: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data" | "priority" | "port" | "flags" | "tag">;
+        domain_record_txt: WithRequired<components["schemas"]["domain_record"], "type" | "name" | "data" | "flags" | "tag">;
         disk_info: {
             /**
              * @description The type of disk. All Droplets contain a `local` disk. Additionally, GPU Droplets can also have a `scratch` disk for non-persistent data.
@@ -12929,7 +12929,7 @@ export interface components {
              */
             type: "assign";
         };
-        floating_ip_action_unassign: Omit<components["schemas"]["floatingIPsAction"], "type"> & Record<string, never> & {
+        floating_ip_action_unassign: Omit<WithRequired<components["schemas"]["floatingIPsAction"], "type">, "type"> & {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
@@ -14897,7 +14897,7 @@ export interface components {
              */
             type: "assign";
         };
-        reserved_ip_action_unassign: Omit<components["schemas"]["reserved_ip_action_type"], "type"> & Record<string, never> & {
+        reserved_ip_action_unassign: Omit<WithRequired<components["schemas"]["reserved_ip_action_type"], "type">, "type"> & {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}

--- a/packages/openapi-typescript/src/lib/ts.ts
+++ b/packages/openapi-typescript/src/lib/ts.ts
@@ -597,6 +597,76 @@ export function tsWithRequired(
   ]);
 }
 
+// Keep one canonical AST so named output and the collision-safe inline fallback cannot drift semantically.
+const WITH_REQUIRED_OBJECT =
+  stringToAST(`type WithRequiredObject<T, K extends string | number | symbol> = T extends infer U
+  ? unknown extends U
+    ? { [P in K]-?: unknown }
+    : U extends readonly unknown[]
+      ? never
+      : U extends (...args: never[]) => unknown
+        ? never
+        : U extends abstract new (...args: never[]) => unknown
+          ? never
+          : U extends object
+            ? U & {
+                [P in K]-?: P extends keyof U
+                  ? { [Q in keyof U]-?: U[Q] }[P]
+                  : unknown
+              }
+            : never
+  : never;`)[0] as ts.TypeAliasDeclaration;
+
+export function isWithRequiredObjectHelper(node: ts.Node): boolean {
+  return node === WITH_REQUIRED_OBJECT;
+}
+
+/**
+ * Create a WithRequiredObject<X, Y> type for exact object constraints.
+ * Structural callables and constructors are rejected; nominal Function remains object-like.
+ */
+export function tsWithRequiredObject(
+  type: ts.TypeNode,
+  keys: string[],
+  injectFooter: ts.Node[],
+  inline = false,
+): ts.TypeNode {
+  if (keys.length === 0) {
+    return type;
+  }
+
+  const keyType = tsUnion(keys.map((key) => tsLiteral(key)));
+  if (inline) {
+    // Substitute only the helper's free T/K parameters; U/P/Q remain local binders in the conditional type.
+    const result = ts.transform(WITH_REQUIRED_OBJECT.type, [
+      (context) => (rootNode) => {
+        const visit = (node: ts.Node): ts.VisitResult<ts.Node> => {
+          if (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName)) {
+            if (node.typeName.text === "T") {
+              return type;
+            }
+            if (node.typeName.text === "K") {
+              return keyType;
+            }
+          }
+          return ts.visitEachChild(node, visit, context);
+        };
+        return ts.visitNode(rootNode, visit) as ts.TypeNode;
+      },
+    ]);
+    const transformed = result.transformed[0];
+    result.dispose();
+    return transformed;
+  }
+
+  // Helper names follow the existing fixed-name injection convention.
+  if (!injectFooter.some((node) => ts.isTypeAliasDeclaration(node) && node.name.escapedText === "WithRequiredObject")) {
+    injectFooter.push(WITH_REQUIRED_OBJECT);
+  }
+
+  return ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("WithRequiredObject"), [type, keyType]);
+}
+
 /**
  * Enhanced ReadonlyArray.
  * eg: type Foo = ReadonlyArray<T>; type Bar = ReadonlyArray<T[]>

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -230,9 +230,20 @@ export function transformSchemaObjectWithComposition(
   }
 
   /** Collect allOf with Omit<> for discriminators */
-  function collectAllOfCompositions(items: (SchemaObject | ReferenceObject)[], required?: string[]): ts.TypeNode[] {
+  function collectAllOfCompositions(
+    items: (SchemaObject | ReferenceObject)[],
+    required?: string[],
+    translatedRequiredConstraintItems?: Set<SchemaObject | ReferenceObject>,
+    discoverRequiredKeys = false,
+    constraintRequiredKeys?: Set<string>,
+  ): ts.TypeNode[] {
     const output: ts.TypeNode[] = [];
     for (const item of items) {
+      if (translatedRequiredConstraintItems?.has(item)) {
+        // Its required assertion is represented through the normal parent-required flow below.
+        continue;
+      }
+
       let itemType: ts.TypeNode;
       // if this is a $ref, use WithRequired<X, Y> if parent specifies required properties
       // (but only for valid keys)
@@ -240,17 +251,22 @@ export function transformSchemaObjectWithComposition(
         itemType = transformSchemaObject(item, options);
 
         const resolved = options.ctx.resolve<SchemaObject>(item.$ref);
+        const discriminator = options.ctx.discriminators.objects[item.$ref];
+        const refHandled = options.ctx.discriminators.refsHandled.includes(item.$ref);
 
         // make keys required, if necessary
-        if (
-          resolved &&
-          typeof resolved === "object" &&
-          "properties" in resolved &&
-          // we have already handled this item (discriminator property was already added as required)
-          !options.ctx.discriminators.refsHandled.includes(item.$ref)
-        ) {
+        if (resolved && typeof resolved === "object") {
+          // refsHandled means the discriminator key was already patched as required. Preserve that
+          // behavior, but still apply newly translated, non-discriminator requirements before Omit<>.
+          const candidateRequired = refHandled
+            ? (required ?? []).filter((key) => constraintRequiredKeys?.has(key) && key !== discriminator?.propertyName)
+            : (required ?? []);
           // add WithRequired<X, Y> if necessary
-          const validRequired = (required ?? []).filter((key) => !!resolved.properties?.[key]);
+          const validRequired = discoverRequiredKeys
+            ? candidateRequired.filter((key) => collectSchemaObjectPropertyNames(resolved).has(key))
+            : "properties" in resolved
+              ? candidateRequired.filter((key) => !!resolved.properties?.[key])
+              : [];
           if (validRequired.length) {
             itemType = tsWithRequired(itemType, validRequired, options.ctx.injectFooter);
           }
@@ -278,10 +294,55 @@ export function transformSchemaObjectWithComposition(
 
   // compile final type
   let finalType: ts.TypeNode | undefined;
+  const translatedRequiredConstraintItems = new Set<SchemaObject | ReferenceObject>();
+  const constraintRequiredKeys: string[] = [];
+  // Hooks and filtering can replace, rename, or remove generated keys. Compositions and early-return
+  // schemas can produce unions/literals instead of objects. In either case raw-key inference is unsafe,
+  // so retain the original allOf member and its existing transformation semantics.
+  const canTranslateRequiredConstraints =
+    !options.ctx.transform &&
+    !options.ctx.postTransform &&
+    !options.ctx.transformProperty &&
+    !options.ctx.excludeDeprecated &&
+    !hasUnsafeRequiredComposition(schemaObject);
+  if (canTranslateRequiredConstraints) {
+    const requiredConstraintItems = (schemaObject.allOf ?? []).flatMap((item) => {
+      const required = getRequiredConstraintKeys(item);
+      return required ? [{ item, required }] : [];
+    });
+    const requiredConstraintSchemas = new Set(requiredConstraintItems.map(({ item }) => item));
+    const knownKeys = collectSchemaObjectPropertyNames(schemaObject);
+    const hasRetainedObjectAssertion = (schemaObject.allOf ?? []).some(
+      (item) => !requiredConstraintSchemas.has(item) && hasExplicitNonNullableObjectType(item),
+    );
+    for (const { item, required } of requiredConstraintItems) {
+      // Removing the member is safe only when every assertion can be represented. A typed constraint
+      // also needs another retained object assertion; otherwise removing type: object widens the schema.
+      if (!required.every((key) => knownKeys.has(key)) || ("type" in item && !hasRetainedObjectAssertion)) {
+        continue;
+      }
+      translatedRequiredConstraintItems.add(item);
+      constraintRequiredKeys.push(...required);
+    }
+  }
+  const combinedRequired = constraintRequiredKeys.length
+    ? [...new Set([...(schemaObject.required ?? []), ...constraintRequiredKeys])]
+    : schemaObject.required;
 
+  // Feed translated keys through existing core/inline/ref required handling. Wrapping the completed
+  // aggregate could pass keys not shared by a union or keys removed by later transformations to WithRequired.
   // core + allOf: intersect
-  const coreObjectType = transformSchemaObjectCore(schemaObject, options);
-  const allOfType = collectAllOfCompositions(schemaObject.allOf ?? [], schemaObject.required);
+  const coreObjectType = transformSchemaObjectCore(
+    constraintRequiredKeys.length ? { ...schemaObject, required: combinedRequired } : schemaObject,
+    options,
+  );
+  const allOfType = collectAllOfCompositions(
+    schemaObject.allOf ?? [],
+    combinedRequired,
+    translatedRequiredConstraintItems,
+    constraintRequiredKeys.length > 0,
+    new Set(constraintRequiredKeys),
+  );
   if (coreObjectType || allOfType.length) {
     const allOf: ts.TypeNode | undefined = allOfType.length ? tsIntersection(allOfType) : undefined;
     finalType = tsIntersection([...(coreObjectType ? [coreObjectType] : []), ...(allOf ? [allOf] : [])]);
@@ -324,6 +385,109 @@ export function transformSchemaObjectWithComposition(
   }
 
   return finalType;
+
+  function collectSchemaObjectPropertyNames(
+    schema: SchemaObject | ReferenceObject,
+    propertyNames = new Set<string>(),
+    refsSeen = new Set<string>(),
+  ): Set<string> {
+    // Required properties may be declared behind nested allOf refs, so follow them recursively while
+    // guarding cycles. Explicit primitives ignore properties during transformation and cannot supply keys.
+    if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+      return propertyNames;
+    }
+    if ("$ref" in schema) {
+      if (refsSeen.has(schema.$ref)) {
+        return propertyNames;
+      }
+      refsSeen.add(schema.$ref);
+      const resolved = options.ctx.resolve<SchemaObject | ReferenceObject>(schema.$ref);
+      if (resolved) {
+        collectSchemaObjectPropertyNames(resolved, propertyNames, refsSeen);
+      }
+      return propertyNames;
+    }
+    if ("properties" in schema && schema.properties && (!("type" in schema) || schema.type === "object")) {
+      for (const key of Object.keys(schema.properties)) {
+        propertyNames.add(key);
+      }
+    }
+    for (const item of schema.allOf ?? []) {
+      collectSchemaObjectPropertyNames(item, propertyNames, refsSeen);
+    }
+    return propertyNames;
+  }
+
+  function hasExplicitNonNullableObjectType(
+    schema: SchemaObject | ReferenceObject,
+    refsSeen = new Set<string>(),
+  ): boolean {
+    if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+      return false;
+    }
+    if ("$ref" in schema) {
+      if (refsSeen.has(schema.$ref)) {
+        return false;
+      }
+      refsSeen.add(schema.$ref);
+      const resolved = options.ctx.resolve<SchemaObject | ReferenceObject>(schema.$ref);
+      return resolved ? hasExplicitNonNullableObjectType(resolved, refsSeen) : false;
+    }
+    if (schema.nullable || (Array.isArray(schema.type) && schema.type.includes("null"))) {
+      return false;
+    }
+    if (schema.type === "object") {
+      return true;
+    }
+    return (schema.allOf ?? []).some((item) => hasExplicitNonNullableObjectType(item, refsSeen));
+  }
+
+  function hasUnsafeRequiredComposition(schema: SchemaObject | ReferenceObject, refsSeen = new Set<string>()): boolean {
+    if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+      return false;
+    }
+    if ("$ref" in schema) {
+      if (refsSeen.has(schema.$ref)) {
+        return false;
+      }
+      refsSeen.add(schema.$ref);
+      const resolved = options.ctx.resolve<SchemaObject | ReferenceObject>(schema.$ref);
+      return resolved ? hasUnsafeRequiredComposition(resolved, refsSeen) : false;
+    }
+    // These paths return literals/unions or apply nullable/composition semantics before object properties
+    // can be trusted. Raw property names therefore cannot safely parameterize WithRequired<T, K>.
+    if (
+      (schema.const !== null && schema.const !== undefined) ||
+      (Array.isArray(schema.enum) && (!("type" in schema) || schema.type !== "object") && !("properties" in schema)) ||
+      schema.nullable ||
+      Array.isArray(schema.type) ||
+      schema.anyOf ||
+      schema.oneOf ||
+      (schema.type === "object" && schema.enum)
+    ) {
+      return true;
+    }
+    return (schema.allOf ?? []).some((item) => hasUnsafeRequiredComposition(item, refsSeen));
+  }
+}
+
+function getRequiredConstraintKeys(schema: SchemaObject | ReferenceObject): string[] | undefined {
+  // Translate only exact { required } or { type: "object", required } members. Any other keyword may
+  // carry validation or annotation semantics that cannot be preserved after removing the allOf member.
+  if (
+    !schema ||
+    typeof schema !== "object" ||
+    Array.isArray(schema) ||
+    "$ref" in schema ||
+    ("type" in schema && schema.type !== "object") ||
+    !Array.isArray(schema.required) ||
+    schema.required.length === 0 ||
+    !schema.required.every((key) => typeof key === "string") ||
+    Object.keys(schema).some((key) => key !== "type" && key !== "required")
+  ) {
+    return undefined;
+  }
+  return schema.required;
 }
 
 /**

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import {
   addJSDocComment,
   BOOLEAN,
+  isWithRequiredObjectHelper,
   NEVER,
   NULL,
   NUMBER,
@@ -22,6 +23,7 @@ import {
   tsRecord,
   tsUnion,
   tsWithRequired,
+  tsWithRequiredObject,
   UNDEFINED,
   UNKNOWN,
 } from "../lib/ts.js";
@@ -30,12 +32,8 @@ import type { ReferenceObject, SchemaObject, TransformNodeOptions } from "../typ
 
 /** Record hook replacements without probing or replaying user callbacks. */
 interface TransformObserver {
-  postTransformReplaced: boolean;
-  transformReplaced: boolean;
+  replaced: boolean;
 }
-
-const WITH_REQUIRED_OBJECT = "WithRequiredObject";
-const generatedWithRequiredObjectHelpers = new WeakSet<ts.Node>();
 
 /**
  * Transform SchemaObject nodes (4.8.24)
@@ -68,7 +66,7 @@ function transformSchemaObjectObserved(
     if (postTransformResult) {
       // Returning the observed node is informational; only a distinct node replaces this occurrence.
       if (observer && postTransformResult !== type) {
-        observer.postTransformReplaced = true;
+        observer.replaced = true;
       }
       return postTransformResult;
     }
@@ -329,7 +327,7 @@ function transformSchemaObjectWithCompositionObserved(
     }[] = [];
 
     for (const [index, item] of items.entries()) {
-      const itemObserver: TransformObserver = { postTransformReplaced: false, transformReplaced: false };
+      const itemObserver: TransformObserver = { replaced: false };
       const transformedItem =
         "$ref" in item
           ? item
@@ -337,14 +335,13 @@ function transformSchemaObjectWithCompositionObserved(
               ...item,
               required: [...(required ?? []), ...(item.required ?? [])],
             };
+      const type = transformSchemaObjectObserved(transformedItem, options, false, itemObserver);
       occurrences.push({
         index,
         item,
-        replaced: false,
-        type: transformSchemaObjectObserved(transformedItem, options, false, itemObserver),
+        replaced: itemObserver.replaced,
+        type,
       });
-      occurrences[occurrences.length - 1].replaced =
-        itemObserver.transformReplaced || itemObserver.postTransformReplaced;
     }
 
     // A replacement is authoritative for that occurrence. Only untouched constraint members may be lowered into
@@ -489,7 +486,8 @@ function transformSchemaObjectWithCompositionObserved(
       finalType = tsWithRequiredObject(
         finalType,
         [...new Set([...callbackParentRequiredKeys, ...callbackAllOf.removedConstraintKeys])],
-        options,
+        options.ctx.injectFooter,
+        shouldInlineWithRequiredObject(options),
       );
     }
   }
@@ -636,200 +634,51 @@ function getRequiredConstraintKeys(schema: SchemaObject | ReferenceObject): stri
   return schema.required;
 }
 
-/**
- * Apply an exact typed-object required constraint after callback transformations. Use a named helper for readable
- * output, or the equivalent anonymous AST when that helper name could collide with generated or injected code.
- */
-function tsWithRequiredObject(type: ts.TypeNode, keys: string[], options: TransformNodeOptions): ts.TypeNode {
-  if (shouldInlineWithRequiredObject(options)) {
-    return tsRequiredObjectConstraint(type, keys);
-  }
-
-  let helper = options.ctx.injectFooter.find((node) => generatedWithRequiredObjectHelpers.has(node));
-  if (!helper) {
-    // Structural call/construct signatures are excluded without naming a shadowable global Function;
-    // nominal Function therefore remains the documented residual limitation in both representations.
-    helper = stringToAST(`type ${WITH_REQUIRED_OBJECT}<T, K extends string | number | symbol> = T extends infer U
-  ? unknown extends U
-    ? { [P in K]-?: unknown }
-    : U extends readonly unknown[]
-      ? never
-      : U extends (...args: never[]) => unknown
-        ? never
-        : U extends abstract new (...args: never[]) => unknown
-          ? never
-          : U extends object
-            ? U & {
-                [P in K]-?: P extends keyof U
-                  ? { [Q in keyof U]-?: U[Q] }[P]
-                  : unknown
-              }
-            : never
-  : never;`)[0] as ts.TypeAliasDeclaration;
-    generatedWithRequiredObjectHelpers.add(helper);
-    options.ctx.injectFooter.push(helper);
-  }
-
-  return ts.factory.createTypeReferenceNode(WITH_REQUIRED_OBJECT, [type, tsUnion(keys.map((key) => tsLiteral(key)))]);
-}
+const WITH_REQUIRED_OBJECT = "WithRequiredObject";
 
 function shouldInlineWithRequiredObject(options: TransformNodeOptions): boolean {
-  // Enum and unprefixed root declarations are emitted later and may claim the helper name. Avoid predicting their
-  // final names; the anonymous representation has identical semantics and cannot collide.
+  // Enums and unprefixed root types are emitted later and may claim the helper name. Existing injected bindings
+  // are known now; in either case inline the same canonical helper body rather than predict or rename declarations.
   if (options.ctx.enum || options.ctx.rootTypesNoSchemaPrefix) {
     return true;
   }
   if (
     options.ctx.inject &&
-    (stringToAST(options.ctx.inject) as ts.Node[]).some((node) => nodeBindsName(node, WITH_REQUIRED_OBJECT))
+    (stringToAST(options.ctx.inject) as ts.Node[]).some((node) => nodeBindsTypeName(node, WITH_REQUIRED_OBJECT))
   ) {
     return true;
   }
-  // Footer helper names have historically been fixed. Reuse only the node created here; any caller-owned
-  // declaration with the same name takes the collision-free anonymous path.
   return options.ctx.injectFooter.some(
-    (node) => !generatedWithRequiredObjectHelpers.has(node) && nodeBindsName(node, WITH_REQUIRED_OBJECT),
+    (node) => !isWithRequiredObjectHelper(node) && nodeBindsTypeName(node, WITH_REQUIRED_OBJECT),
   );
 }
 
-/** Check the TypeScript type/value namespaces conservatively before introducing a generated helper. */
-function nodeBindsName(node: ts.Node, name: string): boolean {
+/** Conservatively check declarations and imports that bind a name in TypeScript's type namespace. */
+function nodeBindsTypeName(node: ts.Node, name: string): boolean {
   if (
     (ts.isTypeAliasDeclaration(node) ||
       ts.isInterfaceDeclaration(node) ||
       ts.isClassDeclaration(node) ||
       ts.isEnumDeclaration(node) ||
-      ts.isFunctionDeclaration(node) ||
       ts.isModuleDeclaration(node) ||
       ts.isImportEqualsDeclaration(node)) &&
     node.name?.text === name
   ) {
     return true;
   }
-  if (ts.isImportDeclaration(node)) {
-    const importClause = node.importClause;
-    if (importClause?.name?.text === name) {
-      return true;
-    }
-    if (importClause?.namedBindings) {
-      if (ts.isNamespaceImport(importClause.namedBindings)) {
-        return importClause.namedBindings.name.text === name;
-      }
-      return importClause.namedBindings.elements.some((element) => element.name.text === name);
-    }
+  if (!ts.isImportDeclaration(node)) {
+    return false;
   }
-  if (ts.isVariableStatement(node)) {
-    return node.declarationList.declarations.some((declaration) => bindingNameContains(declaration.name, name));
+  const clause = node.importClause;
+  if (clause?.name?.text === name) {
+    return true;
   }
-  return false;
-}
-
-function bindingNameContains(bindingName: ts.BindingName, name: string): boolean {
-  if (ts.isIdentifier(bindingName)) {
-    return bindingName.text === name;
-  }
-  return bindingName.elements.some(
-    (element) => !ts.isOmittedExpression(element) && bindingNameContains(element.name, name),
-  );
-}
-
-/** Build the anonymous collision fallback; this must remain semantically equivalent to WithRequiredObject. */
-function tsRequiredObjectConstraint(type: ts.TypeNode, keys: string[]): ts.TypeNode {
-  const u = ts.factory.createTypeReferenceNode("U");
-  const keyUnion = tsUnion(keys.map((key) => tsLiteral(key)));
-  const requiredProjection = ts.factory.createMappedTypeNode(
-    undefined,
-    ts.factory.createTypeParameterDeclaration(
-      undefined,
-      "Q",
-      ts.factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, u),
-    ),
-    undefined,
-    ts.factory.createToken(ts.SyntaxKind.MinusToken),
-    ts.factory.createIndexedAccessTypeNode(u, ts.factory.createTypeReferenceNode("Q")),
-    undefined,
-  );
-  const requiredKeys = ts.factory.createMappedTypeNode(
-    undefined,
-    ts.factory.createTypeParameterDeclaration(undefined, "P", keyUnion),
-    undefined,
-    ts.factory.createToken(ts.SyntaxKind.MinusToken),
-    ts.factory.createConditionalTypeNode(
-      ts.factory.createTypeReferenceNode("P"),
-      ts.factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, u),
-      ts.factory.createIndexedAccessTypeNode(requiredProjection, ts.factory.createTypeReferenceNode("P")),
-      UNKNOWN,
-    ),
-    undefined,
-  );
-  const unknownBranch = ts.factory.createMappedTypeNode(
-    undefined,
-    ts.factory.createTypeParameterDeclaration(undefined, "P", keyUnion),
-    undefined,
-    ts.factory.createToken(ts.SyntaxKind.MinusToken),
-    UNKNOWN,
-    undefined,
-  );
-  const arrayType = ts.factory.createTypeOperatorNode(
-    ts.SyntaxKind.ReadonlyKeyword,
-    ts.factory.createArrayTypeNode(UNKNOWN),
-  );
-  const callableType = ts.factory.createFunctionTypeNode(
-    undefined,
-    [
-      ts.factory.createParameterDeclaration(
-        undefined,
-        ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
-        "args",
-        undefined,
-        ts.factory.createArrayTypeNode(NEVER),
-      ),
-    ],
-    UNKNOWN,
-  );
-  const constructableType = ts.factory.createConstructorTypeNode(
-    [ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)],
-    undefined,
-    [
-      ts.factory.createParameterDeclaration(
-        undefined,
-        ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
-        "args",
-        undefined,
-        ts.factory.createArrayTypeNode(NEVER),
-      ),
-    ],
-    UNKNOWN,
-  );
-  const objectBranch = ts.factory.createConditionalTypeNode(
-    u,
-    ts.factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword),
-    tsIntersection([u, requiredKeys]),
-    NEVER,
-  );
-  const distributive = ts.factory.createConditionalTypeNode(
-    UNKNOWN,
-    u,
-    unknownBranch,
-    ts.factory.createConditionalTypeNode(
-      u,
-      arrayType,
-      NEVER,
-      ts.factory.createConditionalTypeNode(
-        u,
-        callableType,
-        NEVER,
-        // Structural call/construct signatures are non-JSON objects. Nominal Function remains a known residual.
-        ts.factory.createConditionalTypeNode(u, constructableType, NEVER, objectBranch),
-      ),
-    ),
-  );
-  return ts.factory.createConditionalTypeNode(
-    type,
-    ts.factory.createInferTypeNode(ts.factory.createTypeParameterDeclaration(undefined, "U")),
-    distributive,
-    NEVER,
-  );
+  const bindings = clause?.namedBindings;
+  return bindings
+    ? ts.isNamespaceImport(bindings)
+      ? bindings.name.text === name
+      : bindings.elements.some((element) => element.name.text === name)
+    : false;
 }
 
 /**
@@ -874,7 +723,7 @@ function transformSchemaObjectCore(
       const result = options.ctx.transform(schemaObject, options);
       if (result && typeof result === "object") {
         if (observer) {
-          observer.transformReplaced = true;
+          observer.replaced = true;
         }
         if ("schema" in result) {
           if (result.questionToken) {

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -9,6 +9,7 @@ import {
   oapiRef,
   QUESTION_TOKEN,
   STRING,
+  stringToAST,
   tsArrayLiteralExpression,
   tsEnum,
   tsIntersection,
@@ -27,6 +28,15 @@ import {
 import { createDiscriminatorProperty, createRef, getEntries } from "../lib/utils.js";
 import type { ReferenceObject, SchemaObject, TransformNodeOptions } from "../types.js";
 
+/** Record hook replacements without probing or replaying user callbacks. */
+interface TransformObserver {
+  postTransformReplaced: boolean;
+  transformReplaced: boolean;
+}
+
+const WITH_REQUIRED_OBJECT = "WithRequiredObject";
+const generatedWithRequiredObjectHelpers = new WeakSet<ts.Node>();
+
 /**
  * Transform SchemaObject nodes (4.8.24)
  * @see https://spec.openapis.org/oas/v3.1.0#schema-object
@@ -36,10 +46,30 @@ export default function transformSchemaObject(
   options: TransformNodeOptions,
   fromAdditionalProperties = false,
 ): ts.TypeNode {
-  const type = transformSchemaObjectWithComposition(schemaObject, options, fromAdditionalProperties);
+  return transformSchemaObjectObserved(schemaObject, options, fromAdditionalProperties);
+}
+
+function transformSchemaObjectObserved(
+  schemaObject: SchemaObject | ReferenceObject,
+  options: TransformNodeOptions,
+  fromAdditionalProperties = false,
+  observer?: TransformObserver,
+  allowCoreObjectAssertion = true,
+): ts.TypeNode {
+  const type = transformSchemaObjectWithCompositionObserved(
+    schemaObject,
+    options,
+    fromAdditionalProperties,
+    observer,
+    allowCoreObjectAssertion,
+  );
   if (typeof options.ctx.postTransform === "function") {
     const postTransformResult = options.ctx.postTransform(type, options);
     if (postTransformResult) {
+      // Returning the observed node is informational; only a distinct node replaces this occurrence.
+      if (observer && postTransformResult !== type) {
+        observer.postTransformReplaced = true;
+      }
       return postTransformResult;
     }
   }
@@ -53,6 +83,16 @@ export function transformSchemaObjectWithComposition(
   schemaObject: SchemaObject | ReferenceObject,
   options: TransformNodeOptions,
   fromAdditionalProperties = false,
+): ts.TypeNode {
+  return transformSchemaObjectWithCompositionObserved(schemaObject, options, fromAdditionalProperties);
+}
+
+function transformSchemaObjectWithCompositionObserved(
+  schemaObject: SchemaObject | ReferenceObject,
+  options: TransformNodeOptions,
+  fromAdditionalProperties = false,
+  observer?: TransformObserver,
+  allowCoreObjectAssertion = true,
 ): ts.TypeNode {
   /**
    * Unexpected types & edge cases
@@ -249,28 +289,7 @@ export function transformSchemaObjectWithComposition(
       // (but only for valid keys)
       if ("$ref" in item) {
         itemType = transformSchemaObject(item, options);
-
-        const resolved = options.ctx.resolve<SchemaObject>(item.$ref);
-        const discriminator = options.ctx.discriminators.objects[item.$ref];
-        const refHandled = options.ctx.discriminators.refsHandled.includes(item.$ref);
-
-        // make keys required, if necessary
-        if (resolved && typeof resolved === "object") {
-          // refsHandled means the discriminator key was already patched as required. Preserve that
-          // behavior, but still apply newly translated, non-discriminator requirements before Omit<>.
-          const candidateRequired = refHandled
-            ? (required ?? []).filter((key) => constraintRequiredKeys?.has(key) && key !== discriminator?.propertyName)
-            : (required ?? []);
-          // add WithRequired<X, Y> if necessary
-          const validRequired = discoverRequiredKeys
-            ? candidateRequired.filter((key) => collectSchemaObjectPropertyNames(resolved).has(key))
-            : "properties" in resolved
-              ? candidateRequired.filter((key) => !!resolved.properties?.[key])
-              : [];
-          if (validRequired.length) {
-            itemType = tsWithRequired(itemType, validRequired, options.ctx.injectFooter);
-          }
-        }
+        itemType = applyRequiredToRef(item, itemType, required, discoverRequiredKeys, constraintRequiredKeys);
       }
       // otherwise, if this is a schema object, combine parent `required[]` with its own, if any
       else {
@@ -292,60 +311,187 @@ export function transformSchemaObjectWithComposition(
     return output;
   }
 
+  /**
+   * Transform callback-sensitive occurrences once before deciding which typed constraints can be removed.
+   * Store results by occurrence index because a stateful callback may transform the same schema object differently
+   * when that object is reused in allOf.
+   */
+  function collectCallbackAwareAllOfCompositions(
+    items: (SchemaObject | ReferenceObject)[],
+    candidateConstraints: Map<number, string[]>,
+    required?: string[],
+  ): { removedConstraintKeys: string[]; types: ts.TypeNode[] } {
+    const occurrences: {
+      index: number;
+      item: SchemaObject | ReferenceObject;
+      replaced: boolean;
+      type: ts.TypeNode;
+    }[] = [];
+
+    for (const [index, item] of items.entries()) {
+      const itemObserver: TransformObserver = { postTransformReplaced: false, transformReplaced: false };
+      const transformedItem =
+        "$ref" in item
+          ? item
+          : {
+              ...item,
+              required: [...(required ?? []), ...(item.required ?? [])],
+            };
+      occurrences.push({
+        index,
+        item,
+        replaced: false,
+        type: transformSchemaObjectObserved(transformedItem, options, false, itemObserver),
+      });
+      occurrences[occurrences.length - 1].replaced =
+        itemObserver.transformReplaced || itemObserver.postTransformReplaced;
+    }
+
+    // A replacement is authoritative for that occurrence. Only untouched constraint members may be lowered into
+    // the aggregate helper without discarding the callback's result.
+    const removedConstraintKeys = occurrences.flatMap(({ index, replaced }) =>
+      !replaced && candidateConstraints.has(index) ? (candidateConstraints.get(index) ?? []) : [],
+    );
+    const removedConstraintIndexes = new Set(
+      occurrences.flatMap(({ index, replaced }) => (!replaced && candidateConstraints.has(index) ? [index] : [])),
+    );
+    const hasRemovedConstraint = removedConstraintIndexes.size > 0;
+    const types = occurrences.flatMap(({ index, item, type }) => {
+      if (removedConstraintIndexes.has(index)) {
+        return [];
+      }
+
+      let itemType = type;
+      // If no typed member was removed, preserve ordinary parent-required ref lowering without re-running hooks.
+      if (!hasRemovedConstraint && "$ref" in item) {
+        itemType = applyRequiredToRef(item, itemType, required);
+      }
+      const discriminator =
+        ("$ref" in item && options.ctx.discriminators.objects[item.$ref]) || (item as any).discriminator;
+      return [discriminator ? tsOmit(itemType, [discriminator.propertyName]) : itemType];
+    });
+
+    return { removedConstraintKeys: [...new Set(removedConstraintKeys)], types };
+  }
+
+  function applyRequiredToRef(
+    item: ReferenceObject,
+    itemType: ts.TypeNode,
+    required?: string[],
+    discoverRequiredKeys = false,
+    constraintRequiredKeys = new Set<string>(),
+  ): ts.TypeNode {
+    const resolved = options.ctx.resolve<SchemaObject>(item.$ref);
+    const discriminator = options.ctx.discriminators.objects[item.$ref];
+    const refHandled = options.ctx.discriminators.refsHandled.includes(item.$ref);
+    if (!resolved || typeof resolved !== "object") {
+      return itemType;
+    }
+
+    const candidateRequired = refHandled
+      ? (required ?? []).filter((key) => constraintRequiredKeys.has(key) && key !== discriminator?.propertyName)
+      : (required ?? []);
+    const validRequired = discoverRequiredKeys
+      ? candidateRequired.filter((key) => collectSchemaObjectPropertyNames(resolved).has(key))
+      : "properties" in resolved
+        ? candidateRequired.filter((key) => !!resolved.properties?.[key])
+        : [];
+    return validRequired.length ? tsWithRequired(itemType, validRequired, options.ctx.injectFooter) : itemType;
+  }
+
   // compile final type
   let finalType: ts.TypeNode | undefined;
   const translatedRequiredConstraintItems = new Set<SchemaObject | ReferenceObject>();
   const constraintRequiredKeys: string[] = [];
+  let callbackTypedConstraintItems: Map<number, string[]> | undefined;
+  let callbackParentRequiredKeys: string[] = [];
+  const hasTransformCallbacks = !!options.ctx.transform || !!options.ctx.postTransform;
   // Hooks and filtering can replace, rename, or remove generated keys. Compositions and early-return
   // schemas can produce unions/literals instead of objects. In either case raw-key inference is unsafe,
   // so retain the original allOf member and its existing transformation semantics.
   const canTranslateRequiredConstraints =
-    !options.ctx.transform &&
-    !options.ctx.postTransform &&
-    !options.ctx.transformProperty &&
-    !options.ctx.excludeDeprecated &&
-    !hasUnsafeRequiredComposition(schemaObject);
+    !options.ctx.transformProperty && !options.ctx.excludeDeprecated && !hasUnsafeRequiredComposition(schemaObject);
   if (canTranslateRequiredConstraints) {
-    const requiredConstraintItems = (schemaObject.allOf ?? []).flatMap((item) => {
+    const requiredConstraintItems = (schemaObject.allOf ?? []).flatMap((item, index) => {
       const required = getRequiredConstraintKeys(item);
-      return required ? [{ item, required }] : [];
+      return required ? [{ index, item, required, typed: "type" in item }] : [];
     });
     const requiredConstraintSchemas = new Set(requiredConstraintItems.map(({ item }) => item));
     const knownKeys = collectSchemaObjectPropertyNames(schemaObject);
-    const hasRetainedObjectAssertion = (schemaObject.allOf ?? []).some(
+    const hasRetainedAllOfObjectAssertion = (schemaObject.allOf ?? []).some(
       (item) => !requiredConstraintSchemas.has(item) && hasExplicitNonNullableObjectType(item),
     );
+    // Synthetic object branches created while expanding a type array cannot prove that the original schema was
+    // object-only. allowCoreObjectAssertion is false for those recursive transformations.
+    const hasCallbackRetainedObjectAssertion =
+      (allowCoreObjectAssertion && schemaObject.type === "object") || hasRetainedAllOfObjectAssertion;
+    if (hasTransformCallbacks) {
+      // Symbolic refs resolve against their final component declarations, so callback mode needs no outcome cache.
+      const eligibleTypedConstraints = requiredConstraintItems
+        .filter(
+          ({ required, typed }) =>
+            typed && hasCallbackRetainedObjectAssertion && required.every((key) => knownKeys.has(key)),
+        )
+        .map(({ index, required }) => [index, required] as const);
+      if (eligibleTypedConstraints.length) {
+        callbackTypedConstraintItems = new Map(eligibleTypedConstraints);
+        // Parent required names are independent assertions and need not appear in raw properties.
+        // The callback-only helper can represent missing final keys as required unknown.
+        callbackParentRequiredKeys = schemaObject.required ?? [];
+      }
+    }
     for (const { item, required } of requiredConstraintItems) {
       // Removing the member is safe only when every assertion can be represented. A typed constraint
       // also needs another retained object assertion; otherwise removing type: object widens the schema.
-      if (!required.every((key) => knownKeys.has(key)) || ("type" in item && !hasRetainedObjectAssertion)) {
+      if (!required.every((key) => knownKeys.has(key)) || ("type" in item && !hasRetainedAllOfObjectAssertion)) {
         continue;
       }
-      translatedRequiredConstraintItems.add(item);
-      constraintRequiredKeys.push(...required);
+      if (!hasTransformCallbacks) {
+        translatedRequiredConstraintItems.add(item);
+        constraintRequiredKeys.push(...required);
+      }
     }
   }
   const combinedRequired = constraintRequiredKeys.length
     ? [...new Set([...(schemaObject.required ?? []), ...constraintRequiredKeys])]
     : schemaObject.required;
 
-  // Feed translated keys through existing core/inline/ref required handling. Wrapping the completed
-  // aggregate could pass keys not shared by a union or keys removed by later transformations to WithRequired.
+  // No-callback translation uses existing core/inline/ref handling, where raw known-key filtering is sufficient.
+  // Callback mode instead observes every occurrence and wraps the completed retained aggregate once.
   // core + allOf: intersect
   const coreObjectType = transformSchemaObjectCore(
     constraintRequiredKeys.length ? { ...schemaObject, required: combinedRequired } : schemaObject,
     options,
+    observer,
   );
-  const allOfType = collectAllOfCompositions(
-    schemaObject.allOf ?? [],
-    combinedRequired,
-    translatedRequiredConstraintItems,
-    constraintRequiredKeys.length > 0,
-    new Set(constraintRequiredKeys),
-  );
+  const callbackAllOf = callbackTypedConstraintItems
+    ? collectCallbackAwareAllOfCompositions(
+        schemaObject.allOf ?? [],
+        callbackTypedConstraintItems,
+        schemaObject.required,
+      )
+    : undefined;
+  const allOfType =
+    callbackAllOf?.types ??
+    collectAllOfCompositions(
+      schemaObject.allOf ?? [],
+      combinedRequired,
+      translatedRequiredConstraintItems,
+      constraintRequiredKeys.length > 0,
+      new Set(constraintRequiredKeys),
+    );
   if (coreObjectType || allOfType.length) {
     const allOf: ts.TypeNode | undefined = allOfType.length ? tsIntersection(allOfType) : undefined;
     finalType = tsIntersection([...(coreObjectType ? [coreObjectType] : []), ...(allOf ? [allOf] : [])]);
+    if (callbackAllOf?.removedConstraintKeys.length) {
+      // Exact type: object constraints reject non-object callback output, unlike ordinary JSON Schema required.
+      // Keep that behavior separate from the public legacy WithRequired helper.
+      finalType = tsWithRequiredObject(
+        finalType,
+        [...new Set([...callbackParentRequiredKeys, ...callbackAllOf.removedConstraintKeys])],
+        options,
+      );
+    }
   }
   // anyOf: union
   // (note: this may seem counterintuitive, but as TypeScript’s unions are not true XORs, they mimic behavior closer to anyOf than oneOf)
@@ -491,6 +637,202 @@ function getRequiredConstraintKeys(schema: SchemaObject | ReferenceObject): stri
 }
 
 /**
+ * Apply an exact typed-object required constraint after callback transformations. Use a named helper for readable
+ * output, or the equivalent anonymous AST when that helper name could collide with generated or injected code.
+ */
+function tsWithRequiredObject(type: ts.TypeNode, keys: string[], options: TransformNodeOptions): ts.TypeNode {
+  if (shouldInlineWithRequiredObject(options)) {
+    return tsRequiredObjectConstraint(type, keys);
+  }
+
+  let helper = options.ctx.injectFooter.find((node) => generatedWithRequiredObjectHelpers.has(node));
+  if (!helper) {
+    // Structural call/construct signatures are excluded without naming a shadowable global Function;
+    // nominal Function therefore remains the documented residual limitation in both representations.
+    helper = stringToAST(`type ${WITH_REQUIRED_OBJECT}<T, K extends string | number | symbol> = T extends infer U
+  ? unknown extends U
+    ? { [P in K]-?: unknown }
+    : U extends readonly unknown[]
+      ? never
+      : U extends (...args: never[]) => unknown
+        ? never
+        : U extends abstract new (...args: never[]) => unknown
+          ? never
+          : U extends object
+            ? U & {
+                [P in K]-?: P extends keyof U
+                  ? { [Q in keyof U]-?: U[Q] }[P]
+                  : unknown
+              }
+            : never
+  : never;`)[0] as ts.TypeAliasDeclaration;
+    generatedWithRequiredObjectHelpers.add(helper);
+    options.ctx.injectFooter.push(helper);
+  }
+
+  return ts.factory.createTypeReferenceNode(WITH_REQUIRED_OBJECT, [type, tsUnion(keys.map((key) => tsLiteral(key)))]);
+}
+
+function shouldInlineWithRequiredObject(options: TransformNodeOptions): boolean {
+  // Enum and unprefixed root declarations are emitted later and may claim the helper name. Avoid predicting their
+  // final names; the anonymous representation has identical semantics and cannot collide.
+  if (options.ctx.enum || options.ctx.rootTypesNoSchemaPrefix) {
+    return true;
+  }
+  if (
+    options.ctx.inject &&
+    (stringToAST(options.ctx.inject) as ts.Node[]).some((node) => nodeBindsName(node, WITH_REQUIRED_OBJECT))
+  ) {
+    return true;
+  }
+  // Footer helper names have historically been fixed. Reuse only the node created here; any caller-owned
+  // declaration with the same name takes the collision-free anonymous path.
+  return options.ctx.injectFooter.some(
+    (node) => !generatedWithRequiredObjectHelpers.has(node) && nodeBindsName(node, WITH_REQUIRED_OBJECT),
+  );
+}
+
+/** Check the TypeScript type/value namespaces conservatively before introducing a generated helper. */
+function nodeBindsName(node: ts.Node, name: string): boolean {
+  if (
+    (ts.isTypeAliasDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isEnumDeclaration(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isModuleDeclaration(node) ||
+      ts.isImportEqualsDeclaration(node)) &&
+    node.name?.text === name
+  ) {
+    return true;
+  }
+  if (ts.isImportDeclaration(node)) {
+    const importClause = node.importClause;
+    if (importClause?.name?.text === name) {
+      return true;
+    }
+    if (importClause?.namedBindings) {
+      if (ts.isNamespaceImport(importClause.namedBindings)) {
+        return importClause.namedBindings.name.text === name;
+      }
+      return importClause.namedBindings.elements.some((element) => element.name.text === name);
+    }
+  }
+  if (ts.isVariableStatement(node)) {
+    return node.declarationList.declarations.some((declaration) => bindingNameContains(declaration.name, name));
+  }
+  return false;
+}
+
+function bindingNameContains(bindingName: ts.BindingName, name: string): boolean {
+  if (ts.isIdentifier(bindingName)) {
+    return bindingName.text === name;
+  }
+  return bindingName.elements.some(
+    (element) => !ts.isOmittedExpression(element) && bindingNameContains(element.name, name),
+  );
+}
+
+/** Build the anonymous collision fallback; this must remain semantically equivalent to WithRequiredObject. */
+function tsRequiredObjectConstraint(type: ts.TypeNode, keys: string[]): ts.TypeNode {
+  const u = ts.factory.createTypeReferenceNode("U");
+  const keyUnion = tsUnion(keys.map((key) => tsLiteral(key)));
+  const requiredProjection = ts.factory.createMappedTypeNode(
+    undefined,
+    ts.factory.createTypeParameterDeclaration(
+      undefined,
+      "Q",
+      ts.factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, u),
+    ),
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.MinusToken),
+    ts.factory.createIndexedAccessTypeNode(u, ts.factory.createTypeReferenceNode("Q")),
+    undefined,
+  );
+  const requiredKeys = ts.factory.createMappedTypeNode(
+    undefined,
+    ts.factory.createTypeParameterDeclaration(undefined, "P", keyUnion),
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.MinusToken),
+    ts.factory.createConditionalTypeNode(
+      ts.factory.createTypeReferenceNode("P"),
+      ts.factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, u),
+      ts.factory.createIndexedAccessTypeNode(requiredProjection, ts.factory.createTypeReferenceNode("P")),
+      UNKNOWN,
+    ),
+    undefined,
+  );
+  const unknownBranch = ts.factory.createMappedTypeNode(
+    undefined,
+    ts.factory.createTypeParameterDeclaration(undefined, "P", keyUnion),
+    undefined,
+    ts.factory.createToken(ts.SyntaxKind.MinusToken),
+    UNKNOWN,
+    undefined,
+  );
+  const arrayType = ts.factory.createTypeOperatorNode(
+    ts.SyntaxKind.ReadonlyKeyword,
+    ts.factory.createArrayTypeNode(UNKNOWN),
+  );
+  const callableType = ts.factory.createFunctionTypeNode(
+    undefined,
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
+        "args",
+        undefined,
+        ts.factory.createArrayTypeNode(NEVER),
+      ),
+    ],
+    UNKNOWN,
+  );
+  const constructableType = ts.factory.createConstructorTypeNode(
+    [ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)],
+    undefined,
+    [
+      ts.factory.createParameterDeclaration(
+        undefined,
+        ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
+        "args",
+        undefined,
+        ts.factory.createArrayTypeNode(NEVER),
+      ),
+    ],
+    UNKNOWN,
+  );
+  const objectBranch = ts.factory.createConditionalTypeNode(
+    u,
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword),
+    tsIntersection([u, requiredKeys]),
+    NEVER,
+  );
+  const distributive = ts.factory.createConditionalTypeNode(
+    UNKNOWN,
+    u,
+    unknownBranch,
+    ts.factory.createConditionalTypeNode(
+      u,
+      arrayType,
+      NEVER,
+      ts.factory.createConditionalTypeNode(
+        u,
+        callableType,
+        NEVER,
+        // Structural call/construct signatures are non-JSON objects. Nominal Function remains a known residual.
+        ts.factory.createConditionalTypeNode(u, constructableType, NEVER, objectBranch),
+      ),
+    ),
+  );
+  return ts.factory.createConditionalTypeNode(
+    type,
+    ts.factory.createInferTypeNode(ts.factory.createTypeParameterDeclaration(undefined, "U")),
+    distributive,
+    NEVER,
+  );
+}
+
+/**
  * Check if the given OAPI enum should be transformed to a TypeScript enum
  */
 function shouldTransformToTsEnum(options: TransformNodeOptions, schemaObject: SchemaObject): boolean {
@@ -522,11 +864,18 @@ function shouldTransformToTsEnum(options: TransformNodeOptions, schemaObject: Sc
 /**
  * Handle SchemaObject minus composition (anyOf/allOf/oneOf)
  */
-function transformSchemaObjectCore(schemaObject: SchemaObject, options: TransformNodeOptions): ts.TypeNode | undefined {
+function transformSchemaObjectCore(
+  schemaObject: SchemaObject,
+  options: TransformNodeOptions,
+  observer?: TransformObserver,
+): ts.TypeNode | undefined {
   if ("type" in schemaObject && schemaObject.type) {
     if (typeof options.ctx.transform === "function") {
       const result = options.ctx.transform(schemaObject, options);
       if (result && typeof result === "object") {
+        if (observer) {
+          observer.transformReplaced = true;
+        }
         if ("schema" in result) {
           if (result.questionToken) {
             return ts.factory.createUnionTypeNode([result.schema, UNDEFINED]);
@@ -642,9 +991,12 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
           uniqueTypes.push(
             t === "null" || t === null
               ? NULL
-              : transformSchemaObject(
+              : transformSchemaObjectObserved(
                   { ...schemaObject, type: t, oneOf: undefined } as SchemaObject, // don’t stack oneOf transforms
                   options,
+                  false,
+                  undefined,
+                  false,
                 ),
           );
         }
@@ -653,7 +1005,15 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
           if (t === "null" || t === null) {
             uniqueTypes.push(NULL);
           } else {
-            uniqueTypes.push(transformSchemaObject({ ...schemaObject, type: t } as SchemaObject, options));
+            uniqueTypes.push(
+              transformSchemaObjectObserved(
+                { ...schemaObject, type: t } as SchemaObject,
+                options,
+                false,
+                undefined,
+                false,
+              ),
+            );
           }
         }
       }

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -13,6 +13,7 @@ import {
   tsLiteral,
   tsPropertyIndex,
   tsUnion,
+  tsWithRequired,
 } from "../../src/lib/ts.js";
 
 describe("addJSDocComment", () => {
@@ -470,3 +471,88 @@ describe("tsUnion", () => {
 } | null`);
   });
 });
+
+describe("tsWithRequired", () => {
+  test("injects the legacy helper once and keeps binary references", () => {
+    const footer: ts.Node[] = [];
+    const source = ts.factory.createTypeReferenceNode("Source");
+
+    expect(astToString(tsWithRequired(source, ["value"], footer)).trim()).toBe('WithRequired<Source, "value">');
+    expect(astToString(tsWithRequired(source, ["other"], footer)).trim()).toBe('WithRequired<Source, "other">');
+    expect(footer).toHaveLength(1);
+  });
+
+  test("keeps the existing fixed-name caller convention", () => {
+    const existing = ts.factory.createTypeAliasDeclaration(
+      undefined,
+      "WithRequired",
+      undefined,
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+    );
+    const footer: ts.Node[] = [existing];
+
+    expect(astToString(tsWithRequired(ts.factory.createTypeReferenceNode("Source"), ["value"], footer)).trim()).toBe(
+      'WithRequired<Source, "value">',
+    );
+    expect(footer).toEqual([existing]);
+  });
+
+  test("preserves the legacy helper and valid low-level array inputs", () => {
+    const footer: ts.Node[] = [];
+    tsWithRequired(ts.factory.createTypeReferenceNode("Source"), ["value"], footer);
+    const helper = astToString(footer).trim();
+
+    expect(helper).toBe(`type WithRequired<T, K extends keyof T> = T & {
+    [P in K]-?: T[P];
+};`);
+    expectTypeScriptToCompile(`
+      ${helper}
+
+      type Optional = WithRequired<{ value?: string }, "value">;
+      const optional: Optional = { value: "value" };
+      // @ts-expect-error implicit optional undefined is removed
+      const optionalUndefined: Optional = { value: undefined };
+
+      type ExplicitUndefined = WithRequired<{ value?: string | undefined }, "value">;
+      const explicitUndefined: ExplicitUndefined = { value: undefined };
+
+      type ReadonlyValue = WithRequired<{ readonly value?: string }, "value">;
+      const readonlyValue: ReadonlyValue = { value: "value" };
+      // @ts-expect-error readonly is preserved
+      readonlyValue.value = "other";
+
+      type Intersection = WithRequired<{ value?: string } & { other: number }, "value">;
+      const intersection: Intersection = { other: 1, value: "value" };
+
+      type StringIndex = WithRequired<{ [key: string]: number | undefined }, "value">;
+      const stringIndex: StringIndex = { value: 1 };
+
+      type ArrayValue = WithRequired<string[], "length">;
+      const arrayValue: ArrayValue = [];
+    `);
+  });
+});
+
+function expectTypeScriptToCompile(source: string) {
+  const fileName = "/with-required.test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    exactOptionalPropertyTypes: true,
+    module: ts.ModuleKind.ESNext,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (name) => name === fileName || fileExists(name);
+  const readFile = host.readFile.bind(host);
+  host.readFile = (name) => (name === fileName ? source : readFile(name));
+
+  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
+  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+}

--- a/packages/openapi-typescript/test/lib/ts.test.ts
+++ b/packages/openapi-typescript/test/lib/ts.test.ts
@@ -7,6 +7,7 @@ import {
   NUMBER,
   oapiRef,
   STRING,
+  stringToAST,
   tsArrayLiteralExpression,
   tsEnum,
   tsIsPrimitive,
@@ -14,7 +15,9 @@ import {
   tsPropertyIndex,
   tsUnion,
   tsWithRequired,
+  tsWithRequiredObject,
 } from "../../src/lib/ts.js";
+import { expectTypeScriptToCompile } from "../test-helpers.js";
 
 describe("addJSDocComment", () => {
   test("single-line comment", () => {
@@ -473,33 +476,12 @@ describe("tsUnion", () => {
 });
 
 describe("tsWithRequired", () => {
-  test("injects the legacy helper once and keeps binary references", () => {
+  test("injects the legacy helper once and preserves valid low-level inputs", () => {
     const footer: ts.Node[] = [];
     const source = ts.factory.createTypeReferenceNode("Source");
-
     expect(astToString(tsWithRequired(source, ["value"], footer)).trim()).toBe('WithRequired<Source, "value">');
     expect(astToString(tsWithRequired(source, ["other"], footer)).trim()).toBe('WithRequired<Source, "other">');
     expect(footer).toHaveLength(1);
-  });
-
-  test("keeps the existing fixed-name caller convention", () => {
-    const existing = ts.factory.createTypeAliasDeclaration(
-      undefined,
-      "WithRequired",
-      undefined,
-      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
-    );
-    const footer: ts.Node[] = [existing];
-
-    expect(astToString(tsWithRequired(ts.factory.createTypeReferenceNode("Source"), ["value"], footer)).trim()).toBe(
-      'WithRequired<Source, "value">',
-    );
-    expect(footer).toEqual([existing]);
-  });
-
-  test("preserves the legacy helper and valid low-level array inputs", () => {
-    const footer: ts.Node[] = [];
-    tsWithRequired(ts.factory.createTypeReferenceNode("Source"), ["value"], footer);
     const helper = astToString(footer).trim();
 
     expect(helper).toBe(`type WithRequired<T, K extends keyof T> = T & {
@@ -533,26 +515,110 @@ describe("tsWithRequired", () => {
   });
 });
 
-function expectTypeScriptToCompile(source: string) {
-  const fileName = "/with-required.test.ts";
-  const compilerOptions: ts.CompilerOptions = {
-    exactOptionalPropertyTypes: true,
-    module: ts.ModuleKind.ESNext,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-    target: ts.ScriptTarget.ESNext,
-  };
-  const host = ts.createCompilerHost(compilerOptions);
-  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
-  const getSourceFile = host.getSourceFile.bind(host);
-  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
-    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
-  const fileExists = host.fileExists.bind(host);
-  host.fileExists = (name) => name === fileName || fileExists(name);
-  const readFile = host.readFile.bind(host);
-  host.readFile = (name) => (name === fileName ? source : readFile(name));
+describe("tsWithRequiredObject", () => {
+  test("injects the object helper once and keeps named references", () => {
+    const footer: ts.Node[] = [];
+    const source = ts.factory.createTypeReferenceNode("Source");
 
-  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
-  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
-}
+    expect(astToString(tsWithRequiredObject(source, ["value"], footer)).trim()).toBe(
+      'WithRequiredObject<Source, "value">',
+    );
+    expect(astToString(tsWithRequiredObject(source, ["other"], footer)).trim()).toBe(
+      'WithRequiredObject<Source, "other">',
+    );
+    expect(footer).toHaveLength(1);
+  });
+
+  test("preserves object semantics", () => {
+    const footer: ts.Node[] = [];
+    tsWithRequiredObject(ts.factory.createTypeReferenceNode("Source"), ["value"], footer);
+
+    expectTypeScriptToCompile(`
+      ${astToString(footer)}
+      type Optional = WithRequiredObject<{ value?: string }, "value">;
+      type ExplicitUndefined = WithRequiredObject<{ value?: string | undefined }, "value">;
+      type Missing = WithRequiredObject<{ other: number }, "value">;
+      type Union = WithRequiredObject<{ value?: string } | { other: number }, "value">;
+      type Index = WithRequiredObject<{ [key: string]: number | undefined }, "value">;
+      type ReadonlyValue = WithRequiredObject<{ readonly value?: string }, "value">;
+      type NumberIndex = WithRequiredObject<{ [key: number]: string | undefined }, 1>;
+      declare const symbolKey: unique symbol;
+      type SymbolIndex = WithRequiredObject<{ [key: symbol]: boolean | undefined }, typeof symbolKey>;
+      type Primitive = WithRequiredObject<string, "value">;
+      type ArrayValue = WithRequiredObject<string[], "value">;
+      type Callable = WithRequiredObject<() => string, "value">;
+      type Constructor = WithRequiredObject<abstract new () => object, "value">;
+      type Nothing = WithRequiredObject<never, "value">;
+      type UnknownValue = WithRequiredObject<unknown, "value">;
+      type AnyValue = WithRequiredObject<any, "value">;
+
+      const optional: Optional = { value: "value" };
+      // @ts-expect-error implicit optional undefined is removed
+      const optionalUndefined: Optional = { value: undefined };
+      const explicitUndefined: ExplicitUndefined = { value: undefined };
+      const missing: Missing = { other: 1, value: true };
+      // @ts-expect-error missing keys remain required
+      const missingInvalid: Missing = { other: 1 };
+      const union: Union = { other: 1, value: true };
+      // @ts-expect-error every union branch requires value
+      const unionInvalid: Union = { other: 1 };
+      const index: Index = { value: 1 };
+      const readonlyValue: ReadonlyValue = { value: "value" };
+      // @ts-expect-error readonly is preserved
+      readonlyValue.value = "other";
+      const numberIndex: NumberIndex = { 1: "value" };
+      const symbolIndex: SymbolIndex = { [symbolKey]: true };
+      const unknownValue: UnknownValue = { value: true };
+      const anyValue: AnyValue = { value: true };
+      // @ts-expect-error unknown still requires value
+      const unknownInvalid: UnknownValue = {};
+      // @ts-expect-error any does not erase required presence
+      const anyInvalid: AnyValue = {};
+      // @ts-expect-error non-object values are rejected
+      const primitive: Primitive = "value";
+      // @ts-expect-error arrays are not JSON objects
+      const arrayValue: ArrayValue = Object.assign([], { value: true });
+      // @ts-expect-error callables are not JSON objects
+      const callable: Callable = Object.assign(() => "value", { value: true });
+      // @ts-expect-error constructors are not JSON objects
+      const constructorValue: Constructor = Object.assign(class {}, { value: true });
+      // @ts-expect-error never remains never
+      const nothing: Nothing = { value: true };
+    `);
+  });
+
+  test("keeps named and inline helper semantics equivalent", () => {
+    const footer: ts.Node[] = [];
+    const cases = [
+      ["ObjectUnion", "{ value?: string } | { other: number }"],
+      ["Mixed", "{ value?: string } | string | string[] | (() => void) | (abstract new () => object)"],
+      ["UnknownValue", "unknown"],
+      ["AnyValue", "any"],
+      ["Nothing", "never"],
+      ["Optional", "{ value?: string }"],
+    ] as const;
+    const aliases = cases
+      .map(([name, source]) => {
+        const input = (stringToAST(`type Input = ${source}`)[0] as ts.TypeAliasDeclaration).type;
+        const named = astToString(tsWithRequiredObject(input, ["value"], footer, false)).trim();
+        const inline = astToString(tsWithRequiredObject(input, ["value"], [], true)).trim();
+        return `type Named${name} = ${named}; type Inline${name} = ${inline}; type Check${name} = Assert<Equal<Named${name}, Inline${name}>>;`;
+      })
+      .join("\n");
+    const generic = "{ value?: T; key?: K; outerU?: U; outerP?: P; outerQ?: Q }";
+    const genericInput = (stringToAST(`type Input = ${generic}`)[0] as ts.TypeAliasDeclaration).type;
+    const namedGeneric = astToString(tsWithRequiredObject(genericInput, ["value"], footer, false)).trim();
+    const inlineGeneric = astToString(tsWithRequiredObject(genericInput, ["value"], [], true)).trim();
+
+    expectTypeScriptToCompile(`${astToString(footer)}
+      type Equal<A, B> = (<X>() => X extends A ? 1 : 2) extends (<X>() => X extends B ? 1 : 2)
+        ? (<X>() => X extends B ? 1 : 2) extends (<X>() => X extends A ? 1 : 2) ? true : false
+        : false;
+      type Assert<T extends true> = T;
+      ${aliases}
+      type NamedGeneric<T, K, U, P, Q> = ${namedGeneric};
+      type InlineGeneric<T, K, U, P, Q> = ${inlineGeneric};
+      type CheckGeneric<T, K, U, P, Q> = Assert<Equal<NamedGeneric<T, K, U, P, Q>, InlineGeneric<T, K, U, P, Q>>>;
+    `);
+  });
+});

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import openapiTS, { astToString, COMMENT_HEADER } from "../src/index.js";
+import openapiTS, { astToString, COMMENT_HEADER, stringToAST } from "../src/index.js";
 import type { OpenAPITSOptions } from "../src/types.js";
-import type { TestCase } from "./test-helpers.js";
+import { expectTypeScriptToCompile, type TestCase } from "./test-helpers.js";
 
 const EXAMPLES_DIR = new URL("../examples/", import.meta.url);
 
@@ -1819,371 +1819,134 @@ export type operations = Record<string, never>;`,
       ci?.timeout || 5000,
     );
   }
-
-  test("required-only allOf remains concise with an unrelated binary transform", async () => {
-    let sawOuterHelper = false;
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        dedupeEnums: true,
-        enumValues: true,
-        rootTypes: true,
-        transform(schemaObject) {
-          if (schemaObject.format === "binary") {
-            return BLOB;
-          }
+  test("required-only allOf public output compiles across callback modes", async () => {
+    const componentPath = "#/components/schemas/CompanyResource";
+    const objectReplacement = typeNode(`{
+      organization?: number;
+      addresses?: string[];
+      processingTypes?: string[];
+    }`);
+    const missingReplacement = typeNode("{ other: string }");
+    const unionReplacement = typeNode("{ organization?: number } | { other: string }");
+    const standardAssertions = `
+      const valid: Generated = { organization: "org", addresses: [], processingTypes: [] };
+      // @ts-expect-error all required-only keys are required
+      const missing: Generated = { organization: "org" };
+    `;
+    const cases: { name: string; options: OpenAPITSOptions; assertions: string }[] = [
+      { name: "no callback", options: {}, assertions: standardAssertions },
+      { name: "unrelated transform", options: { transform: binaryTransform }, assertions: standardAssertions },
+      { name: "identity postTransform", options: { postTransform: (type) => type }, assertions: standardAssertions },
+      {
+        name: "component transform replacement",
+        options: { transform: (_schema, options) => (options.path === componentPath ? objectReplacement : undefined) },
+        assertions: `
+          const valid: Generated = { organization: 1, addresses: [], processingTypes: [] };
+          // @ts-expect-error callback-produced property types are retained
+          const wrong: Generated = { organization: "org", addresses: [], processingTypes: [] };
+        `,
+      },
+      {
+        name: "component postTransform replacement",
+        options: {
+          postTransform: (_type, options) => (options.path === componentPath ? objectReplacement : undefined),
         },
-        postTransform(type, options) {
-          if (
-            options.path?.includes("/paths/~1companies/get/responses/200") &&
-            ts.isTypeReferenceNode(type) &&
-            ts.isIdentifier(type.typeName) &&
-            type.typeName.text === "WithRequiredObject"
-          ) {
-            sawOuterHelper = true;
-          }
-          return type;
+        assertions: `
+          const valid: Generated = { organization: 1, addresses: [], processingTypes: [] };
+          // @ts-expect-error postTransform-produced property types are retained
+          const wrong: Generated = { organization: "org", addresses: [], processingTypes: [] };
+        `,
+      },
+      {
+        name: "callback-removed keys",
+        options: { transform: (_schema, options) => (options.path === componentPath ? missingReplacement : undefined) },
+        assertions: `
+          const valid: Generated = { other: "value", organization: 1, addresses: null, processingTypes: true };
+          // @ts-expect-error removed keys remain required as unknown
+          const missing: Generated = { other: "value" };
+        `,
+      },
+      {
+        name: "primitive replacement",
+        options: {
+          transform: (_schema, options) =>
+            options.path === componentPath ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword) : undefined,
         },
-      }),
-    );
-    const exact =
-      'WithRequiredObject<components["schemas"]["CompanyResource"], "organization" | "addresses" | "processingTypes">';
-
-    expect(result.split(exact)).toHaveLength(4);
-    expect(result.match(/type WithRequiredObject</g)).toHaveLength(1);
-    expect(result.match(/extends infer U \?/g)).toHaveLength(1);
-    expect(result).not.toContain('components["schemas"]["CompanyResource"] & Record<string, never>');
-    expect(sawOuterHelper).toBe(true);
-    expectTypeScriptSourceToCompile(result);
-  });
-
-  test.each([
-    "transform",
-    "postTransform",
-  ] as const)("required-only allOf uses final component property types from %s", async (callback) => {
-    const replacement = ts.factory.createTypeLiteralNode([
-      ts.factory.createPropertySignature(
-        undefined,
-        "organization",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
-      ),
-      ts.factory.createPropertySignature(
-        undefined,
-        "addresses",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-      ),
-      ts.factory.createPropertySignature(
-        undefined,
-        "processingTypes",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-      ),
-    ]);
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        [callback]: (_value: any, options: any) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-        type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-        const valid: Generated = { organization: 1, addresses: [], processingTypes: [] };
-        // @ts-expect-error WithRequiredObject reads the final callback-produced property type
-        const wrong: Generated = { organization: "value", addresses: [], processingTypes: [] };
-      `);
-  });
-
-  test("required-only allOf makes callback-removed component keys required unknown", async () => {
-    const replacement = ts.factory.createTypeLiteralNode([
-      ts.factory.createPropertySignature(
-        undefined,
-        "other",
-        undefined,
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ),
-    ]);
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      const valid: Generated = {
-        other: "value",
-        organization: 1,
-        addresses: "callback-defined",
-        processingTypes: null,
-      };
-      // @ts-expect-error removed keys remain required
-      const missing: Generated = { other: "value" };
-    `);
-  });
-
-  test.each([
-    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword), "1"],
-    ["null", ts.factory.createLiteralTypeNode(ts.factory.createNull()), "null"],
-    [
-      "array",
-      ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-      '["value"]',
-    ],
-    [
-      "callable",
-      ts.factory.createFunctionTypeNode(undefined, [], ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-      '() => "value"',
-    ],
-    [
-      "constructor",
-      ts.factory.createConstructorTypeNode(undefined, undefined, [], ts.factory.createTypeLiteralNode([])),
-      "class {}",
-    ],
-  ])("required-only allOf rejects a transformed %s component", async (_label, replacement, value) => {
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      // @ts-expect-error typed required constraint rejects non-object callback output
-      const invalid: Generated = ${value};
-    `);
-  });
-
-  test("required-only allOf distributes over a transformed object union", async () => {
-    const replacement = ts.factory.createUnionTypeNode([
-      ts.factory.createTypeLiteralNode([
-        ts.factory.createPropertySignature(
-          undefined,
-          "organization",
-          ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-          ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
-        ),
-      ]),
-      ts.factory.createTypeLiteralNode([
-        ts.factory.createPropertySignature(
-          undefined,
-          "other",
-          undefined,
-          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-        ),
-      ]),
-    ]);
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      const first: Generated = { organization: 1, addresses: [], processingTypes: [] };
-      const second: Generated = {
-        other: "value",
-        organization: "unknown",
-        addresses: "unknown",
-        processingTypes: "unknown",
-      };
-      // @ts-expect-error every distributed object branch requires every key
-      const missing: Generated = { other: "value" };
-    `);
-  });
-
-  test("required-only allOf constrains a postTransform replacement of the ref occurrence", async () => {
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        postTransform: (type, options) =>
-          options.path?.includes("/paths/~1companies/get/responses/200") && ts.isIndexedAccessTypeNode(type)
-            ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
-            : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      // @ts-expect-error the typed member still rejects a primitive ref-occurrence replacement
-      const invalid: Generated = 1;
-    `);
-  });
-
-  test("required-only allOf keeps every parent required key after component callbacks", async () => {
-    const schema = requiredOnlyAllOfCallbackSchema() as any;
-    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
-    constrained.required = ["callbackOnly", "missing"];
-    constrained.allOf[1].required = ["organization"];
-    const replacement = ts.factory.createTypeLiteralNode([
-      ts.factory.createPropertySignature(
-        undefined,
-        "organization",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ),
-      ts.factory.createPropertySignature(
-        undefined,
-        "callbackOnly",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
-      ),
-    ]);
-    const result = astToString(
-      await openapiTS(schema, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expect(result).toContain(
-      'WithRequiredObject<components["schemas"]["CompanyResource"], "callbackOnly" | "missing" | "organization">',
-    );
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      const valid: Generated = { organization: "value", callbackOnly: 1, missing: null };
-      // @ts-expect-error callbackOnly uses the callback-produced number type
-      const wrongCallbackType: Generated = { organization: "value", callbackOnly: "wrong", missing: null };
-      // @ts-expect-error a parent required key absent from both raw and callback properties is required unknown
-      const missingUnknownKey: Generated = { organization: "value", callbackOnly: 1 };
-    `);
-  });
-
-  test.each([
-    [
-      "array",
-      ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
-      '["value"]',
-    ],
-    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), '"value"'],
-  ])("plain parent required over callback-produced %s keeps legacy WithRequired", async (_label, replacement, value) => {
-    const schema = requiredOnlyAllOfCallbackSchema() as any;
-    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
-    constrained.required = ["length"];
-    constrained.allOf = [constrained.allOf[0]];
-    schema.components.schemas.CompanyResource = {
-      type: "object",
-      properties: { length: { type: "number" } },
-    };
-    const result = astToString(
-      await openapiTS(schema, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expect(result).toContain('WithRequired<components["schemas"]["CompanyResource"], "length">');
-    expect(result).not.toContain("WithRequiredObject");
-    expect(result).toContain("type WithRequired<T, K extends keyof T>");
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      const valid: Generated = ${value};
-    `);
-  });
-
-  test("required-only allOf helper preserves callback readonly, undefined, and index signatures", async () => {
-    const schema = requiredOnlyAllOfCallbackSchema() as any;
-    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
-    constrained.allOf[1].required = ["organization", "addresses"];
-    const stringOrUndefined = ts.factory.createUnionTypeNode([
-      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
-    ]);
-    const replacement = ts.factory.createTypeLiteralNode([
-      ts.factory.createPropertySignature(
-        [ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword)],
-        "organization",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ),
-      ts.factory.createPropertySignature(
-        undefined,
-        "addresses",
-        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-        stringOrUndefined,
-      ),
-      ts.factory.createIndexSignature(
-        undefined,
-        [
-          ts.factory.createParameterDeclaration(
-            undefined,
-            undefined,
-            "key",
-            undefined,
-            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-          ),
-        ],
-        stringOrUndefined,
-      ),
-    ]);
-    const result = astToString(
-      await openapiTS(schema, {
-        transform: (_schema, options) =>
-          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
-      }),
-    );
-
-    expectTypeScriptSourceToCompile(`${result}
-      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
-      const valid: Generated = { organization: "value", addresses: undefined };
-      // @ts-expect-error implicit optional undefined is removed when made required
-      const implicitUndefined: Generated = { organization: undefined, addresses: undefined };
-      // @ts-expect-error readonly survives the required projection
-      valid.organization = "other";
-      // @ts-expect-error the callback-produced string index signature remains effective
-      const wrongIndex: Generated = { organization: "value", addresses: undefined, other: 1 };
-    `);
-  });
-
-  test.each([
-    ["alias", "type WithRequiredObject = unknown;"],
-    ["interface", "interface WithRequiredObject { caller: true }"],
-    ["class", "declare class WithRequiredObject {}"],
-    ["enum", "enum WithRequiredObject { Caller }"],
-    ["import", 'import type { paths as WithRequiredObject } from "./required-callback.test";'],
-  ])("required-only allOf uses anonymous fallback for public inject %s conflicts", async (_label, inject) => {
-    let sawOuterConditional = false;
-    const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        inject,
-        transform: () => undefined,
-        postTransform(type, options) {
-          if (options.path?.includes("/paths/~1companies/get/responses/200") && ts.isConditionalTypeNode(type)) {
-            sawOuterConditional = true;
-          }
-          return type;
+        assertions: `
+          // @ts-expect-error typed object constraint rejects primitives
+          const invalid: Generated = 1;
+        `,
+      },
+      {
+        name: "array replacement",
+        options: {
+          transform: (_schema, options) => (options.path === componentPath ? typeNode("string[]") : undefined),
         },
-      }),
-    );
+        assertions: `
+          // @ts-expect-error typed object constraint rejects arrays
+          const invalid: Generated = Object.assign([], {
+            organization: "org", addresses: [], processingTypes: [],
+          });
+        `,
+      },
+      {
+        name: "object union replacement",
+        options: { transform: (_schema, options) => (options.path === componentPath ? unionReplacement : undefined) },
+        assertions: `
+          const first: Generated = { organization: 1, addresses: [], processingTypes: [] };
+          const second: Generated = { other: "value", organization: null, addresses: true, processingTypes: 1 };
+          // @ts-expect-error every object branch requires every key
+          const missing: Generated = { other: "value" };
+        `,
+      },
+    ];
 
-    expect(result).not.toContain('WithRequiredObject<components["schemas"]["CompanyResource"]');
-    expect(result.match(/extends infer U \?/g)).toHaveLength(3);
-    expect(sawOuterConditional).toBe(true);
-    expectTypeScriptSourceToCompile(result);
+    for (const { name, options, assertions } of cases) {
+      const result = astToString(await openapiTS(requiredOnlyAllOfSchema() as any, options));
+      expectTypeScriptToCompile(
+        result,
+        `
+          type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+          ${assertions}
+        `,
+      );
+      expect(result, name).not.toContain('components["schemas"]["CompanyResource"] & Record<string, never>');
+      if (name === "unrelated transform") {
+        const reference =
+          'WithRequiredObject<components["schemas"]["CompanyResource"], "organization" | "addresses" | "processingTypes">';
+        expect(result.split(reference)).toHaveLength(4);
+        expect(result.match(/type WithRequiredObject</g)).toHaveLength(1);
+      }
+    }
   });
 
   test.each([
+    ["public inject alias", { inject: "type WithRequiredObject = unknown;" }],
+    [
+      "public inject import",
+      {
+        inject: 'import type { components as WithRequiredObject } from "./generated.test.js";',
+      },
+    ],
     ["enum output", { enum: true }],
-    ["unprefixed root types", { rootTypes: true, rootTypesNoSchemaPrefix: true }],
-  ] as const)("required-only allOf uses anonymous fallback with %s", async (_label, fallbackOptions) => {
+    ["unprefixed root type", { rootTypes: true, rootTypesNoSchemaPrefix: true }],
+  ] satisfies [
+    string,
+    OpenAPITSOptions,
+  ][])("required-only allOf inlines for %s collisions", async (_name, collisionOptions) => {
     const result = astToString(
-      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
-        ...fallbackOptions,
-        transform: () => undefined,
+      await openapiTS(requiredOnlyAllOfSchema() as any, {
+        ...collisionOptions,
+        transform: binaryTransform,
       }),
     );
-
-    expect(result).not.toContain("WithRequiredObject");
-    expect(result.match(/extends infer U \?/g)).toHaveLength(3);
-    expectTypeScriptSourceToCompile(result);
+    expect(result).not.toContain('WithRequiredObject<components["schemas"]["CompanyResource"]');
+    expect(result).not.toContain("type WithRequiredObject<T");
+    expectTypeScriptToCompile(result);
   });
 });
 
-function requiredOnlyAllOfCallbackSchema() {
+function requiredOnlyAllOfSchema() {
   const requiredResource = {
     allOf: [
       { $ref: "#/components/schemas/CompanyResource" },
@@ -2236,32 +1999,16 @@ function requiredOnlyAllOfCallbackSchema() {
           },
         },
         BinaryPayload: { type: "string", format: "binary" },
+        WithRequiredObject: { type: "string", enum: ["collision"] },
       },
     },
   } as const;
 }
 
-function expectTypeScriptSourceToCompile(source: string) {
-  const fileName = "/required-callback.test.ts";
-  const compilerOptions: ts.CompilerOptions = {
-    exactOptionalPropertyTypes: true,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-    target: ts.ScriptTarget.ESNext,
-  };
-  const host = ts.createCompilerHost(compilerOptions);
-  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
-  const getSourceFile = host.getSourceFile.bind(host);
-  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
-    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
-  const fileExists = host.fileExists.bind(host);
-  host.fileExists = (name) => name === fileName || fileExists(name);
-  const readFile = host.readFile.bind(host);
-  host.readFile = (name) => (name === fileName ? source : readFile(name));
+function binaryTransform(schemaObject: any) {
+  return schemaObject.format === "binary" ? BLOB : undefined;
+}
 
-  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
-  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+function typeNode(source: string): ts.TypeNode {
+  return (stringToAST(`type Generated = ${source}`)[0] as ts.TypeAliasDeclaration).type;
 }

--- a/packages/openapi-typescript/test/node-api.test.ts
+++ b/packages/openapi-typescript/test/node-api.test.ts
@@ -1819,4 +1819,449 @@ export type operations = Record<string, never>;`,
       ci?.timeout || 5000,
     );
   }
+
+  test("required-only allOf remains concise with an unrelated binary transform", async () => {
+    let sawOuterHelper = false;
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        dedupeEnums: true,
+        enumValues: true,
+        rootTypes: true,
+        transform(schemaObject) {
+          if (schemaObject.format === "binary") {
+            return BLOB;
+          }
+        },
+        postTransform(type, options) {
+          if (
+            options.path?.includes("/paths/~1companies/get/responses/200") &&
+            ts.isTypeReferenceNode(type) &&
+            ts.isIdentifier(type.typeName) &&
+            type.typeName.text === "WithRequiredObject"
+          ) {
+            sawOuterHelper = true;
+          }
+          return type;
+        },
+      }),
+    );
+    const exact =
+      'WithRequiredObject<components["schemas"]["CompanyResource"], "organization" | "addresses" | "processingTypes">';
+
+    expect(result.split(exact)).toHaveLength(4);
+    expect(result.match(/type WithRequiredObject</g)).toHaveLength(1);
+    expect(result.match(/extends infer U \?/g)).toHaveLength(1);
+    expect(result).not.toContain('components["schemas"]["CompanyResource"] & Record<string, never>');
+    expect(sawOuterHelper).toBe(true);
+    expectTypeScriptSourceToCompile(result);
+  });
+
+  test.each([
+    "transform",
+    "postTransform",
+  ] as const)("required-only allOf uses final component property types from %s", async (callback) => {
+    const replacement = ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        undefined,
+        "organization",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+      ),
+      ts.factory.createPropertySignature(
+        undefined,
+        "addresses",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+      ),
+      ts.factory.createPropertySignature(
+        undefined,
+        "processingTypes",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+      ),
+    ]);
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        [callback]: (_value: any, options: any) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+        type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+        const valid: Generated = { organization: 1, addresses: [], processingTypes: [] };
+        // @ts-expect-error WithRequiredObject reads the final callback-produced property type
+        const wrong: Generated = { organization: "value", addresses: [], processingTypes: [] };
+      `);
+  });
+
+  test("required-only allOf makes callback-removed component keys required unknown", async () => {
+    const replacement = ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        undefined,
+        "other",
+        undefined,
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ),
+    ]);
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      const valid: Generated = {
+        other: "value",
+        organization: 1,
+        addresses: "callback-defined",
+        processingTypes: null,
+      };
+      // @ts-expect-error removed keys remain required
+      const missing: Generated = { other: "value" };
+    `);
+  });
+
+  test.each([
+    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword), "1"],
+    ["null", ts.factory.createLiteralTypeNode(ts.factory.createNull()), "null"],
+    [
+      "array",
+      ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+      '["value"]',
+    ],
+    [
+      "callable",
+      ts.factory.createFunctionTypeNode(undefined, [], ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+      '() => "value"',
+    ],
+    [
+      "constructor",
+      ts.factory.createConstructorTypeNode(undefined, undefined, [], ts.factory.createTypeLiteralNode([])),
+      "class {}",
+    ],
+  ])("required-only allOf rejects a transformed %s component", async (_label, replacement, value) => {
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      // @ts-expect-error typed required constraint rejects non-object callback output
+      const invalid: Generated = ${value};
+    `);
+  });
+
+  test("required-only allOf distributes over a transformed object union", async () => {
+    const replacement = ts.factory.createUnionTypeNode([
+      ts.factory.createTypeLiteralNode([
+        ts.factory.createPropertySignature(
+          undefined,
+          "organization",
+          ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+        ),
+      ]),
+      ts.factory.createTypeLiteralNode([
+        ts.factory.createPropertySignature(
+          undefined,
+          "other",
+          undefined,
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+      ]),
+    ]);
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      const first: Generated = { organization: 1, addresses: [], processingTypes: [] };
+      const second: Generated = {
+        other: "value",
+        organization: "unknown",
+        addresses: "unknown",
+        processingTypes: "unknown",
+      };
+      // @ts-expect-error every distributed object branch requires every key
+      const missing: Generated = { other: "value" };
+    `);
+  });
+
+  test("required-only allOf constrains a postTransform replacement of the ref occurrence", async () => {
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        postTransform: (type, options) =>
+          options.path?.includes("/paths/~1companies/get/responses/200") && ts.isIndexedAccessTypeNode(type)
+            ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+            : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      // @ts-expect-error the typed member still rejects a primitive ref-occurrence replacement
+      const invalid: Generated = 1;
+    `);
+  });
+
+  test("required-only allOf keeps every parent required key after component callbacks", async () => {
+    const schema = requiredOnlyAllOfCallbackSchema() as any;
+    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
+    constrained.required = ["callbackOnly", "missing"];
+    constrained.allOf[1].required = ["organization"];
+    const replacement = ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        undefined,
+        "organization",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ),
+      ts.factory.createPropertySignature(
+        undefined,
+        "callbackOnly",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+      ),
+    ]);
+    const result = astToString(
+      await openapiTS(schema, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expect(result).toContain(
+      'WithRequiredObject<components["schemas"]["CompanyResource"], "callbackOnly" | "missing" | "organization">',
+    );
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      const valid: Generated = { organization: "value", callbackOnly: 1, missing: null };
+      // @ts-expect-error callbackOnly uses the callback-produced number type
+      const wrongCallbackType: Generated = { organization: "value", callbackOnly: "wrong", missing: null };
+      // @ts-expect-error a parent required key absent from both raw and callback properties is required unknown
+      const missingUnknownKey: Generated = { organization: "value", callbackOnly: 1 };
+    `);
+  });
+
+  test.each([
+    [
+      "array",
+      ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
+      '["value"]',
+    ],
+    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), '"value"'],
+  ])("plain parent required over callback-produced %s keeps legacy WithRequired", async (_label, replacement, value) => {
+    const schema = requiredOnlyAllOfCallbackSchema() as any;
+    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
+    constrained.required = ["length"];
+    constrained.allOf = [constrained.allOf[0]];
+    schema.components.schemas.CompanyResource = {
+      type: "object",
+      properties: { length: { type: "number" } },
+    };
+    const result = astToString(
+      await openapiTS(schema, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expect(result).toContain('WithRequired<components["schemas"]["CompanyResource"], "length">');
+    expect(result).not.toContain("WithRequiredObject");
+    expect(result).toContain("type WithRequired<T, K extends keyof T>");
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      const valid: Generated = ${value};
+    `);
+  });
+
+  test("required-only allOf helper preserves callback readonly, undefined, and index signatures", async () => {
+    const schema = requiredOnlyAllOfCallbackSchema() as any;
+    const constrained = schema.paths["/companies"].get.responses[200].content["application/json"].schema;
+    constrained.allOf[1].required = ["organization", "addresses"];
+    const stringOrUndefined = ts.factory.createUnionTypeNode([
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    ]);
+    const replacement = ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        [ts.factory.createModifier(ts.SyntaxKind.ReadonlyKeyword)],
+        "organization",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ),
+      ts.factory.createPropertySignature(
+        undefined,
+        "addresses",
+        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+        stringOrUndefined,
+      ),
+      ts.factory.createIndexSignature(
+        undefined,
+        [
+          ts.factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            "key",
+            undefined,
+            ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+          ),
+        ],
+        stringOrUndefined,
+      ),
+    ]);
+    const result = astToString(
+      await openapiTS(schema, {
+        transform: (_schema, options) =>
+          options.path === "#/components/schemas/CompanyResource" ? replacement : undefined,
+      }),
+    );
+
+    expectTypeScriptSourceToCompile(`${result}
+      type Generated = paths["/companies"]["get"]["responses"][200]["content"]["application/json"];
+      const valid: Generated = { organization: "value", addresses: undefined };
+      // @ts-expect-error implicit optional undefined is removed when made required
+      const implicitUndefined: Generated = { organization: undefined, addresses: undefined };
+      // @ts-expect-error readonly survives the required projection
+      valid.organization = "other";
+      // @ts-expect-error the callback-produced string index signature remains effective
+      const wrongIndex: Generated = { organization: "value", addresses: undefined, other: 1 };
+    `);
+  });
+
+  test.each([
+    ["alias", "type WithRequiredObject = unknown;"],
+    ["interface", "interface WithRequiredObject { caller: true }"],
+    ["class", "declare class WithRequiredObject {}"],
+    ["enum", "enum WithRequiredObject { Caller }"],
+    ["import", 'import type { paths as WithRequiredObject } from "./required-callback.test";'],
+  ])("required-only allOf uses anonymous fallback for public inject %s conflicts", async (_label, inject) => {
+    let sawOuterConditional = false;
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        inject,
+        transform: () => undefined,
+        postTransform(type, options) {
+          if (options.path?.includes("/paths/~1companies/get/responses/200") && ts.isConditionalTypeNode(type)) {
+            sawOuterConditional = true;
+          }
+          return type;
+        },
+      }),
+    );
+
+    expect(result).not.toContain('WithRequiredObject<components["schemas"]["CompanyResource"]');
+    expect(result.match(/extends infer U \?/g)).toHaveLength(3);
+    expect(sawOuterConditional).toBe(true);
+    expectTypeScriptSourceToCompile(result);
+  });
+
+  test.each([
+    ["enum output", { enum: true }],
+    ["unprefixed root types", { rootTypes: true, rootTypesNoSchemaPrefix: true }],
+  ] as const)("required-only allOf uses anonymous fallback with %s", async (_label, fallbackOptions) => {
+    const result = astToString(
+      await openapiTS(requiredOnlyAllOfCallbackSchema() as any, {
+        ...fallbackOptions,
+        transform: () => undefined,
+      }),
+    );
+
+    expect(result).not.toContain("WithRequiredObject");
+    expect(result.match(/extends infer U \?/g)).toHaveLength(3);
+    expectTypeScriptSourceToCompile(result);
+  });
 });
+
+function requiredOnlyAllOfCallbackSchema() {
+  const requiredResource = {
+    allOf: [
+      { $ref: "#/components/schemas/CompanyResource" },
+      { type: "object", required: ["organization", "addresses", "processingTypes"] },
+    ],
+  };
+  return {
+    openapi: "3.1.0",
+    info: { title: "Required callback", version: "1.0.0" },
+    paths: {
+      "/companies": {
+        get: {
+          responses: {
+            200: {
+              description: "Company",
+              content: { "application/json": { schema: requiredResource } },
+            },
+          },
+        },
+      },
+      "/companies/{company}": {
+        get: {
+          responses: {
+            200: {
+              description: "Company",
+              content: { "application/json": { schema: requiredResource } },
+            },
+          },
+        },
+      },
+      "/companies/{company}/claim": {
+        post: {
+          responses: {
+            200: {
+              description: "Company",
+              content: { "application/json": { schema: requiredResource } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        CompanyResource: {
+          type: "object",
+          properties: {
+            organization: { type: "string" },
+            addresses: { type: "array", items: { type: "string" } },
+            processingTypes: { type: "array", items: { type: "string" } },
+          },
+        },
+        BinaryPayload: { type: "string", format: "binary" },
+      },
+    },
+  } as const;
+}
+
+function expectTypeScriptSourceToCompile(source: string) {
+  const fileName = "/required-callback.test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    exactOptionalPropertyTypes: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (name) => name === fileName || fileExists(name);
+  const readFile = host.readFile.bind(host);
+  host.readFile = (name) => (name === fileName ? source : readFile(name));
+
+  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
+  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+}

--- a/packages/openapi-typescript/test/test-helpers.ts
+++ b/packages/openapi-typescript/test/test-helpers.ts
@@ -1,4 +1,5 @@
 import { createConfig } from "@redocly/openapi-core";
+import ts from "typescript";
 import { resolveRef } from "../src/lib/utils.js";
 import type { GlobalContext, TransformNodeOptions } from "../src/types.js";
 
@@ -63,3 +64,30 @@ export type TestCase<T = any, O = TransformNodeOptions> = [
     ci?: { timeout?: number; skipIf?: boolean };
   },
 ];
+
+/** Compile generated TypeScript with the package's strict semantic expectations. */
+export function expectTypeScriptToCompile(source: string, extraSource = "") {
+  const fileName = "/generated.test.ts";
+  const contents = `${source}\n${extraSource}`;
+  const compilerOptions: ts.CompilerOptions = {
+    exactOptionalPropertyTypes: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const sourceFile = ts.createSourceFile(fileName, contents, ts.ScriptTarget.ESNext, true);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (name) => name === fileName || fileExists(name);
+  const readFile = host.readFile.bind(host);
+  host.readFile = (name) => (name === fileName ? contents : readFile(name));
+
+  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
+  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+}

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { astToString } from "../../../src/lib/ts.js";
 import transformSchemaObject from "../../../src/transform/schema-object.js";
 import { DEFAULT_CTX, type TestCase } from "../../test-helpers.js";
@@ -581,6 +582,636 @@ describe("composition", () => {
       },
     ],
     [
+      "allOf > Scramble object required constraint",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        },
+        want: `WithRequired<components["schemas"]["Base"], "required_string">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: {
+              required_string: { type: "string" },
+              optional_number: { type: "number" },
+            },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > annotations prevent required constraint classification",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              required: ["required_string"],
+              title: "Required base fields",
+              description: "This annotation does not change validation.",
+              $comment: "Required in this use of Base.",
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & unknown`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > required constraint across composed members",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { $ref: "#/components/schemas/Details" },
+            {
+              type: "object",
+              properties: { inline_flag: { type: "boolean" } },
+            },
+            {
+              required: ["required_string", "detail_id", "inline_flag"],
+            },
+          ],
+        },
+        want: `WithRequired<components["schemas"]["Base"], "required_string"> & WithRequired<components["schemas"]["Details"], "detail_id"> & {
+    inline_flag: boolean;
+}`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+          Details: {
+            type: "object",
+            properties: { detail_id: { type: "number" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > parent and constraint required are combined and deduplicated",
+      {
+        given: {
+          required: ["optional_number", "required_string"],
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        },
+        want: `WithRequired<components["schemas"]["Base"], "optional_number" | "required_string">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: {
+              required_string: { type: "string" },
+              optional_number: { type: "number" },
+            },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > required constraint applies to core and ref properties",
+      {
+        given: {
+          type: "object",
+          properties: { core_id: { type: "string" } },
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["core_id", "required_string"] }],
+        },
+        want: `{
+    core_id: string;
+} & WithRequired<components["schemas"]["Base"], "required_string">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > required constraint discovers nested ref properties",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Derived" }, { required: ["required_string"] }],
+        },
+        want: `WithRequired<components["schemas"]["Derived"], "required_string">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+          Derived: {
+            allOf: [{ $ref: "#/components/schemas/Base" }],
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > required constraint discovers properties through a recursive ref cycle",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/RecursiveA" }, { type: "object", required: ["recursive_key"] }],
+        },
+        want: `WithRequired<components["schemas"]["RecursiveA"], "recursive_key">`,
+        options: optionsWithSchemas({
+          RecursiveA: {
+            allOf: [{ $ref: "#/components/schemas/RecursiveB" }],
+          },
+          RecursiveB: {
+            type: "object",
+            properties: { recursive_key: { type: "string" } },
+            allOf: [{ $ref: "#/components/schemas/RecursiveA" }],
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > multiple required constraints deduplicate keys",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { required: ["required_string"] },
+            { required: ["optional_number", "required_string"] },
+          ],
+        },
+        want: `WithRequired<components["schemas"]["Base"], "required_string" | "optional_number">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: {
+              required_string: { type: "string" },
+              optional_number: { type: "number" },
+            },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > typed required constraints do not prove object-likeness for each other",
+      {
+        given: {
+          allOf: [
+            {
+              properties: {
+                first: { type: "string" },
+                second: { type: "string" },
+              },
+            },
+            { type: "object", required: ["first"] },
+            { type: "object", required: ["second"] },
+          ],
+        },
+        want: `{
+    first?: string;
+    second?: string;
+} & Record<string, never> & Record<string, never>`,
+      },
+    ],
+    [
+      "allOf > typed required constraint does not erase a primitive composition",
+      {
+        given: {
+          allOf: [
+            {
+              type: "string",
+              properties: { required_string: { type: "string" } },
+            },
+            { type: "object", required: ["required_string"] },
+          ],
+        },
+        want: `string & Record<string, never>`,
+      },
+    ],
+    [
+      "allOf > typed required constraint with unknown key preserves its object assertion",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["unknown_property"] }],
+        },
+        want: `components["schemas"]["Base"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > untyped required constraint with mixed known and unknown keys is preserved",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string", "unknown_property"] }],
+        },
+        want: `components["schemas"]["Base"] & unknown`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > typed required constraint with mixed known and unknown keys is preserved",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { type: "object", required: ["required_string", "unknown_property"] },
+          ],
+        },
+        want: `components["schemas"]["Base"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > polymorphic type array ref prevents untyped constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Polymorphic"] & unknown`,
+        options: optionsWithSchemas({
+          Polymorphic: {
+            type: ["object", "string"],
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > polymorphic type array ref prevents typed constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { type: "object", required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Polymorphic"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Polymorphic: {
+            type: ["object", "string"],
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > primitive ref properties do not make required keys discoverable",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Primitive" }, { required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Primitive"] & unknown`,
+        options: optionsWithSchemas({
+          Primitive: {
+            type: "string",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > const object ref prevents untyped constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Constant" }, { required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Constant"] & unknown`,
+        options: optionsWithSchemas({
+          Constant: {
+            type: "object",
+            const: {},
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > const object ref prevents typed constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Constant" }, { type: "object", required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Constant"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Constant: {
+            type: "object",
+            const: {},
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > early-return enum ref prevents constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Enumerated" }, { required: ["required_string"] }],
+        },
+        want: `components["schemas"]["Enumerated"] & unknown`,
+        options: optionsWithSchemas({
+          Enumerated: {
+            enum: ["fixed"],
+            allOf: [
+              {
+                type: "object",
+                properties: { required_string: { type: "string" } },
+              },
+            ],
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > nullable object ref does not prove typed constraint object-likeness",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/NullableBase" }, { type: "object", required: ["required_string"] }],
+        },
+        want: `components["schemas"]["NullableBase"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          NullableBase: {
+            type: ["object", "null"],
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > outer anyOf prevents required constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+          anyOf: [{ type: "string" }],
+        },
+        want: `(components["schemas"]["Base"] & unknown) | string`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > outer oneOf prevents required constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+          oneOf: [{ type: "object", properties: { variant: { type: "string" } } }],
+        },
+        want: `(components["schemas"]["Base"] & unknown) & {
+    variant?: string;
+}`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > excludeDeprecated prevents required constraint translation",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["deprecated_key"] }],
+        },
+        want: `components["schemas"]["Base"] & unknown`,
+        options: {
+          ...optionsWithSchemas({
+            Base: {
+              type: "object",
+              properties: { deprecated_key: { type: "string", deprecated: true } },
+            },
+          }),
+          ctx: {
+            ...optionsWithSchemas({
+              Base: {
+                type: "object",
+                properties: { deprecated_key: { type: "string", deprecated: true } },
+              },
+            }).ctx,
+            excludeDeprecated: true,
+          },
+        },
+      },
+    ],
+    [
+      "allOf > explicit additionalProperties false is not a required-only constraint",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              type: "object",
+              required: ["required_string"],
+              additionalProperties: false,
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > member with properties remains an ordinary intersection",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              type: "object",
+              required: ["inline_flag"],
+              properties: { inline_flag: { type: "boolean" } },
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & {
+    inline_flag: boolean;
+}`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > member with another validation keyword remains an ordinary intersection",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              type: "object",
+              required: ["required_string"],
+              minProperties: 1,
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & Record<string, never>`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > nullable object type union is not a required-only constraint",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              type: ["object", "null"],
+              required: ["required_string"],
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & (Record<string, never> | null)`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > vendor extension prevents required constraint classification",
+      {
+        given: {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            {
+              required: ["required_string"],
+              "x-validation-behavior": true,
+            },
+          ],
+        },
+        want: `components["schemas"]["Base"] & unknown`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > unknown required constraint name preserves the member",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["unknown_property"] }],
+        },
+        want: `components["schemas"]["Base"] & unknown`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "discriminator > allOf required constraint uses ref required handling before Omit",
+      {
+        given: {
+          type: "object",
+          allOf: [{ $ref: "#/components/schemas/parent" }, { type: "object", required: ["name"] }],
+        },
+        want: `{
+    operation: "test";
+} & Omit<WithRequired<components["schemas"]["parent"], "name">, "operation">`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            discriminators: {
+              objects: {
+                [DEFAULT_OPTIONS.path]: {
+                  propertyName: "operation",
+                  mapping: { test: DEFAULT_OPTIONS.path },
+                },
+                "#/components/schemas/parent": {
+                  propertyName: "operation",
+                  mapping: { test: DEFAULT_OPTIONS.path },
+                },
+              },
+              refsHandled: [],
+            },
+            resolve($ref) {
+              if ($ref === "#/components/schemas/parent") {
+                return {
+                  type: "object",
+                  properties: {
+                    operation: { type: "string" },
+                    name: { type: "string" },
+                  },
+                };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
+      "discriminator > handled ref keeps translated non-discriminator required key",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/parent" }, { required: ["name"] }],
+        },
+        want: `Omit<WithRequired<components["schemas"]["parent"], "name">, "operation">`,
+        options: {
+          ...DEFAULT_OPTIONS,
+          ctx: {
+            ...DEFAULT_OPTIONS.ctx,
+            discriminators: {
+              objects: {
+                "#/components/schemas/parent": {
+                  propertyName: "operation",
+                  mapping: { test: DEFAULT_OPTIONS.path },
+                },
+              },
+              refsHandled: ["#/components/schemas/parent"],
+            },
+            resolve($ref) {
+              if ($ref === "#/components/schemas/parent") {
+                return {
+                  type: "object",
+                  required: ["operation"],
+                  properties: {
+                    operation: { type: "string", enum: ["test"] },
+                    name: { type: "string" },
+                  },
+                };
+              }
+              return undefined as any;
+            },
+          },
+        },
+      },
+    ],
+    [
       "anyOf > basic",
       {
         given: {
@@ -628,4 +1259,501 @@ describe("composition", () => {
       ci?.timeout,
     );
   }
+
+  for (const [keyword, value] of [
+    ["default", { required_string: "default" }],
+    ["readOnly", true],
+    ["writeOnly", true],
+    ["deprecated", true],
+    ["examples", [{ required_string: "example" }]],
+    ["example", { required_string: "legacy example" }],
+  ] as const) {
+    test(`allOf > ${keyword} prevents required constraint classification`, () => {
+      const result = astToString(
+        transformSchemaObject(
+          {
+            allOf: [
+              { $ref: "#/components/schemas/Base" },
+              {
+                type: "object",
+                required: ["required_string"],
+                [keyword]: value,
+              },
+            ],
+          } as any,
+          optionsWithSchemas({
+            Base: {
+              type: "object",
+              properties: { required_string: { type: "string" } },
+            },
+          }),
+        ),
+      );
+
+      expect(result).toBe('components["schemas"]["Base"] & Record<string, never>\n');
+    });
+  }
+
+  test("allOf > transform callback replacement prevents constraint translation", () => {
+    let transformCalls = 0;
+    let postTransformCalls = 0;
+    const options = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    options.ctx.transform = () => {
+      transformCalls++;
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    };
+    options.ctx.postTransform = () => void postTransformCalls++;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Base"] & number\n');
+    expect(transformCalls).toBe(1);
+    expect(postTransformCalls).toBe(3);
+  });
+
+  test("allOf > postTransform callback replacement prevents constraint translation", () => {
+    const options = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    options.ctx.postTransform = (type) =>
+      ts.isTypeReferenceNode(type) && ts.isIdentifier(type.typeName) && type.typeName.text === "Record"
+        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+        : undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Base"] & number\n');
+  });
+
+  test("allOf > generated required constraint types compile", () => {
+    const scrambleOptions = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    const scramble = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        scrambleOptions,
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+      interface components { schemas: { Base: { required_string?: string } } }
+      type Generated = ${scramble};
+      const valid: Generated = { required_string: "value" };
+      // @ts-expect-error required_string is required
+      const invalid: Generated = {};
+    `);
+
+    const untyped = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+        } as any,
+        optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+      interface components { schemas: { Base: { required_string?: string } } }
+      type Generated = ${untyped};
+      const valid: Generated = { required_string: "value" };
+      // @ts-expect-error required_string is required
+      const invalid: Generated = {};
+    `);
+
+    const nullableOptions = optionsWithSchemas({
+      NullableBase: {
+        type: ["object", "null"],
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    const nullable = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/NullableBase" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        nullableOptions,
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      interface components { schemas: { NullableBase: { required_string?: string } | null } }
+      type Generated = ${nullable};
+      // @ts-expect-error the retained typed constraint remains unassignable
+      const invalid: Generated = { required_string: "value" };
+    `);
+
+    const deprecatedOptions = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { deprecated_key: { type: "string", deprecated: true } },
+      },
+    });
+    deprecatedOptions.ctx.excludeDeprecated = true;
+    const deprecated = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["deprecated_key"] }],
+        } as any,
+        deprecatedOptions,
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Base: Record<string, never> } }
+      type Generated = ${deprecated};
+      const valid: Generated = {};
+    `);
+
+    const transformPropertyOptions = { ...DEFAULT_OPTIONS, ctx: { ...DEFAULT_OPTIONS.ctx } };
+    transformPropertyOptions.ctx.transformProperty = (property) =>
+      ts.factory.updatePropertySignature(
+        property,
+        property.modifiers,
+        ts.factory.createIdentifier("renamed"),
+        property.questionToken,
+        property.type,
+      );
+    const renamed = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ type: "object", properties: { original: { type: "string" } } }, { required: ["original"] }],
+        } as any,
+        transformPropertyOptions,
+      ),
+    ).trim();
+    expect(renamed).toBe(`{
+    renamed?: string;
+} & unknown`);
+    expectTypeScriptToCompile(`
+      type Generated = ${renamed};
+      const valid: Generated = { renamed: "value" };
+    `);
+
+    const union = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+          anyOf: [{ type: "string" }],
+        } as any,
+        optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Base: { required_string?: string } } }
+      type Generated = ${union};
+      const objectValue: Generated = {};
+      const stringValue: Generated = "value";
+    `);
+
+    const polymorphicOptions = optionsWithSchemas({
+      Polymorphic: {
+        type: ["object", "string"],
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    const polymorphic = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
+        } as any,
+        polymorphicOptions,
+      ),
+    ).trim();
+    expect(polymorphic).toBe('components["schemas"]["Polymorphic"] & unknown');
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Polymorphic: { required_string?: string } | string } }
+      type Generated = ${polymorphic};
+      const objectValue: Generated = {};
+      const stringValue: Generated = "value";
+    `);
+
+    const typedPolymorphic = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        polymorphicOptions,
+      ),
+    ).trim();
+    expect(typedPolymorphic).toBe('components["schemas"]["Polymorphic"] & Record<string, never>');
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Polymorphic: { required_string?: string } | string } }
+      type Generated = ${typedPolymorphic};
+      // @ts-expect-error the retained object constraint remains unassignable
+      const invalid: Generated = { required_string: "value" };
+    `);
+
+    const handledDiscriminatorOptions = optionsWithSchemas({
+      parent: {
+        type: "object",
+        required: ["operation"],
+        properties: {
+          operation: { type: "string", enum: ["test"] },
+          name: { type: "string" },
+        },
+      },
+    });
+    handledDiscriminatorOptions.ctx.discriminators = {
+      objects: {
+        "#/components/schemas/parent": {
+          propertyName: "operation",
+          mapping: { test: DEFAULT_OPTIONS.path },
+        },
+      },
+      refsHandled: ["#/components/schemas/parent"],
+    };
+    const handledDiscriminator = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/parent" }, { required: ["name"] }],
+        } as any,
+        handledDiscriminatorOptions,
+      ),
+    ).trim();
+    expectTypeScriptToCompile(`
+      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+      interface components { schemas: { parent: { operation: "test"; name?: string } } }
+      type Generated = ${handledDiscriminator};
+      const valid: Generated = { name: "value" };
+      // @ts-expect-error name is required after omitting the discriminator property
+      const invalid: Generated = {};
+    `);
+  });
+
+  test("allOf > generated components and constrained types compile together", () => {
+    const baseSchemas = {
+      Base: {
+        type: "object",
+        properties: { required_string: { type: "string" } },
+      },
+    };
+    const scramble = generateComponentsAndConstrainedType(baseSchemas, {
+      allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+    });
+    expectTypeScriptToCompile(`${scramble.source}
+      const valid: Generated = { required_string: "value" };
+      // @ts-expect-error required_string is required
+      const invalid: Generated = {};
+    `);
+
+    const constantSchemas = {
+      Constant: {
+        type: "object",
+        const: {},
+        properties: { required_string: { type: "string" } },
+      },
+    };
+    for (const constraint of [{ required: ["required_string"] }, { type: "object", required: ["required_string"] }]) {
+      const constant = generateComponentsAndConstrainedType(constantSchemas, {
+        allOf: [{ $ref: "#/components/schemas/Constant" }, constraint],
+      });
+      expect(constant.generated).not.toContain("WithRequired");
+      expectTypeScriptToCompile(`${constant.source}
+        type Check = Generated;
+      `);
+    }
+
+    const enumerated = generateComponentsAndConstrainedType(
+      {
+        Enumerated: {
+          enum: ["fixed"],
+          allOf: [
+            {
+              type: "object",
+              properties: { required_string: { type: "string" } },
+            },
+          ],
+        },
+      },
+      {
+        allOf: [{ $ref: "#/components/schemas/Enumerated" }, { required: ["required_string"] }],
+      },
+    );
+    expect(enumerated.generated).not.toContain("WithRequired");
+    expectTypeScriptToCompile(`${enumerated.source}
+      const valid: Generated = "fixed";
+    `);
+
+    const polymorphic = generateComponentsAndConstrainedType(
+      {
+        Polymorphic: {
+          type: ["object", "string"],
+          properties: { required_string: { type: "string" } },
+        },
+      },
+      {
+        allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
+      },
+    );
+    expect(polymorphic.generated).not.toContain("WithRequired");
+    expectTypeScriptToCompile(`${polymorphic.source}
+      const objectValue: Generated = {};
+      const stringValue: Generated = "value";
+    `);
+
+    const nullable = generateComponentsAndConstrainedType(
+      {
+        Nullable: {
+          type: ["object", "null"],
+          properties: { required_string: { type: "string" } },
+        },
+      },
+      {
+        allOf: [{ $ref: "#/components/schemas/Nullable" }, { type: "object", required: ["required_string"] }],
+      },
+    );
+    expect(nullable.generated).not.toContain("WithRequired");
+    expectTypeScriptToCompile(`${nullable.source}
+      type Check = Generated;
+    `);
+
+    const deprecated = generateComponentsAndConstrainedType(
+      {
+        Deprecated: {
+          type: "object",
+          properties: { old: { type: "string", deprecated: true } },
+        },
+      },
+      {
+        allOf: [{ $ref: "#/components/schemas/Deprecated" }, { required: ["old"] }],
+      },
+      (options) => {
+        options.ctx.excludeDeprecated = true;
+      },
+    );
+    expect(deprecated.generated).not.toContain("WithRequired");
+    expectTypeScriptToCompile(`${deprecated.source}
+      const valid: Generated = {};
+    `);
+
+    const renamed = generateComponentsAndConstrainedType(
+      {
+        Renamed: {
+          type: "object",
+          properties: { original: { type: "string" } },
+        },
+      },
+      {
+        allOf: [{ $ref: "#/components/schemas/Renamed" }, { required: ["original"] }],
+      },
+      (options) => {
+        options.ctx.transformProperty = (property) =>
+          ts.factory.updatePropertySignature(
+            property,
+            property.modifiers,
+            ts.factory.createIdentifier("renamed"),
+            property.questionToken,
+            property.type,
+          );
+      },
+    );
+    expect(renamed.generated).not.toContain("WithRequired");
+    expectTypeScriptToCompile(`${renamed.source}
+      const valid: Generated = { renamed: "value" };
+    `);
+  });
 });
+
+function optionsWithSchemas(schemas: Record<string, any>) {
+  return {
+    ...DEFAULT_OPTIONS,
+    ctx: {
+      ...DEFAULT_OPTIONS.ctx,
+      resolve($ref: string) {
+        const name = $ref.startsWith("#/components/schemas/") ? $ref.slice("#/components/schemas/".length) : undefined;
+        return name ? schemas[name] : undefined;
+      },
+    },
+  };
+}
+
+function generateComponentsAndConstrainedType(
+  schemas: Record<string, any>,
+  constrainedSchema: any,
+  configure?: (options: ReturnType<typeof optionsWithSchemas>) => void,
+) {
+  const options = optionsWithSchemas(schemas);
+  options.ctx.injectFooter = [];
+  configure?.(options);
+  const componentTypes = Object.entries(schemas)
+    .map(([name, schema]) => {
+      const type = astToString(
+        transformSchemaObject(schema, {
+          ...options,
+          path: `#/components/schemas/${name}`,
+        }),
+      ).trim();
+      return `${JSON.stringify(name)}: ${type};`;
+    })
+    .join("\n");
+  const generated = astToString(transformSchemaObject(constrainedSchema, options)).trim();
+  const footer = astToString(options.ctx.injectFooter).trim();
+
+  return {
+    generated,
+    source: `
+      interface components { schemas: { ${componentTypes} } }
+      type Generated = ${generated};
+      ${footer}
+    `,
+  };
+}
+
+function expectTypeScriptToCompile(source: string) {
+  const fileName = "/required-constraint.test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.ESNext,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
+    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (name) => name === fileName || fileExists(name);
+  const readFile = host.readFile.bind(host);
+  host.readFile = (name) => (name === fileName ? source : readFile(name));
+
+  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
+  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+}

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import { astToString } from "../../../src/lib/ts.js";
+import { astToString, stringToAST } from "../../../src/lib/ts.js";
 import transformSchemaObject from "../../../src/transform/schema-object.js";
 import { DEFAULT_CTX, type TestCase } from "../../test-helpers.js";
 
@@ -1347,6 +1347,668 @@ describe("composition", () => {
     expect(result).toBe('components["schemas"]["Base"] & number\n');
   });
 
+  test("allOf > unrelated transform callback keeps concise typed constraint output", () => {
+    const calls: string[] = [];
+    const options = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    options.ctx.transform = (schema) => {
+      calls.push(schema.required?.includes("required_string") ? "constraint" : "other");
+      return undefined;
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
+    expect(calls).toEqual(["constraint"]);
+    expect(astToString(options.ctx.injectFooter).match(/type WithRequiredObject</g)).toHaveLength(1);
+  });
+
+  test("allOf > outer object core retains typed callback constraint", () => {
+    const schema = {
+      type: "object",
+      properties: { value: { type: "string" } },
+      allOf: [{ type: "object", required: ["value"] }],
+    };
+    const generated = generateComponentsAndConstrainedType({}, schema, (options) => {
+      options.ctx.transform = () => undefined;
+    });
+
+    expect(generated.generated).toBe(`WithRequiredObject<{
+    value?: string;
+}, "value">`);
+    expectTypeScriptToCompile(`${generated.source}
+      const valid: Generated = { value: "value" };
+      // @ts-expect-error the typed sibling makes the core property required
+      const invalid: Generated = {};
+    `);
+
+    const noCallback = generateComponentsAndConstrainedType({}, schema);
+    expect(noCallback.generated).toBe(`{
+    value?: string;
+} & Record<string, never>`);
+  });
+
+  test("allOf > outer object core retains typed constraint with identity postTransform", () => {
+    const generated = generateComponentsAndConstrainedType(
+      {},
+      {
+        type: "object",
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+      },
+      (options) => {
+        options.ctx.postTransform = (type) => type;
+      },
+    );
+
+    expect(generated.generated).toBe(`WithRequiredObject<{
+    value?: string;
+}, "value">`);
+    expectTypeScriptToCompile(`${generated.source}
+      const valid: Generated = { value: "value" };
+      // @ts-expect-error identity observation does not remove the sibling assertion
+      const invalid: Generated = {};
+    `);
+  });
+
+  test("allOf > typed sibling constrains a callback-replaced outer object core", () => {
+    const replacement = ts.factory.createTypeLiteralNode([
+      ts.factory.createPropertySignature(
+        undefined,
+        "other",
+        undefined,
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+      ),
+    ]);
+    const generated = generateComponentsAndConstrainedType(
+      {},
+      {
+        type: "object",
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+      },
+      (options) => {
+        options.ctx.transform = (schema) => ("properties" in schema && schema.properties ? replacement : undefined);
+      },
+    );
+
+    expect(generated.generated).toBe(`WithRequiredObject<{
+    other: number;
+}, "value">`);
+    expectTypeScriptToCompile(`${generated.source}
+      const valid: Generated = { other: 1, value: "required unknown" };
+      // @ts-expect-error callback replacement does not erase the untouched typed sibling
+      const invalid: Generated = { other: 1 };
+    `);
+  });
+
+  test.each([
+    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)],
+    ["array", ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword))],
+  ])("allOf > typed sibling rejects a callback-replaced %s outer core", (_label, replacement) => {
+    const generated = generateComponentsAndConstrainedType(
+      {},
+      {
+        type: "object",
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+      },
+      (options) => {
+        options.ctx.transform = (schema) => ("properties" in schema && schema.properties ? replacement : undefined);
+      },
+    );
+
+    expect(generated.generated).toContain("WithRequiredObject<");
+    expectTypeScriptToCompile(`${generated.source}
+      type IsNever<T> = [T] extends [never] ? true : false;
+      const isNever: IsNever<Generated> = true;
+      // @ts-expect-error the untouched type: object sibling rejects non-object callback output
+      const invalid: Generated = ${_label === "array" ? "[]" : '"value"'};
+    `);
+  });
+
+  test("allOf > outer object core supports partial typed member replacement", () => {
+    const generated = generateComponentsAndConstrainedType(
+      {},
+      {
+        type: "object",
+        properties: { first: { type: "string" }, second: { type: "number" } },
+        allOf: [
+          { type: "object", required: ["first"] },
+          { type: "object", required: ["second"] },
+        ],
+      },
+      (options) => {
+        options.ctx.transform = (schema) =>
+          schema.required?.includes("first")
+            ? ts.factory.createTypeLiteralNode([
+                ts.factory.createPropertySignature(
+                  undefined,
+                  "replacement",
+                  undefined,
+                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+                ),
+              ])
+            : undefined;
+      },
+    );
+
+    expect(generated.generated).toBe(`WithRequiredObject<{
+    first?: string;
+    second?: number;
+} & {
+    replacement: boolean;
+}, "second">`);
+    expectTypeScriptToCompile(`${generated.source}
+      const valid: Generated = { replacement: true, second: 1 };
+      // @ts-expect-error the untouched second constraint is still applied
+      const missingSecond: Generated = { replacement: true };
+      // @ts-expect-error the replacement remains authoritative
+      const missingReplacement: Generated = { second: 1 };
+    `);
+  });
+
+  test.each([
+    [
+      "nullable",
+      {
+        type: "object",
+        nullable: true,
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+      },
+    ],
+    [
+      "type array",
+      {
+        type: ["object", "string"],
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+      },
+    ],
+    [
+      "anyOf union",
+      {
+        type: "object",
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+        anyOf: [{ type: "string" }],
+      },
+    ],
+    [
+      "oneOf union",
+      {
+        type: "object",
+        properties: { value: { type: "string" } },
+        allOf: [{ type: "object", required: ["value"] }],
+        oneOf: [{ type: "string" }],
+      },
+    ],
+  ])("allOf > unsafe %s core does not prove exact callback object semantics", (_label, schema) => {
+    const generated = generateComponentsAndConstrainedType({}, schema, (options) => {
+      options.ctx.transform = () => undefined;
+    });
+
+    expect(generated.generated).not.toContain("WithRequiredObject");
+    expect(generated.generated).toContain("Record<string, never>");
+    expectTypeScriptToCompile(`${generated.source}
+      declare const generated: Generated;
+      const assignment: unknown = generated;
+    `);
+  });
+
+  test("discriminator > synthesized outer core property remains in callback aggregate", () => {
+    const generated = generateComponentsAndConstrainedType(
+      {},
+      {
+        type: "object",
+        properties: { name: { type: "string" } },
+        allOf: [{ type: "object", required: ["name"] }],
+      },
+      (options) => {
+        options.ctx.transform = () => undefined;
+        options.ctx.discriminators = {
+          objects: {
+            [options.path ?? DEFAULT_OPTIONS.path]: { propertyName: "operation" },
+          },
+          refsHandled: [],
+        };
+      },
+    );
+
+    expect(generated.generated).toBe(`WithRequiredObject<{
+    operation: "schema-object";
+    name?: string;
+}, "name">`);
+    expectTypeScriptToCompile(`${generated.source}
+      const valid: Generated = { operation: "schema-object", name: "value" };
+      // @ts-expect-error synthesized discriminator does not replace the required name assertion
+      const invalid: Generated = { operation: "schema-object" };
+    `);
+  });
+
+  test("allOf > generated callback object helper has typed object semantics", () => {
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { value: { type: "string" } } },
+    });
+    options.ctx.transform = () => undefined;
+    transformSchemaObject(
+      {
+        allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["value"] }],
+      } as any,
+      options,
+    );
+    const helper = astToString(options.ctx.injectFooter).trim();
+
+    expect(helper.match(/type WithRequiredObject</g)).toHaveLength(1);
+    expectTypeScriptToCompile(`
+      ${helper}
+
+      type Optional = WithRequiredObject<{ value?: string }, "value">;
+      const optional: Optional = { value: "value" };
+      // @ts-expect-error implicit optional undefined is removed
+      const optionalUndefined: Optional = { value: undefined };
+
+      type ExplicitUndefined = WithRequiredObject<{ value?: string | undefined }, "value">;
+      const explicitUndefined: ExplicitUndefined = { value: undefined };
+
+      type ReadonlyValue = WithRequiredObject<{ readonly value?: string }, "value">;
+      const readonlyValue: ReadonlyValue = { value: "value" };
+      // @ts-expect-error readonly is preserved
+      readonlyValue.value = "other";
+
+      type Union = WithRequiredObject<{ value?: string } | { other: number }, "value">;
+      const unionKnown: Union = { value: "value" };
+      const unionMissing: Union = { other: 1, value: true };
+      // @ts-expect-error every object branch requires value
+      const unionInvalid: Union = { other: 1 };
+
+      declare const symbolKey: unique symbol;
+      type StringIndex = WithRequiredObject<{ [key: string]: number | undefined }, "value">;
+      type NumberIndex = WithRequiredObject<{ [key: number]: string | undefined }, 1>;
+      type SymbolIndex = WithRequiredObject<{ [key: symbol]: boolean | undefined }, typeof symbolKey>;
+      const stringIndex: StringIndex = { value: 1 };
+      const numberIndex: NumberIndex = { 1: "value" };
+      const symbolIndex: SymbolIndex = { [symbolKey]: true };
+
+      type Missing = WithRequiredObject<{ other: number }, "value">;
+      const missing: Missing = { other: 1, value: "anything" };
+      // @ts-expect-error a callback-removed key remains required
+      const missingInvalid: Missing = { other: 1 };
+
+      type UnknownValue = WithRequiredObject<unknown, "value">;
+      type AnyValue = WithRequiredObject<any, "value">;
+      const unknownValue: UnknownValue = { value: 1 };
+      const anyValue: AnyValue = { value: 1 };
+      // @ts-expect-error unknown still requires the key
+      const unknownInvalid: UnknownValue = {};
+      // @ts-expect-error any does not erase required presence
+      const anyInvalid: AnyValue = {};
+
+      type Primitive = WithRequiredObject<string | null, "value">;
+      type ArrayValue = WithRequiredObject<readonly string[], "value">;
+      type Callable = WithRequiredObject<() => string, "value">;
+      type Constructor = WithRequiredObject<abstract new () => object, "value">;
+      type GlobalFunction = WithRequiredObject<Function, "value">;
+      type Nothing = WithRequiredObject<never, "value">;
+      // @ts-expect-error primitives become never
+      const primitive: Primitive = "value";
+      // @ts-expect-error arrays become never
+      const arrayValue: ArrayValue = Object.assign([], { value: 1 });
+      // @ts-expect-error callables become never
+      const callable: Callable = Object.assign(() => "value", { value: 1 });
+      // @ts-expect-error constructors become never
+      const constructorValue: Constructor = Object.assign(class {}, { value: 1 });
+      // Nominal Function has no call/construct signature and remains structurally indistinguishable from an object.
+      const globalFunction: GlobalFunction = Object.assign(() => "value", { value: 1 });
+      // @ts-expect-error never remains never
+      const nothing: Nothing = { value: 1 };
+    `);
+  });
+
+  test("allOf > required-only transform replacement is authoritative", () => {
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { required_string: { type: "string" } } },
+    });
+    options.ctx.transform = (schema) =>
+      schema.required?.includes("required_string")
+        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+        : undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Base"] & number\n');
+  });
+
+  test("allOf > required-only postTransform replacement is authoritative", () => {
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { required_string: { type: "string" } } },
+    });
+    options.ctx.postTransform = (type) =>
+      ts.isTypeReferenceNode(type) && ts.isIdentifier(type.typeName) && type.typeName.text === "Record"
+        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+        : undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Base"] & number\n');
+  });
+
+  test("allOf > identity postTransform translates typed constraint and sees final helper", () => {
+    const calls: string[] = [];
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { required_string: { type: "string" } } },
+    });
+    options.ctx.postTransform = (type) => {
+      calls.push(astToString(type).trim());
+      return type;
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
+    expect(calls).toEqual([
+      'components["schemas"]["Base"]',
+      "Record<string, never>",
+      'WithRequiredObject<components["schemas"]["Base"], "required_string">',
+    ]);
+  });
+
+  test("allOf > callback order options and occurrence counts remain unchanged", () => {
+    const sharedConstraint = { type: "object", required: ["required_string"] } as const;
+    const schemas = { Base: { type: "object", properties: { required_string: { type: "string" } } } };
+    const schema = {
+      allOf: [{ $ref: "#/components/schemas/Base" }, sharedConstraint, sharedConstraint],
+    };
+    const baselineOptions = optionsWithSchemas(schemas);
+    const baselineCalls: string[] = [];
+    baselineOptions.ctx.transform = (item, callbackOptions) => {
+      baselineCalls.push(
+        `${callbackOptions.path}:${item.required?.includes("required_string") ? "constraint" : "other"}`,
+      );
+      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    };
+    const baseline = astToString(transformSchemaObject(schema as any, baselineOptions));
+
+    const optimizedOptions = optionsWithSchemas(schemas);
+    const optimizedCalls: string[] = [];
+    optimizedOptions.ctx.transform = (item, callbackOptions) => {
+      optimizedCalls.push(
+        `${callbackOptions.path}:${item.required?.includes("required_string") ? "constraint" : "other"}`,
+      );
+      return undefined;
+    };
+    const optimized = astToString(transformSchemaObject(schema as any, optimizedOptions));
+
+    expect(baseline).toBe('components["schemas"]["Base"] & number\n');
+    expect(optimized).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
+    expect(optimizedCalls).toEqual(baselineCalls);
+    expect(optimizedCalls).toEqual([`${optimizedOptions.path}:constraint`, `${optimizedOptions.path}:constraint`]);
+  });
+
+  test("allOf > repeated object occurrences keep stateful callback results", () => {
+    const sharedConstraint = { type: "object", required: ["required_string"] } as const;
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { required_string: { type: "string" } } },
+    });
+    let calls = 0;
+    options.ctx.transform = (schema) => {
+      if (!schema.required?.includes("required_string")) {
+        return undefined;
+      }
+      calls++;
+      return ts.factory.createTypeLiteralNode([
+        ts.factory.createPropertySignature(
+          undefined,
+          ts.factory.createIdentifier(`occurrence${calls}`),
+          undefined,
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+      ]);
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, sharedConstraint, sharedConstraint],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(calls).toBe(2);
+    expect(result).toContain("occurrence1: string");
+    expect(result).toContain("occurrence2: string");
+    expect(result).not.toContain("WithRequired");
+  });
+
+  test("allOf > completed callback aggregate supports keys spread across refs", () => {
+    const options = optionsWithSchemas({
+      First: { type: "object", properties: { first: { type: "string" } } },
+      Second: { type: "object", properties: { second: { type: "number" } } },
+    });
+    options.ctx.transform = () => undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [
+            { $ref: "#/components/schemas/First" },
+            { $ref: "#/components/schemas/Second" },
+            { type: "object", required: ["first", "second"] },
+          ],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe(
+      'WithRequiredObject<components["schemas"]["First"] & components["schemas"]["Second"], "first" | "second">\n',
+    );
+  });
+
+  test("allOf > parent required joins surviving typed callback constraint", () => {
+    const options = optionsWithSchemas({
+      Base: {
+        type: "object",
+        properties: { parent: { type: "number" }, constraint: { type: "boolean" } },
+      },
+    });
+    options.ctx.transform = () => undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          required: ["parent"],
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["constraint"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "parent" | "constraint">\n');
+  });
+
+  test("allOf > callback aggregate keeps parent required names absent from raw properties", () => {
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { constraint: { type: "boolean" } } },
+    });
+    options.ctx.transform = () => undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          required: ["callback_only"],
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["constraint"] }],
+        } as any,
+        options,
+      ),
+    ).trim();
+    const footer = astToString(options.ctx.injectFooter).trim();
+
+    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "callback_only" | "constraint">');
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Base: { constraint?: boolean } } }
+      ${footer}
+      type Generated = ${result};
+      const valid: Generated = { callback_only: "unknown is accepted", constraint: true };
+      // @ts-expect-error callback_only remains required even though it was absent from raw properties
+      const missingParent: Generated = { constraint: true };
+    `);
+  });
+
+  test("allOf > caller footer name conflict uses anonymous typed object constraint", () => {
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { required_string: { type: "string" } } },
+    });
+    options.ctx.injectFooter = stringToAST("interface WithRequiredObject { caller: true }") as ts.Node[];
+    options.ctx.transform = () => undefined;
+    let sawOuterConditional = false;
+    options.ctx.postTransform = (type) => {
+      if (ts.isConditionalTypeNode(type)) {
+        sawOuterConditional = true;
+      }
+      return type;
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    ).trim();
+
+    expect(result).not.toContain("WithRequiredObject<");
+    expect(result).toContain("extends infer U");
+    expect(sawOuterConditional).toBe(true);
+    expect(options.ctx.injectFooter).toHaveLength(1);
+    expectTypeScriptToCompile(`
+      interface components { schemas: { Base: { required_string?: string } } }
+      ${astToString(options.ctx.injectFooter)}
+      type Generated = ${result};
+      const valid: Generated = { required_string: "value" };
+      // @ts-expect-error required_string remains required
+      const invalid: Generated = {};
+    `);
+  });
+
+  test("allOf > unknown raw key remains ordinary callback member", () => {
+    let calls = 0;
+    const options = optionsWithSchemas({
+      Base: { type: "object", properties: { known: { type: "string" } } },
+    });
+    options.ctx.transform = () => {
+      calls++;
+      return undefined;
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["unknown"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Base"] & Record<string, never>\n');
+    expect(result).not.toContain("WithRequired");
+    expect(calls).toBe(1);
+  });
+
+  test("allOf > untyped callback constraint stays on the baseline path", () => {
+    const options = optionsWithSchemas({
+      Polymorphic: {
+        type: ["object", "string"],
+        properties: { required_string: { type: "string" } },
+      },
+    });
+    options.ctx.transform = () => undefined;
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe('components["schemas"]["Polymorphic"] & unknown\n');
+    expect(result).not.toContain("WithRequired");
+  });
+
+  test("discriminator > callback typed constraint preserves Omit ordering", () => {
+    const options = optionsWithSchemas({
+      parent: {
+        type: "object",
+        properties: { operation: { type: "string" }, name: { type: "string" } },
+      },
+    });
+    options.ctx.postTransform = (type) => type;
+    options.ctx.discriminators = {
+      objects: {
+        [DEFAULT_OPTIONS.path]: {
+          propertyName: "operation",
+          mapping: { test: DEFAULT_OPTIONS.path },
+        },
+        "#/components/schemas/parent": {
+          propertyName: "operation",
+          mapping: { test: DEFAULT_OPTIONS.path },
+        },
+      },
+      refsHandled: [],
+    };
+
+    const result = astToString(
+      transformSchemaObject(
+        {
+          type: "object",
+          allOf: [{ $ref: "#/components/schemas/parent" }, { type: "object", required: ["name"] }],
+        } as any,
+        options,
+      ),
+    );
+
+    expect(result).toBe(`WithRequiredObject<{
+    operation: "test";
+} & Omit<components["schemas"]["parent"], "operation">, "name">\n`);
+  });
+
   test("allOf > generated required constraint types compile", () => {
     const scrambleOptions = optionsWithSchemas({
       Base: {
@@ -1695,6 +2357,7 @@ function optionsWithSchemas(schemas: Record<string, any>) {
     ...DEFAULT_OPTIONS,
     ctx: {
       ...DEFAULT_OPTIONS.ctx,
+      injectFooter: [] as ts.Node[],
       resolve($ref: string) {
         const name = $ref.startsWith("#/components/schemas/") ? $ref.slice("#/components/schemas/".length) : undefined;
         return name ? schemas[name] : undefined;
@@ -1738,7 +2401,9 @@ function generateComponentsAndConstrainedType(
 function expectTypeScriptToCompile(source: string) {
   const fileName = "/required-constraint.test.ts";
   const compilerOptions: ts.CompilerOptions = {
+    exactOptionalPropertyTypes: true,
     module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
     noEmit: true,
     skipLibCheck: true,
     strict: true,

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { astToString, stringToAST } from "../../../src/lib/ts.js";
 import transformSchemaObject from "../../../src/transform/schema-object.js";
-import { DEFAULT_CTX, type TestCase } from "../../test-helpers.js";
+import { DEFAULT_CTX, expectTypeScriptToCompile, type TestCase } from "../../test-helpers.js";
 
 const DEFAULT_OPTIONS = {
   path: "#/components/schemas/schema-object",
@@ -582,7 +582,7 @@ describe("composition", () => {
       },
     ],
     [
-      "allOf > Scramble object required constraint",
+      "allOf > #1474 typed required-only constraint",
       {
         given: {
           allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
@@ -591,60 +591,53 @@ describe("composition", () => {
         options: optionsWithSchemas({
           Base: {
             type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > #1474 untyped required-only constraint",
+      {
+        given: {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+        },
+        want: `WithRequired<components["schemas"]["Base"], "required_string">`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+      },
+    ],
+    [
+      "allOf > aggregates parent, ref, inline, and repeated required keys",
+      {
+        given: {
+          type: "object",
+          properties: { core_id: { type: "string" } },
+          required: ["optional_number"],
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { $ref: "#/components/schemas/Details" },
+            { type: "object", properties: { inline_flag: { type: "boolean" } } },
+            { required: ["required_string", "detail_id", "inline_flag", "core_id"] },
+            { required: ["optional_number", "required_string"] },
+          ],
+        },
+        want: `{
+    core_id: string;
+} & (WithRequired<components["schemas"]["Base"], "optional_number" | "required_string"> & WithRequired<components["schemas"]["Details"], "detail_id"> & {
+    inline_flag: boolean;
+})`,
+        options: optionsWithSchemas({
+          Base: {
+            type: "object",
             properties: {
               required_string: { type: "string" },
               optional_number: { type: "number" },
             },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > annotations prevent required constraint classification",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              required: ["required_string"],
-              title: "Required base fields",
-              description: "This annotation does not change validation.",
-              $comment: "Required in this use of Base.",
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & unknown`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > required constraint across composed members",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            { $ref: "#/components/schemas/Details" },
-            {
-              type: "object",
-              properties: { inline_flag: { type: "boolean" } },
-            },
-            {
-              required: ["required_string", "detail_id", "inline_flag"],
-            },
-          ],
-        },
-        want: `WithRequired<components["schemas"]["Base"], "required_string"> & WithRequired<components["schemas"]["Details"], "detail_id"> & {
-    inline_flag: boolean;
-}`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
           },
           Details: {
             type: "object",
@@ -654,63 +647,7 @@ describe("composition", () => {
       },
     ],
     [
-      "allOf > parent and constraint required are combined and deduplicated",
-      {
-        given: {
-          required: ["optional_number", "required_string"],
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        },
-        want: `WithRequired<components["schemas"]["Base"], "optional_number" | "required_string">`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: {
-              required_string: { type: "string" },
-              optional_number: { type: "number" },
-            },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > required constraint applies to core and ref properties",
-      {
-        given: {
-          type: "object",
-          properties: { core_id: { type: "string" } },
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["core_id", "required_string"] }],
-        },
-        want: `{
-    core_id: string;
-} & WithRequired<components["schemas"]["Base"], "required_string">`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > required constraint discovers nested ref properties",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Derived" }, { required: ["required_string"] }],
-        },
-        want: `WithRequired<components["schemas"]["Derived"], "required_string">`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-          Derived: {
-            allOf: [{ $ref: "#/components/schemas/Base" }],
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > required constraint discovers properties through a recursive ref cycle",
+      "allOf > discovers required properties through a recursive ref cycle",
       {
         given: {
           allOf: [{ $ref: "#/components/schemas/RecursiveA" }, { type: "object", required: ["recursive_key"] }],
@@ -729,410 +666,7 @@ describe("composition", () => {
       },
     ],
     [
-      "allOf > multiple required constraints deduplicate keys",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            { required: ["required_string"] },
-            { required: ["optional_number", "required_string"] },
-          ],
-        },
-        want: `WithRequired<components["schemas"]["Base"], "required_string" | "optional_number">`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: {
-              required_string: { type: "string" },
-              optional_number: { type: "number" },
-            },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > typed required constraints do not prove object-likeness for each other",
-      {
-        given: {
-          allOf: [
-            {
-              properties: {
-                first: { type: "string" },
-                second: { type: "string" },
-              },
-            },
-            { type: "object", required: ["first"] },
-            { type: "object", required: ["second"] },
-          ],
-        },
-        want: `{
-    first?: string;
-    second?: string;
-} & Record<string, never> & Record<string, never>`,
-      },
-    ],
-    [
-      "allOf > typed required constraint does not erase a primitive composition",
-      {
-        given: {
-          allOf: [
-            {
-              type: "string",
-              properties: { required_string: { type: "string" } },
-            },
-            { type: "object", required: ["required_string"] },
-          ],
-        },
-        want: `string & Record<string, never>`,
-      },
-    ],
-    [
-      "allOf > typed required constraint with unknown key preserves its object assertion",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["unknown_property"] }],
-        },
-        want: `components["schemas"]["Base"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > untyped required constraint with mixed known and unknown keys is preserved",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string", "unknown_property"] }],
-        },
-        want: `components["schemas"]["Base"] & unknown`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > typed required constraint with mixed known and unknown keys is preserved",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            { type: "object", required: ["required_string", "unknown_property"] },
-          ],
-        },
-        want: `components["schemas"]["Base"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > polymorphic type array ref prevents untyped constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Polymorphic"] & unknown`,
-        options: optionsWithSchemas({
-          Polymorphic: {
-            type: ["object", "string"],
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > polymorphic type array ref prevents typed constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { type: "object", required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Polymorphic"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Polymorphic: {
-            type: ["object", "string"],
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > primitive ref properties do not make required keys discoverable",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Primitive" }, { required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Primitive"] & unknown`,
-        options: optionsWithSchemas({
-          Primitive: {
-            type: "string",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > const object ref prevents untyped constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Constant" }, { required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Constant"] & unknown`,
-        options: optionsWithSchemas({
-          Constant: {
-            type: "object",
-            const: {},
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > const object ref prevents typed constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Constant" }, { type: "object", required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Constant"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Constant: {
-            type: "object",
-            const: {},
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > early-return enum ref prevents constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Enumerated" }, { required: ["required_string"] }],
-        },
-        want: `components["schemas"]["Enumerated"] & unknown`,
-        options: optionsWithSchemas({
-          Enumerated: {
-            enum: ["fixed"],
-            allOf: [
-              {
-                type: "object",
-                properties: { required_string: { type: "string" } },
-              },
-            ],
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > nullable object ref does not prove typed constraint object-likeness",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/NullableBase" }, { type: "object", required: ["required_string"] }],
-        },
-        want: `components["schemas"]["NullableBase"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          NullableBase: {
-            type: ["object", "null"],
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > outer anyOf prevents required constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
-          anyOf: [{ type: "string" }],
-        },
-        want: `(components["schemas"]["Base"] & unknown) | string`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > outer oneOf prevents required constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
-          oneOf: [{ type: "object", properties: { variant: { type: "string" } } }],
-        },
-        want: `(components["schemas"]["Base"] & unknown) & {
-    variant?: string;
-}`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > excludeDeprecated prevents required constraint translation",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["deprecated_key"] }],
-        },
-        want: `components["schemas"]["Base"] & unknown`,
-        options: {
-          ...optionsWithSchemas({
-            Base: {
-              type: "object",
-              properties: { deprecated_key: { type: "string", deprecated: true } },
-            },
-          }),
-          ctx: {
-            ...optionsWithSchemas({
-              Base: {
-                type: "object",
-                properties: { deprecated_key: { type: "string", deprecated: true } },
-              },
-            }).ctx,
-            excludeDeprecated: true,
-          },
-        },
-      },
-    ],
-    [
-      "allOf > explicit additionalProperties false is not a required-only constraint",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              type: "object",
-              required: ["required_string"],
-              additionalProperties: false,
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > member with properties remains an ordinary intersection",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              type: "object",
-              required: ["inline_flag"],
-              properties: { inline_flag: { type: "boolean" } },
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & {
-    inline_flag: boolean;
-}`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > member with another validation keyword remains an ordinary intersection",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              type: "object",
-              required: ["required_string"],
-              minProperties: 1,
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & Record<string, never>`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > nullable object type union is not a required-only constraint",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              type: ["object", "null"],
-              required: ["required_string"],
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & (Record<string, never> | null)`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > vendor extension prevents required constraint classification",
-      {
-        given: {
-          allOf: [
-            { $ref: "#/components/schemas/Base" },
-            {
-              required: ["required_string"],
-              "x-validation-behavior": true,
-            },
-          ],
-        },
-        want: `components["schemas"]["Base"] & unknown`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "allOf > unknown required constraint name preserves the member",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["unknown_property"] }],
-        },
-        want: `components["schemas"]["Base"] & unknown`,
-        options: optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      },
-    ],
-    [
-      "discriminator > allOf required constraint uses ref required handling before Omit",
+      "discriminator > applies required constraint before Omit",
       {
         given: {
           type: "object",
@@ -1159,53 +693,17 @@ describe("composition", () => {
               refsHandled: [],
             },
             resolve($ref) {
-              if ($ref === "#/components/schemas/parent") {
-                return {
-                  type: "object",
-                  properties: {
-                    operation: { type: "string" },
-                    name: { type: "string" },
-                  },
-                };
-              }
-              return undefined as any;
-            },
-          },
-        },
-      },
-    ],
-    [
-      "discriminator > handled ref keeps translated non-discriminator required key",
-      {
-        given: {
-          allOf: [{ $ref: "#/components/schemas/parent" }, { required: ["name"] }],
-        },
-        want: `Omit<WithRequired<components["schemas"]["parent"], "name">, "operation">`,
-        options: {
-          ...DEFAULT_OPTIONS,
-          ctx: {
-            ...DEFAULT_OPTIONS.ctx,
-            discriminators: {
-              objects: {
-                "#/components/schemas/parent": {
-                  propertyName: "operation",
-                  mapping: { test: DEFAULT_OPTIONS.path },
-                },
-              },
-              refsHandled: ["#/components/schemas/parent"],
-            },
-            resolve($ref) {
-              if ($ref === "#/components/schemas/parent") {
-                return {
-                  type: "object",
-                  required: ["operation"],
-                  properties: {
-                    operation: { type: "string", enum: ["test"] },
-                    name: { type: "string" },
-                  },
-                };
-              }
-              return undefined as any;
+              return (
+                $ref === "#/components/schemas/parent"
+                  ? {
+                      type: "object",
+                      properties: {
+                        operation: { type: "string" },
+                        name: { type: "string" },
+                      },
+                    }
+                  : undefined
+              ) as any;
             },
           },
         },
@@ -1259,663 +757,347 @@ describe("composition", () => {
       ci?.timeout,
     );
   }
-
-  for (const [keyword, value] of [
-    ["default", { required_string: "default" }],
-    ["readOnly", true],
-    ["writeOnly", true],
-    ["deprecated", true],
-    ["examples", [{ required_string: "example" }]],
-    ["example", { required_string: "legacy example" }],
-  ] as const) {
-    test(`allOf > ${keyword} prevents required constraint classification`, () => {
-      const result = astToString(
-        transformSchemaObject(
-          {
-            allOf: [
-              { $ref: "#/components/schemas/Base" },
-              {
-                type: "object",
-                required: ["required_string"],
-                [keyword]: value,
-              },
-            ],
-          } as any,
-          optionsWithSchemas({
-            Base: {
-              type: "object",
-              properties: { required_string: { type: "string" } },
-            },
-          }),
-        ),
+  test("allOf > preserves unsafe required-only constraints", () => {
+    const transformPropertyOptions: any = { ...DEFAULT_OPTIONS, ctx: { ...DEFAULT_OPTIONS.ctx } };
+    transformPropertyOptions.ctx.transformProperty = (property: ts.PropertySignature) =>
+      ts.factory.updatePropertySignature(
+        property,
+        property.modifiers,
+        ts.factory.createIdentifier("renamed"),
+        property.questionToken,
+        property.type,
       );
-
-      expect(result).toBe('components["schemas"]["Base"] & Record<string, never>\n');
-    });
-  }
-
-  test("allOf > transform callback replacement prevents constraint translation", () => {
-    let transformCalls = 0;
-    let postTransformCalls = 0;
-    const options = optionsWithSchemas({
+    const deprecatedOptions = optionsWithSchemas({
       Base: {
         type: "object",
-        properties: { required_string: { type: "string" } },
+        properties: { deprecated_key: { type: "string", deprecated: true } },
       },
     });
-    options.ctx.transform = () => {
-      transformCalls++;
-      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-    };
-    options.ctx.postTransform = () => void postTransformCalls++;
+    deprecatedOptions.ctx.excludeDeprecated = true;
 
-    const result = astToString(
-      transformSchemaObject(
+    const cases: [string, any, any, string][] = [
+      [
+        "extra validation keyword",
+        {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { type: "object", required: ["required_string"], minProperties: 1 },
+          ],
+        },
+        baseOptions(),
+        'components["schemas"]["Base"] & Record<string, never>',
+      ],
+      [
+        "unknown typed key",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["unknown"] }],
+        },
+        baseOptions(),
+        'components["schemas"]["Base"] & Record<string, never>',
+      ],
+      [
+        "unknown untyped key",
+        { allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["unknown"] }] },
+        baseOptions(),
+        'components["schemas"]["Base"] & unknown',
+      ],
+      [
+        "no retained object assertion",
+        {
+          allOf: [
+            { properties: { required_string: { type: "string" } } },
+            { type: "object", required: ["required_string"] },
+          ],
+        },
+        DEFAULT_OPTIONS,
+        `{
+    required_string?: string;
+} & Record<string, never>`,
+      ],
+      [
+        "mixed known/unknown typed and untyped keys",
+        {
+          allOf: [
+            { $ref: "#/components/schemas/Base" },
+            { type: "object", required: ["required_string", "unknown"] },
+            { required: ["required_string", "unknown"] },
+          ],
+        },
+        baseOptions(),
+        'components["schemas"]["Base"] & Record<string, never> & unknown',
+      ],
+      [
+        "nullable ref",
         {
           allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('components["schemas"]["Base"] & number\n');
-    expect(transformCalls).toBe(1);
-    expect(postTransformCalls).toBe(3);
-  });
-
-  test("allOf > postTransform callback replacement prevents constraint translation", () => {
-    const options = optionsWithSchemas({
-      Base: {
-        type: "object",
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    options.ctx.postTransform = (type) =>
-      ts.isTypeReferenceNode(type) && ts.isIdentifier(type.typeName) && type.typeName.text === "Record"
-        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
-        : undefined;
-
-    const result = astToString(
-      transformSchemaObject(
+        },
+        optionsWithSchemas({
+          Base: {
+            type: ["object", "null"],
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+        'components["schemas"]["Base"] & Record<string, never>',
+      ],
+      [
+        "polymorphic ref",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+        },
+        optionsWithSchemas({
+          Base: {
+            type: ["object", "string"],
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+        'components["schemas"]["Base"] & unknown',
+      ],
+      [
+        "const ref",
         {
           allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
+        },
+        optionsWithSchemas({
+          Base: {
+            type: "object",
+            const: {},
+            properties: { required_string: { type: "string" } },
+          },
+        }),
+        'components["schemas"]["Base"] & Record<string, never>',
+      ],
+      [
+        "enum ref",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+        },
+        optionsWithSchemas({
+          Base: {
+            enum: ["fixed"],
+            allOf: [{ type: "object", properties: { required_string: { type: "string" } } }],
+          },
+        }),
+        'components["schemas"]["Base"] & unknown',
+      ],
+      [
+        "outer anyOf",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+          anyOf: [{ type: "string" }],
+        },
+        baseOptions(),
+        '(components["schemas"]["Base"] & unknown) | string',
+      ],
+      [
+        "outer oneOf",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
+          oneOf: [{ type: "object", properties: { variant: { type: "string" } } }],
+        },
+        baseOptions(),
+        `(components["schemas"]["Base"] & unknown) & {
+    variant?: string;
+}`,
+      ],
+      [
+        "transformProperty",
+        {
+          allOf: [{ type: "object", properties: { original: { type: "string" } } }, { required: ["original"] }],
+        },
+        transformPropertyOptions,
+        `{
+    renamed?: string;
+} & unknown`,
+      ],
+      [
+        "excludeDeprecated",
+        {
+          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["deprecated_key"] }],
+        },
+        deprecatedOptions,
+        'components["schemas"]["Base"] & unknown',
+      ],
+    ];
 
-    expect(result).toBe('components["schemas"]["Base"] & number\n');
+    for (const [name, schema, options, want] of cases) {
+      expect(astToString(transformSchemaObject(schema, options)).trim(), name).toBe(want);
+    }
   });
 
-  test("allOf > unrelated transform callback keeps concise typed constraint output", () => {
+  test("allOf > callback lifecycle preserves reused occurrence order and identity", () => {
+    const sharedConstraint = { type: "object", required: ["required_string"] } as const;
+    const schema = { allOf: [{ $ref: "#/components/schemas/Base" }, sharedConstraint, sharedConstraint] };
+    const identityOptions = baseOptions();
     const calls: string[] = [];
-    const options = optionsWithSchemas({
-      Base: {
-        type: "object",
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    options.ctx.transform = (schema) => {
-      calls.push(schema.required?.includes("required_string") ? "constraint" : "other");
+    const postCalls: string[] = [];
+    identityOptions.ctx.transform = (item, options) => {
+      calls.push(`${options.path}:${item.required?.join(",")}`);
       return undefined;
     };
+    identityOptions.ctx.postTransform = (type) => {
+      postCalls.push(astToString(type).trim());
+      return type;
+    };
 
-    const result = astToString(
+    expect(astToString(transformSchemaObject(schema as any, identityOptions)).trim()).toBe(
+      'WithRequiredObject<components["schemas"]["Base"], "required_string">',
+    );
+    expect(calls).toEqual([`${identityOptions.path}:required_string`, `${identityOptions.path}:required_string`]);
+    expect(postCalls).toEqual([
+      'components["schemas"]["Base"]',
+      "Record<string, never>",
+      "Record<string, never>",
+      'WithRequiredObject<components["schemas"]["Base"], "required_string">',
+    ]);
+
+    const replacementOptions = baseOptions();
+    let occurrence = 0;
+    replacementOptions.ctx.transform = (item) =>
+      item.required?.includes("required_string")
+        ? objectType({ [`occurrence${++occurrence}`]: ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword) })
+        : undefined;
+    const replaced = astToString(transformSchemaObject(schema as any, replacementOptions));
+    expect(occurrence).toBe(2);
+    expect(replaced).toContain("occurrence1: string");
+    expect(replaced).toContain("occurrence2: string");
+    expect(replaced).not.toContain("WithRequired");
+  });
+
+  test.each(["transform", "postTransform"] as const)("allOf > thrown %s propagates", (hook) => {
+    const options = baseOptions();
+    const callback = () => {
+      throw new Error(hook);
+    };
+    if (hook === "transform") {
+      options.ctx.transform = callback;
+    } else {
+      options.ctx.postTransform = callback;
+    }
+    expect(() =>
       transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
+        { allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }] } as any,
         options,
       ),
-    );
-
-    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
-    expect(calls).toEqual(["constraint"]);
-    expect(astToString(options.ctx.injectFooter).match(/type WithRequiredObject</g)).toHaveLength(1);
+    ).toThrow(hook);
   });
 
-  test("allOf > outer object core retains typed callback constraint", () => {
-    const schema = {
-      type: "object",
-      properties: { value: { type: "string" } },
-      allOf: [{ type: "object", required: ["value"] }],
+  test("allOf > callback replacements remain authoritative", () => {
+    const baseSchema = {
+      allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
     };
-    const generated = generateComponentsAndConstrainedType({}, schema, (options) => {
-      options.ctx.transform = () => undefined;
-    });
-
-    expect(generated.generated).toBe(`WithRequiredObject<{
-    value?: string;
-}, "value">`);
-    expectTypeScriptToCompile(`${generated.source}
-      const valid: Generated = { value: "value" };
-      // @ts-expect-error the typed sibling makes the core property required
-      const invalid: Generated = {};
-    `);
-
-    const noCallback = generateComponentsAndConstrainedType({}, schema);
-    expect(noCallback.generated).toBe(`{
-    value?: string;
-} & Record<string, never>`);
-  });
-
-  test("allOf > outer object core retains typed constraint with identity postTransform", () => {
-    const generated = generateComponentsAndConstrainedType(
-      {},
-      {
-        type: "object",
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-      },
-      (options) => {
-        options.ctx.postTransform = (type) => type;
-      },
-    );
-
-    expect(generated.generated).toBe(`WithRequiredObject<{
-    value?: string;
-}, "value">`);
-    expectTypeScriptToCompile(`${generated.source}
-      const valid: Generated = { value: "value" };
-      // @ts-expect-error identity observation does not remove the sibling assertion
-      const invalid: Generated = {};
-    `);
-  });
-
-  test("allOf > typed sibling constrains a callback-replaced outer object core", () => {
-    const replacement = ts.factory.createTypeLiteralNode([
-      ts.factory.createPropertySignature(
-        undefined,
-        "other",
-        undefined,
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
-      ),
-    ]);
-    const generated = generateComponentsAndConstrainedType(
-      {},
-      {
-        type: "object",
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-      },
-      (options) => {
-        options.ctx.transform = (schema) => ("properties" in schema && schema.properties ? replacement : undefined);
-      },
-    );
-
-    expect(generated.generated).toBe(`WithRequiredObject<{
-    other: number;
-}, "value">`);
-    expectTypeScriptToCompile(`${generated.source}
-      const valid: Generated = { other: 1, value: "required unknown" };
-      // @ts-expect-error callback replacement does not erase the untouched typed sibling
-      const invalid: Generated = { other: 1 };
-    `);
-  });
-
-  test.each([
-    ["primitive", ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)],
-    ["array", ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword))],
-  ])("allOf > typed sibling rejects a callback-replaced %s outer core", (_label, replacement) => {
-    const generated = generateComponentsAndConstrainedType(
-      {},
-      {
-        type: "object",
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-      },
-      (options) => {
-        options.ctx.transform = (schema) => ("properties" in schema && schema.properties ? replacement : undefined);
-      },
-    );
-
-    expect(generated.generated).toContain("WithRequiredObject<");
-    expectTypeScriptToCompile(`${generated.source}
-      type IsNever<T> = [T] extends [never] ? true : false;
-      const isNever: IsNever<Generated> = true;
-      // @ts-expect-error the untouched type: object sibling rejects non-object callback output
-      const invalid: Generated = ${_label === "array" ? "[]" : '"value"'};
-    `);
-  });
-
-  test("allOf > outer object core supports partial typed member replacement", () => {
-    const generated = generateComponentsAndConstrainedType(
-      {},
-      {
-        type: "object",
-        properties: { first: { type: "string" }, second: { type: "number" } },
-        allOf: [
-          { type: "object", required: ["first"] },
-          { type: "object", required: ["second"] },
-        ],
-      },
-      (options) => {
-        options.ctx.transform = (schema) =>
-          schema.required?.includes("first")
-            ? ts.factory.createTypeLiteralNode([
-                ts.factory.createPropertySignature(
-                  undefined,
-                  "replacement",
-                  undefined,
-                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
-                ),
-              ])
-            : undefined;
-      },
-    );
-
-    expect(generated.generated).toBe(`WithRequiredObject<{
+    const cases: [string, any, any, (options: ReturnType<typeof optionsWithSchemas>) => void, string][] = [
+      [
+        "transform replacement",
+        baseSchema,
+        { Base: BASE_SCHEMA },
+        (options) => {
+          options.ctx.transform = () => ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+        },
+        'components["schemas"]["Base"] & number',
+      ],
+      [
+        "postTransform replacement",
+        baseSchema,
+        { Base: BASE_SCHEMA },
+        (options) => {
+          options.ctx.postTransform = (type) =>
+            astToString(type).trim() === "Record<string, never>"
+              ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+              : undefined;
+        },
+        'components["schemas"]["Base"] & number',
+      ],
+      [
+        "partial typed-constraint replacement",
+        {
+          type: "object",
+          properties: { first: { type: "string" }, second: { type: "number" } },
+          allOf: [
+            { type: "object", required: ["first"] },
+            { type: "object", required: ["second"] },
+          ],
+        },
+        {},
+        (options) => {
+          options.ctx.transform = (schema) =>
+            schema.required?.includes("first")
+              ? objectType({ replacement: ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword) })
+              : undefined;
+        },
+        `WithRequiredObject<{
     first?: string;
     second?: number;
 } & {
     replacement: boolean;
-}, "second">`);
-    expectTypeScriptToCompile(`${generated.source}
-      const valid: Generated = { replacement: true, second: 1 };
-      // @ts-expect-error the untouched second constraint is still applied
-      const missingSecond: Generated = { replacement: true };
-      // @ts-expect-error the replacement remains authoritative
-      const missingReplacement: Generated = { second: 1 };
-    `);
+}, "second">`,
+      ],
+      [
+        "untyped callback baseline",
+        { allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }] },
+        { Base: BASE_SCHEMA },
+        (options) => {
+          options.ctx.transform = () => undefined;
+        },
+        'components["schemas"]["Base"] & unknown',
+      ],
+      [
+        "ref postTransform replacement",
+        baseSchema,
+        { Base: BASE_SCHEMA },
+        (options) => {
+          options.ctx.postTransform = (type) =>
+            astToString(type).trim() === 'components["schemas"]["Base"]'
+              ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+              : undefined;
+        },
+        'WithRequiredObject<number, "required_string">',
+      ],
+    ];
+
+    for (const [name, schema, schemas, configure, want] of cases) {
+      const options = optionsWithSchemas(schemas);
+      configure(options);
+      expect(astToString(transformSchemaObject(schema, options)).trim(), name).toBe(want);
+    }
   });
 
-  test.each([
-    [
-      "nullable",
-      {
+  test("discriminator > callback handled ref keeps non-discriminator required key through Omit", () => {
+    const options = optionsWithSchemas({
+      parent: {
         type: "object",
-        nullable: true,
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
+        required: ["operation"],
+        properties: { operation: { type: "string", enum: ["test"] }, name: { type: "string" } },
       },
-    ],
-    [
-      "type array",
-      {
-        type: ["object", "string"],
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-      },
-    ],
-    [
-      "anyOf union",
-      {
-        type: "object",
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-        anyOf: [{ type: "string" }],
-      },
-    ],
-    [
-      "oneOf union",
-      {
-        type: "object",
-        properties: { value: { type: "string" } },
-        allOf: [{ type: "object", required: ["value"] }],
-        oneOf: [{ type: "string" }],
-      },
-    ],
-  ])("allOf > unsafe %s core does not prove exact callback object semantics", (_label, schema) => {
-    const generated = generateComponentsAndConstrainedType({}, schema, (options) => {
-      options.ctx.transform = () => undefined;
     });
-
-    expect(generated.generated).not.toContain("WithRequiredObject");
-    expect(generated.generated).toContain("Record<string, never>");
-    expectTypeScriptToCompile(`${generated.source}
-      declare const generated: Generated;
-      const assignment: unknown = generated;
-    `);
-  });
-
-  test("discriminator > synthesized outer core property remains in callback aggregate", () => {
-    const generated = generateComponentsAndConstrainedType(
-      {},
-      {
-        type: "object",
-        properties: { name: { type: "string" } },
-        allOf: [{ type: "object", required: ["name"] }],
-      },
-      (options) => {
-        options.ctx.transform = () => undefined;
-        options.ctx.discriminators = {
-          objects: {
-            [options.path ?? DEFAULT_OPTIONS.path]: { propertyName: "operation" },
-          },
-          refsHandled: [],
-        };
-      },
-    );
-
-    expect(generated.generated).toBe(`WithRequiredObject<{
-    operation: "schema-object";
-    name?: string;
-}, "name">`);
-    expectTypeScriptToCompile(`${generated.source}
-      const valid: Generated = { operation: "schema-object", name: "value" };
-      // @ts-expect-error synthesized discriminator does not replace the required name assertion
-      const invalid: Generated = { operation: "schema-object" };
-    `);
-  });
-
-  test("allOf > generated callback object helper has typed object semantics", () => {
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { value: { type: "string" } } },
-    });
-    options.ctx.transform = () => undefined;
-    transformSchemaObject(
-      {
-        allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["value"] }],
-      } as any,
-      options,
-    );
-    const helper = astToString(options.ctx.injectFooter).trim();
-
-    expect(helper.match(/type WithRequiredObject</g)).toHaveLength(1);
-    expectTypeScriptToCompile(`
-      ${helper}
-
-      type Optional = WithRequiredObject<{ value?: string }, "value">;
-      const optional: Optional = { value: "value" };
-      // @ts-expect-error implicit optional undefined is removed
-      const optionalUndefined: Optional = { value: undefined };
-
-      type ExplicitUndefined = WithRequiredObject<{ value?: string | undefined }, "value">;
-      const explicitUndefined: ExplicitUndefined = { value: undefined };
-
-      type ReadonlyValue = WithRequiredObject<{ readonly value?: string }, "value">;
-      const readonlyValue: ReadonlyValue = { value: "value" };
-      // @ts-expect-error readonly is preserved
-      readonlyValue.value = "other";
-
-      type Union = WithRequiredObject<{ value?: string } | { other: number }, "value">;
-      const unionKnown: Union = { value: "value" };
-      const unionMissing: Union = { other: 1, value: true };
-      // @ts-expect-error every object branch requires value
-      const unionInvalid: Union = { other: 1 };
-
-      declare const symbolKey: unique symbol;
-      type StringIndex = WithRequiredObject<{ [key: string]: number | undefined }, "value">;
-      type NumberIndex = WithRequiredObject<{ [key: number]: string | undefined }, 1>;
-      type SymbolIndex = WithRequiredObject<{ [key: symbol]: boolean | undefined }, typeof symbolKey>;
-      const stringIndex: StringIndex = { value: 1 };
-      const numberIndex: NumberIndex = { 1: "value" };
-      const symbolIndex: SymbolIndex = { [symbolKey]: true };
-
-      type Missing = WithRequiredObject<{ other: number }, "value">;
-      const missing: Missing = { other: 1, value: "anything" };
-      // @ts-expect-error a callback-removed key remains required
-      const missingInvalid: Missing = { other: 1 };
-
-      type UnknownValue = WithRequiredObject<unknown, "value">;
-      type AnyValue = WithRequiredObject<any, "value">;
-      const unknownValue: UnknownValue = { value: 1 };
-      const anyValue: AnyValue = { value: 1 };
-      // @ts-expect-error unknown still requires the key
-      const unknownInvalid: UnknownValue = {};
-      // @ts-expect-error any does not erase required presence
-      const anyInvalid: AnyValue = {};
-
-      type Primitive = WithRequiredObject<string | null, "value">;
-      type ArrayValue = WithRequiredObject<readonly string[], "value">;
-      type Callable = WithRequiredObject<() => string, "value">;
-      type Constructor = WithRequiredObject<abstract new () => object, "value">;
-      type GlobalFunction = WithRequiredObject<Function, "value">;
-      type Nothing = WithRequiredObject<never, "value">;
-      // @ts-expect-error primitives become never
-      const primitive: Primitive = "value";
-      // @ts-expect-error arrays become never
-      const arrayValue: ArrayValue = Object.assign([], { value: 1 });
-      // @ts-expect-error callables become never
-      const callable: Callable = Object.assign(() => "value", { value: 1 });
-      // @ts-expect-error constructors become never
-      const constructorValue: Constructor = Object.assign(class {}, { value: 1 });
-      // Nominal Function has no call/construct signature and remains structurally indistinguishable from an object.
-      const globalFunction: GlobalFunction = Object.assign(() => "value", { value: 1 });
-      // @ts-expect-error never remains never
-      const nothing: Nothing = { value: 1 };
-    `);
-  });
-
-  test("allOf > required-only transform replacement is authoritative", () => {
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { required_string: { type: "string" } } },
-    });
-    options.ctx.transform = (schema) =>
-      schema.required?.includes("required_string")
-        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
-        : undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('components["schemas"]["Base"] & number\n');
-  });
-
-  test("allOf > required-only postTransform replacement is authoritative", () => {
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { required_string: { type: "string" } } },
-    });
-    options.ctx.postTransform = (type) =>
-      ts.isTypeReferenceNode(type) && ts.isIdentifier(type.typeName) && type.typeName.text === "Record"
-        ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
-        : undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('components["schemas"]["Base"] & number\n');
-  });
-
-  test("allOf > identity postTransform translates typed constraint and sees final helper", () => {
-    const calls: string[] = [];
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { required_string: { type: "string" } } },
-    });
-    options.ctx.postTransform = (type) => {
-      calls.push(astToString(type).trim());
-      return type;
+    options.ctx.postTransform = (type) => type;
+    options.ctx.discriminators = {
+      objects: { "#/components/schemas/parent": { propertyName: "operation" } },
+      refsHandled: ["#/components/schemas/parent"],
     };
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
-    expect(calls).toEqual([
-      'components["schemas"]["Base"]',
-      "Record<string, never>",
-      'WithRequiredObject<components["schemas"]["Base"], "required_string">',
-    ]);
-  });
-
-  test("allOf > callback order options and occurrence counts remain unchanged", () => {
-    const sharedConstraint = { type: "object", required: ["required_string"] } as const;
-    const schemas = { Base: { type: "object", properties: { required_string: { type: "string" } } } };
-    const schema = {
-      allOf: [{ $ref: "#/components/schemas/Base" }, sharedConstraint, sharedConstraint],
-    };
-    const baselineOptions = optionsWithSchemas(schemas);
-    const baselineCalls: string[] = [];
-    baselineOptions.ctx.transform = (item, callbackOptions) => {
-      baselineCalls.push(
-        `${callbackOptions.path}:${item.required?.includes("required_string") ? "constraint" : "other"}`,
-      );
-      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-    };
-    const baseline = astToString(transformSchemaObject(schema as any, baselineOptions));
-
-    const optimizedOptions = optionsWithSchemas(schemas);
-    const optimizedCalls: string[] = [];
-    optimizedOptions.ctx.transform = (item, callbackOptions) => {
-      optimizedCalls.push(
-        `${callbackOptions.path}:${item.required?.includes("required_string") ? "constraint" : "other"}`,
-      );
-      return undefined;
-    };
-    const optimized = astToString(transformSchemaObject(schema as any, optimizedOptions));
-
-    expect(baseline).toBe('components["schemas"]["Base"] & number\n');
-    expect(optimized).toBe('WithRequiredObject<components["schemas"]["Base"], "required_string">\n');
-    expect(optimizedCalls).toEqual(baselineCalls);
-    expect(optimizedCalls).toEqual([`${optimizedOptions.path}:constraint`, `${optimizedOptions.path}:constraint`]);
-  });
-
-  test("allOf > repeated object occurrences keep stateful callback results", () => {
-    const sharedConstraint = { type: "object", required: ["required_string"] } as const;
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { required_string: { type: "string" } } },
-    });
-    let calls = 0;
-    options.ctx.transform = (schema) => {
-      if (!schema.required?.includes("required_string")) {
-        return undefined;
-      }
-      calls++;
-      return ts.factory.createTypeLiteralNode([
-        ts.factory.createPropertySignature(
-          undefined,
-          ts.factory.createIdentifier(`occurrence${calls}`),
-          undefined,
-          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    expect(
+      astToString(
+        transformSchemaObject(
+          {
+            allOf: [{ $ref: "#/components/schemas/parent" }, { type: "object", required: ["name"] }],
+          } as any,
+          options,
         ),
-      ]);
-    };
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, sharedConstraint, sharedConstraint],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(calls).toBe(2);
-    expect(result).toContain("occurrence1: string");
-    expect(result).toContain("occurrence2: string");
-    expect(result).not.toContain("WithRequired");
+      ).trim(),
+    ).toBe('WithRequiredObject<Omit<components["schemas"]["parent"], "operation">, "name">');
   });
 
-  test("allOf > completed callback aggregate supports keys spread across refs", () => {
-    const options = optionsWithSchemas({
-      First: { type: "object", properties: { first: { type: "string" } } },
-      Second: { type: "object", properties: { second: { type: "number" } } },
-    });
-    options.ctx.transform = () => undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [
-            { $ref: "#/components/schemas/First" },
-            { $ref: "#/components/schemas/Second" },
-            { type: "object", required: ["first", "second"] },
-          ],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe(
-      'WithRequiredObject<components["schemas"]["First"] & components["schemas"]["Second"], "first" | "second">\n',
-    );
-  });
-
-  test("allOf > parent required joins surviving typed callback constraint", () => {
-    const options = optionsWithSchemas({
-      Base: {
-        type: "object",
-        properties: { parent: { type: "number" }, constraint: { type: "boolean" } },
-      },
-    });
-    options.ctx.transform = () => undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          required: ["parent"],
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["constraint"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "parent" | "constraint">\n');
-  });
-
-  test("allOf > callback aggregate keeps parent required names absent from raw properties", () => {
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { constraint: { type: "boolean" } } },
-    });
-    options.ctx.transform = () => undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          required: ["callback_only"],
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["constraint"] }],
-        } as any,
-        options,
-      ),
-    ).trim();
-    const footer = astToString(options.ctx.injectFooter).trim();
-
-    expect(result).toBe('WithRequiredObject<components["schemas"]["Base"], "callback_only" | "constraint">');
-    expectTypeScriptToCompile(`
-      interface components { schemas: { Base: { constraint?: boolean } } }
-      ${footer}
-      type Generated = ${result};
-      const valid: Generated = { callback_only: "unknown is accepted", constraint: true };
-      // @ts-expect-error callback_only remains required even though it was absent from raw properties
-      const missingParent: Generated = { constraint: true };
-    `);
-  });
-
-  test("allOf > caller footer name conflict uses anonymous typed object constraint", () => {
-    const options = optionsWithSchemas({
-      Base: { type: "object", properties: { required_string: { type: "string" } } },
-    });
+  test("allOf > footer helper conflict uses the inline object constraint", () => {
+    const options = baseOptions();
     options.ctx.injectFooter = stringToAST("interface WithRequiredObject { caller: true }") as ts.Node[];
     options.ctx.transform = () => undefined;
-    let sawOuterConditional = false;
-    options.ctx.postTransform = (type) => {
-      if (ts.isConditionalTypeNode(type)) {
-        sawOuterConditional = true;
-      }
-      return type;
-    };
-
     const result = astToString(
       transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
+        { allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }] } as any,
         options,
       ),
     ).trim();
-
     expect(result).not.toContain("WithRequiredObject<");
-    expect(result).toContain("extends infer U");
-    expect(sawOuterConditional).toBe(true);
-    expect(options.ctx.injectFooter).toHaveLength(1);
+    expect(astToString(options.ctx.injectFooter)).not.toContain("type WithRequiredObject<");
     expectTypeScriptToCompile(`
       interface components { schemas: { Base: { required_string?: string } } }
       ${astToString(options.ctx.injectFooter)}
@@ -1926,429 +1108,67 @@ describe("composition", () => {
     `);
   });
 
-  test("allOf > unknown raw key remains ordinary callback member", () => {
-    let calls = 0;
+  test("allOf > completed callback aggregate combines refs, parent keys, and callback output", () => {
     const options = optionsWithSchemas({
-      Base: { type: "object", properties: { known: { type: "string" } } },
+      First: { type: "object", properties: { first: { type: "string" } } },
+      Second: { type: "object", properties: { second: { type: "number" } } },
     });
-    options.ctx.transform = () => {
-      calls++;
-      return undefined;
-    };
+    options.ctx.transform = (schema) =>
+      "properties" in schema && schema.properties?.callback_value
+        ? objectType({ callback_value: ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword) }, true)
+        : undefined;
 
     const result = astToString(
       transformSchemaObject(
         {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["unknown"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('components["schemas"]["Base"] & Record<string, never>\n');
-    expect(result).not.toContain("WithRequired");
-    expect(calls).toBe(1);
-  });
-
-  test("allOf > untyped callback constraint stays on the baseline path", () => {
-    const options = optionsWithSchemas({
-      Polymorphic: {
-        type: ["object", "string"],
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    options.ctx.transform = () => undefined;
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe('components["schemas"]["Polymorphic"] & unknown\n');
-    expect(result).not.toContain("WithRequired");
-  });
-
-  test("discriminator > callback typed constraint preserves Omit ordering", () => {
-    const options = optionsWithSchemas({
-      parent: {
-        type: "object",
-        properties: { operation: { type: "string" }, name: { type: "string" } },
-      },
-    });
-    options.ctx.postTransform = (type) => type;
-    options.ctx.discriminators = {
-      objects: {
-        [DEFAULT_OPTIONS.path]: {
-          propertyName: "operation",
-          mapping: { test: DEFAULT_OPTIONS.path },
-        },
-        "#/components/schemas/parent": {
-          propertyName: "operation",
-          mapping: { test: DEFAULT_OPTIONS.path },
-        },
-      },
-      refsHandled: [],
-    };
-
-    const result = astToString(
-      transformSchemaObject(
-        {
-          type: "object",
-          allOf: [{ $ref: "#/components/schemas/parent" }, { type: "object", required: ["name"] }],
-        } as any,
-        options,
-      ),
-    );
-
-    expect(result).toBe(`WithRequiredObject<{
-    operation: "test";
-} & Omit<components["schemas"]["parent"], "operation">, "name">\n`);
-  });
-
-  test("allOf > generated required constraint types compile", () => {
-    const scrambleOptions = optionsWithSchemas({
-      Base: {
-        type: "object",
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    const scramble = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        scrambleOptions,
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-      interface components { schemas: { Base: { required_string?: string } } }
-      type Generated = ${scramble};
-      const valid: Generated = { required_string: "value" };
-      // @ts-expect-error required_string is required
-      const invalid: Generated = {};
-    `);
-
-    const untyped = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
-        } as any,
-        optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-      interface components { schemas: { Base: { required_string?: string } } }
-      type Generated = ${untyped};
-      const valid: Generated = { required_string: "value" };
-      // @ts-expect-error required_string is required
-      const invalid: Generated = {};
-    `);
-
-    const nullableOptions = optionsWithSchemas({
-      NullableBase: {
-        type: ["object", "null"],
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    const nullable = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/NullableBase" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        nullableOptions,
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      interface components { schemas: { NullableBase: { required_string?: string } | null } }
-      type Generated = ${nullable};
-      // @ts-expect-error the retained typed constraint remains unassignable
-      const invalid: Generated = { required_string: "value" };
-    `);
-
-    const deprecatedOptions = optionsWithSchemas({
-      Base: {
-        type: "object",
-        properties: { deprecated_key: { type: "string", deprecated: true } },
-      },
-    });
-    deprecatedOptions.ctx.excludeDeprecated = true;
-    const deprecated = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["deprecated_key"] }],
-        } as any,
-        deprecatedOptions,
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      interface components { schemas: { Base: Record<string, never> } }
-      type Generated = ${deprecated};
-      const valid: Generated = {};
-    `);
-
-    const transformPropertyOptions = { ...DEFAULT_OPTIONS, ctx: { ...DEFAULT_OPTIONS.ctx } };
-    transformPropertyOptions.ctx.transformProperty = (property) =>
-      ts.factory.updatePropertySignature(
-        property,
-        property.modifiers,
-        ts.factory.createIdentifier("renamed"),
-        property.questionToken,
-        property.type,
-      );
-    const renamed = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ type: "object", properties: { original: { type: "string" } } }, { required: ["original"] }],
-        } as any,
-        transformPropertyOptions,
-      ),
-    ).trim();
-    expect(renamed).toBe(`{
-    renamed?: string;
-} & unknown`);
-    expectTypeScriptToCompile(`
-      type Generated = ${renamed};
-      const valid: Generated = { renamed: "value" };
-    `);
-
-    const union = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Base" }, { required: ["required_string"] }],
-          anyOf: [{ type: "string" }],
-        } as any,
-        optionsWithSchemas({
-          Base: {
-            type: "object",
-            properties: { required_string: { type: "string" } },
-          },
-        }),
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      interface components { schemas: { Base: { required_string?: string } } }
-      type Generated = ${union};
-      const objectValue: Generated = {};
-      const stringValue: Generated = "value";
-    `);
-
-    const polymorphicOptions = optionsWithSchemas({
-      Polymorphic: {
-        type: ["object", "string"],
-        properties: { required_string: { type: "string" } },
-      },
-    });
-    const polymorphic = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
-        } as any,
-        polymorphicOptions,
-      ),
-    ).trim();
-    expect(polymorphic).toBe('components["schemas"]["Polymorphic"] & unknown');
-    expectTypeScriptToCompile(`
-      interface components { schemas: { Polymorphic: { required_string?: string } | string } }
-      type Generated = ${polymorphic};
-      const objectValue: Generated = {};
-      const stringValue: Generated = "value";
-    `);
-
-    const typedPolymorphic = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { type: "object", required: ["required_string"] }],
-        } as any,
-        polymorphicOptions,
-      ),
-    ).trim();
-    expect(typedPolymorphic).toBe('components["schemas"]["Polymorphic"] & Record<string, never>');
-    expectTypeScriptToCompile(`
-      interface components { schemas: { Polymorphic: { required_string?: string } | string } }
-      type Generated = ${typedPolymorphic};
-      // @ts-expect-error the retained object constraint remains unassignable
-      const invalid: Generated = { required_string: "value" };
-    `);
-
-    const handledDiscriminatorOptions = optionsWithSchemas({
-      parent: {
-        type: "object",
-        required: ["operation"],
-        properties: {
-          operation: { type: "string", enum: ["test"] },
-          name: { type: "string" },
-        },
-      },
-    });
-    handledDiscriminatorOptions.ctx.discriminators = {
-      objects: {
-        "#/components/schemas/parent": {
-          propertyName: "operation",
-          mapping: { test: DEFAULT_OPTIONS.path },
-        },
-      },
-      refsHandled: ["#/components/schemas/parent"],
-    };
-    const handledDiscriminator = astToString(
-      transformSchemaObject(
-        {
-          allOf: [{ $ref: "#/components/schemas/parent" }, { required: ["name"] }],
-        } as any,
-        handledDiscriminatorOptions,
-      ),
-    ).trim();
-    expectTypeScriptToCompile(`
-      type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-      interface components { schemas: { parent: { operation: "test"; name?: string } } }
-      type Generated = ${handledDiscriminator};
-      const valid: Generated = { name: "value" };
-      // @ts-expect-error name is required after omitting the discriminator property
-      const invalid: Generated = {};
-    `);
-  });
-
-  test("allOf > generated components and constrained types compile together", () => {
-    const baseSchemas = {
-      Base: {
-        type: "object",
-        properties: { required_string: { type: "string" } },
-      },
-    };
-    const scramble = generateComponentsAndConstrainedType(baseSchemas, {
-      allOf: [{ $ref: "#/components/schemas/Base" }, { type: "object", required: ["required_string"] }],
-    });
-    expectTypeScriptToCompile(`${scramble.source}
-      const valid: Generated = { required_string: "value" };
-      // @ts-expect-error required_string is required
-      const invalid: Generated = {};
-    `);
-
-    const constantSchemas = {
-      Constant: {
-        type: "object",
-        const: {},
-        properties: { required_string: { type: "string" } },
-      },
-    };
-    for (const constraint of [{ required: ["required_string"] }, { type: "object", required: ["required_string"] }]) {
-      const constant = generateComponentsAndConstrainedType(constantSchemas, {
-        allOf: [{ $ref: "#/components/schemas/Constant" }, constraint],
-      });
-      expect(constant.generated).not.toContain("WithRequired");
-      expectTypeScriptToCompile(`${constant.source}
-        type Check = Generated;
-      `);
-    }
-
-    const enumerated = generateComponentsAndConstrainedType(
-      {
-        Enumerated: {
-          enum: ["fixed"],
+          required: ["parent_only"],
           allOf: [
-            {
-              type: "object",
-              properties: { required_string: { type: "string" } },
-            },
+            { $ref: "#/components/schemas/First" },
+            { $ref: "#/components/schemas/Second" },
+            { type: "object", properties: { callback_value: { type: "string" } } },
+            { type: "object", required: ["first", "second", "callback_value"] },
           ],
-        },
-      },
-      {
-        allOf: [{ $ref: "#/components/schemas/Enumerated" }, { required: ["required_string"] }],
-      },
-    );
-    expect(enumerated.generated).not.toContain("WithRequired");
-    expectTypeScriptToCompile(`${enumerated.source}
-      const valid: Generated = "fixed";
-    `);
+        } as any,
+        options,
+      ),
+    ).trim();
 
-    const polymorphic = generateComponentsAndConstrainedType(
-      {
-        Polymorphic: {
+    expect(result).toBe(`WithRequiredObject<components["schemas"]["First"] & components["schemas"]["Second"] & {
+    callback_value?: number;
+}, "parent_only" | "first" | "second" | "callback_value">`);
+  });
+
+  test("allOf > exact outer object enables callback constraints but synthetic type-array objects do not", () => {
+    const exactOptions = optionsWithSchemas({});
+    exactOptions.ctx.transform = () => undefined;
+    const exact = astToString(
+      transformSchemaObject(
+        {
+          type: "object",
+          properties: { value: { type: "string" } },
+          allOf: [{ type: "object", required: ["value"] }],
+        },
+        exactOptions,
+      ),
+    ).trim();
+    expect(exact).toBe(`WithRequiredObject<{
+    value?: string;
+}, "value">`);
+
+    const syntheticOptions = optionsWithSchemas({});
+    syntheticOptions.ctx.transform = () => undefined;
+    const synthetic = astToString(
+      transformSchemaObject(
+        {
           type: ["object", "string"],
-          properties: { required_string: { type: "string" } },
-        },
-      },
-      {
-        allOf: [{ $ref: "#/components/schemas/Polymorphic" }, { required: ["required_string"] }],
-      },
+          properties: { value: { type: "string" } },
+          allOf: [{ type: "object", required: ["value"] }],
+        } as any,
+        syntheticOptions,
+      ),
     );
-    expect(polymorphic.generated).not.toContain("WithRequired");
-    expectTypeScriptToCompile(`${polymorphic.source}
-      const objectValue: Generated = {};
-      const stringValue: Generated = "value";
-    `);
-
-    const nullable = generateComponentsAndConstrainedType(
-      {
-        Nullable: {
-          type: ["object", "null"],
-          properties: { required_string: { type: "string" } },
-        },
-      },
-      {
-        allOf: [{ $ref: "#/components/schemas/Nullable" }, { type: "object", required: ["required_string"] }],
-      },
-    );
-    expect(nullable.generated).not.toContain("WithRequired");
-    expectTypeScriptToCompile(`${nullable.source}
-      type Check = Generated;
-    `);
-
-    const deprecated = generateComponentsAndConstrainedType(
-      {
-        Deprecated: {
-          type: "object",
-          properties: { old: { type: "string", deprecated: true } },
-        },
-      },
-      {
-        allOf: [{ $ref: "#/components/schemas/Deprecated" }, { required: ["old"] }],
-      },
-      (options) => {
-        options.ctx.excludeDeprecated = true;
-      },
-    );
-    expect(deprecated.generated).not.toContain("WithRequired");
-    expectTypeScriptToCompile(`${deprecated.source}
-      const valid: Generated = {};
-    `);
-
-    const renamed = generateComponentsAndConstrainedType(
-      {
-        Renamed: {
-          type: "object",
-          properties: { original: { type: "string" } },
-        },
-      },
-      {
-        allOf: [{ $ref: "#/components/schemas/Renamed" }, { required: ["original"] }],
-      },
-      (options) => {
-        options.ctx.transformProperty = (property) =>
-          ts.factory.updatePropertySignature(
-            property,
-            property.modifiers,
-            ts.factory.createIdentifier("renamed"),
-            property.questionToken,
-            property.type,
-          );
-      },
-    );
-    expect(renamed.generated).not.toContain("WithRequired");
-    expectTypeScriptToCompile(`${renamed.source}
-      const valid: Generated = { renamed: "value" };
-    `);
+    expect(synthetic).toContain("Record<string, never>");
+    expect(synthetic).not.toContain("WithRequiredObject");
   });
 });
 
@@ -2366,59 +1186,27 @@ function optionsWithSchemas(schemas: Record<string, any>) {
   };
 }
 
-function generateComponentsAndConstrainedType(
-  schemas: Record<string, any>,
-  constrainedSchema: any,
-  configure?: (options: ReturnType<typeof optionsWithSchemas>) => void,
-) {
-  const options = optionsWithSchemas(schemas);
-  options.ctx.injectFooter = [];
-  configure?.(options);
-  const componentTypes = Object.entries(schemas)
-    .map(([name, schema]) => {
-      const type = astToString(
-        transformSchemaObject(schema, {
-          ...options,
-          path: `#/components/schemas/${name}`,
-        }),
-      ).trim();
-      return `${JSON.stringify(name)}: ${type};`;
-    })
-    .join("\n");
-  const generated = astToString(transformSchemaObject(constrainedSchema, options)).trim();
-  const footer = astToString(options.ctx.injectFooter).trim();
+const BASE_SCHEMA = {
+  type: "object",
+  properties: {
+    required_string: { type: "string" },
+    optional_number: { type: "number" },
+  },
+};
 
-  return {
-    generated,
-    source: `
-      interface components { schemas: { ${componentTypes} } }
-      type Generated = ${generated};
-      ${footer}
-    `,
-  };
+function baseOptions() {
+  return optionsWithSchemas({ Base: BASE_SCHEMA });
 }
 
-function expectTypeScriptToCompile(source: string) {
-  const fileName = "/required-constraint.test.ts";
-  const compilerOptions: ts.CompilerOptions = {
-    exactOptionalPropertyTypes: true,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-    target: ts.ScriptTarget.ESNext,
-  };
-  const host = ts.createCompilerHost(compilerOptions);
-  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true);
-  const getSourceFile = host.getSourceFile.bind(host);
-  host.getSourceFile = (name, languageVersion, onError, shouldCreateNewSourceFile) =>
-    name === fileName ? sourceFile : getSourceFile(name, languageVersion, onError, shouldCreateNewSourceFile);
-  const fileExists = host.fileExists.bind(host);
-  host.fileExists = (name) => name === fileName || fileExists(name);
-  const readFile = host.readFile.bind(host);
-  host.readFile = (name) => (name === fileName ? source : readFile(name));
-
-  const diagnostics = ts.getPreEmitDiagnostics(ts.createProgram([fileName], compilerOptions, host));
-  expect(diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))).toEqual([]);
+function objectType(properties: Record<string, ts.TypeNode>, optional = false) {
+  return ts.factory.createTypeLiteralNode(
+    Object.entries(properties).map(([name, type]) =>
+      ts.factory.createPropertySignature(
+        undefined,
+        name,
+        optional ? ts.factory.createToken(ts.SyntaxKind.QuestionToken) : undefined,
+        type,
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary

Handle `allOf` members that only make existing object properties required.

Fixes #1474  
Related to #1520 and #2570

## Problem

Given a schema such as:

```yaml
allOf:
  - $ref: "#/components/schemas/Base"
  - type: object
    required: [name]
```

`openapi-typescript` generated `Base & Record<string, never>`. The second member is a presence constraint, but it was transformed as an empty object, making the resulting type effectively unusable.

## Solution

Exact `{ required: [...] }` and `{ type: object, required: [...] }` members are translated through the existing parent `required` flow. For referenced schemas this produces `WithRequired<Base, "name">` instead of an empty-object intersection.

The implementation is intentionally conservative:

- Every required key must exist in the retained object schemas.
- Typed constraints require another retained, non-nullable object assertion.
- Schemas with extra keywords, callbacks, renamed or filtered properties, unions, nullability, or early-return types keep the previous behavior.
- Recursive `allOf` references are followed with cycle protection.
- Existing discriminator handling is preserved while allowing additional non-discriminator fields to become required.

The main logic is in `transform/schema-object.ts`. The composition tests include generated TypeScript compilation checks, and the DigitalOcean fixture was regenerated because it contains several real examples of this schema pattern.

## Validation

- 324 package tests passed
- TypeScript and generated-example checks passed
- Build and package export validation passed
- DigitalOcean generated fixture compiles

## Notes

While the original implementation has been written by me, after several rounds of validation by GPT-5.6 Sol it found so many corner cases that it basically rewrote it from scratch.