### PR TITLE
docs: fix occurred typo in react-query examples

### DIFF
--- a/docs/ja/openapi-react-query/index.md
+++ b/docs/ja/openapi-react-query/index.md
@@ -39,7 +39,7 @@ const MyComponent = () => {
 
   if (isLoading || !data) return "Loading...";
 
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.title}</div>;
 };
@@ -97,7 +97,7 @@ const MyComponent = () => {
 
   if (isLoading || !data) return "Loading...";
 
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.title}</div>;
 };

--- a/docs/openapi-react-query/index.md
+++ b/docs/openapi-react-query/index.md
@@ -38,7 +38,7 @@ const MyComponent = () => {
 
   if (isLoading || !data) return "Loading...";
 
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.title}</div>;
 };
@@ -96,7 +96,7 @@ const MyComponent = () => {
 
   if (isLoading || !data) return "Loading...";
 
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.title}</div>;
 };
@@ -107,4 +107,3 @@ const MyComponent = () => {
 ::: tip
 You can find more information about `createFetchClient` on the [openapi-fetch documentation](../openapi-fetch/index.md).
 :::
-

--- a/docs/openapi-react-query/query-options.md
+++ b/docs/openapi-react-query/query-options.md
@@ -34,7 +34,7 @@ export const App = () => {
   );
 
   if (!data || isLoading) return "Loading...";
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.firstname}</div>;
 };

--- a/docs/openapi-react-query/use-query.md
+++ b/docs/openapi-react-query/use-query.md
@@ -29,7 +29,7 @@ export const App = () => {
   });
 
   if (!data || isLoading) return "Loading...";
-  if (error) return `An error occured: ${error.message}`;
+  if (error) return `An error occurred: ${error.message}`;
 
   return <div>{data.firstname}</div>;
 };


### PR DESCRIPTION
Fixes `occured` to `occurred` in the openapi-react-query docs and the Japanese translation. Docs-only change.