### PR TITLE
fix(ci): unblock test-e2e by upgrading Playwright past the yauzl hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - run: pnpm test
   test-e2e:
     runs-on: ubuntu-latest
+    # Browser installation has hung indefinitely before (microsoft/playwright#40724).
+    # Without a timeout, a hung job burns the full 6h runner limit before being killed.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@biomejs/biome": "2.4.14",
     "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.0",
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.62.1",
     "@size-limit/preset-small-lib": "12.1.0",
     "@types/node": "25.6.0",
     "prettier": "3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 2.31.0
         version: 2.31.0(@types/node@25.6.0)
       '@playwright/test':
-        specifier: 1.59.1
-        version: 1.59.1
+        specifier: 1.62.1
+        version: 1.62.1
       '@size-limit/preset-small-lib':
         specifier: 12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
@@ -116,7 +116,7 @@ importers:
     dependencies:
       next:
         specifier: ^15.5.12
-        version: 15.5.12(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.12(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openapi-fetch:
         specifier: workspace:^
         version: link:../..
@@ -1562,9 +1562,9 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@polka/url@1.0.0-next.29':
@@ -3573,14 +3573,14 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pluralize@8.0.0:
@@ -5648,9 +5648,9 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7585,7 +7585,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.12(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.12(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -7603,7 +7603,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
-      '@playwright/test': 1.59.1
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7757,11 +7757,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.59.1:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Changes

`test-e2e` has not completed on any PR since **2026-05-12**. It hangs on `pnpm exec playwright install --with-deps` until GitHub kills the job at the **6-hour** runner limit, so every run ends `cancelled` and the check never reports.

This bumps `@playwright/test` from `1.59.1` to `1.62.1`, and adds a `timeout-minutes` guard to the job.

### Root cause

The hang is **not** in the system dependency install — `apt` finishes normally (`No services need to be restarted`). The job stalls immediately after the browser archive download completes, during extraction:

```
16:52:29  Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) …
16:52:30  |■■■■■■■■…■■■■■■■■| 100% of 170.4 MiB
22:51:35  ##[error]The operation was canceled.        ← 5.98h of silence
```

This is the yauzl regression in [thejoshwolfe/yauzl#168](https://github.com/thejoshwolfe/yauzl/issues/168): the `for await` over `openReadStream` never terminates on **Node 24.16.0+ and Node 26.x**. See [microsoft/playwright#40724](https://github.com/microsoft/playwright/issues/40724) — filed against Playwright **1.59.1 on Node 26**, exactly this repo's configuration — plus [#41000](https://github.com/microsoft/playwright/issues/41000) and [#41133](https://github.com/microsoft/playwright/issues/41133).

Playwright vendored the fix in **1.60.0**. This repo has been pinned to 1.59.1 since 2026-04-01.

### Why it started when it did

The job runs `node-version: latest`, which began resolving to Node 26 when 26.0.0 shipped:

| Date | Event |
| :--- | :--- |
| 2026-04-01 | `@playwright/test` pinned to 1.59.1 |
| 2026-05-05 19:11 | **last green `test-e2e`** (run `25396835833`) |
| 2026-05-05 | **Node 26.0.0 released** — `latest` moves to it |
| 2026-05-11 | Playwright 1.60.0 released, containing the fix |
| 2026-05-12 | **first 6h hang** (run `25732646823`) |
| since | every run reaching this step is killed at 6h (Node v26.3.0 in June, v26.7.0 in August) |

The other jobs stay green because only `test-e2e` installs browsers.

### Why this didn't self-heal

Renovate already queued `@playwright/test` → 1.62.1, but it is **rate-limited** in the dependency dashboard (#2173) and was never opened as a PR. And `renovate.json` automerges devDependency minor/patch updates *only once CI passes* — which it no longer can. The update that fixes this is blocked by the very problem it fixes, which is why a manual PR is needed.

### On the timeout

`timeout-minutes: 20` is defence in depth, not the fix. Without it a hang costs 6h of runner time per run, and since in-progress job logs aren't retrievable through the API, it also makes the next such hang much harder to diagnose — the logs above only became readable once the job was cancelled.

I scoped it to `test-e2e`, the only job that has demonstrably hung. Happy to extend it to the other jobs if you'd prefer them bounded too.

### Considered and rejected

Pinning `node-version` to an LTS instead of `latest`: wouldn't actually fix it, since Node 24.16+ (LTS) is affected too, and it would cut CI coverage of current Node. The Playwright bump is the real fix.

## How to Review

- The behavioural claim is entirely in the version bump; `packages/openapi-fetch/playwright.config.ts` uses only `defineConfig` / `devices` / `webServer` / `projects`, which are unchanged across 1.59 → 1.62.
- The real check is this PR's own `test-e2e` job: it should conclude in minutes instead of hanging.
- Locally (Node 22, unaffected by the bug, so it can't reproduce the hang) `playwright install` extracts without stalling and the e2e suite passes on chrome and firefox; webkit only fails there on a missing host lib that `--with-deps` installs on CI.

Worth noting: this blocks every other open PR in the repo from showing a complete CI run, including #2853.

## Checklist

- [x] Unit tests updated _(n/a — CI and devDependency only)_
- [x] `docs/` updated (if necessary) _(n/a)_
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript) _(n/a)_
