### PR TITLE
fix(openapi-typescript): redundant nested unions from type arrays with anyOf/allOf

### DIFF
--- a/.changeset/eager-moles-wash.md
+++ b/.changeset/eager-moles-wash.md
@@ -1,0 +1,5 @@
+---
+"openapi-typescript": patch
+---
+
+Fix redundant nested unions from a type array with a sibling `anyOf`/`allOf`.

--- a/.changeset/eager-moles-wash.md
+++ b/.changeset/eager-moles-wash.md
@@ -2,4 +2,4 @@
 "openapi-typescript": patch
 ---
 
-Fix redundant nested unions from a type array with a sibling `anyOf`/`allOf`.
+Fix redundant nested unions from a type array with a sibling `anyOf`/`allOf`, including when a `oneOf` sits alongside them.

--- a/packages/openapi-typescript/examples/github-api-next.ts
+++ b/packages/openapi-typescript/examples/github-api-next.ts
@@ -35615,7 +35615,7 @@ export interface components {
          * @description User-defined metadata to store domain-specific information limited to 8 keys with scalar values.
          */
         metadata: {
-            [key: string]: (null | (string | number | boolean) | (number | string | boolean) | (boolean | string | number)) | string | number | boolean;
+            [key: string]: (null | string | number | boolean) | string | number | boolean;
         };
         dependency: {
             /**

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -467,6 +467,22 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
     if (Array.isArray(schemaObject.type) && !Array.isArray(schemaObject)) {
       // skip any primitive types that appear in oneOf as well
       const uniqueTypes: ts.TypeNode[] = [];
+      // The caller transforms the sibling composition keywords itself, so drop them here
+      // or each type member re-applies them. 'type' alone fully describes a primitive
+      // member; object/array members keep anyOf/allOf, because there the composition is
+      // what carries the shape and stripping it leaves Record<string, never> / unknown[].
+      const transformTypeMember = (t: string) => {
+        const stackable = t === "object" || t === "array";
+        return transformSchemaObject(
+          {
+            ...schemaObject,
+            type: t,
+            oneOf: undefined,
+            ...(stackable ? {} : { anyOf: undefined, allOf: undefined }),
+          } as SchemaObject,
+          options,
+        );
+      };
       if (Array.isArray(schemaObject.oneOf)) {
         for (const t of schemaObject.type) {
           if (
@@ -475,33 +491,11 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
           ) {
             continue;
           }
-          uniqueTypes.push(
-            t === "null" || t === null
-              ? NULL
-              : transformSchemaObject(
-                  { ...schemaObject, type: t, oneOf: undefined } as SchemaObject, // don’t stack oneOf transforms
-                  options,
-                ),
-          );
+          uniqueTypes.push(t === "null" || t === null ? NULL : transformTypeMember(t));
         }
       } else {
         for (const t of schemaObject.type) {
-          if (t === "null" || t === null) {
-            uniqueTypes.push(NULL);
-          } else {
-            // 'type' alone fully describes a primitive member, so re-running anyOf/allOf
-            // here only stacks the composition the caller already applies. object/array
-            // members keep it: there, composition is what carries the shape.
-            const stackable = t === "object" || t === "array";
-            uniqueTypes.push(
-              transformSchemaObject(
-                (stackable
-                  ? { ...schemaObject, type: t }
-                  : { ...schemaObject, type: t, anyOf: undefined, allOf: undefined }) as SchemaObject,
-                options,
-              ),
-            );
-          }
+          uniqueTypes.push(t === "null" || t === null ? NULL : transformTypeMember(t));
         }
       }
       return tsUnion(uniqueTypes);

--- a/packages/openapi-typescript/src/transform/schema-object.ts
+++ b/packages/openapi-typescript/src/transform/schema-object.ts
@@ -489,7 +489,18 @@ function transformSchemaObjectCore(schemaObject: SchemaObject, options: Transfor
           if (t === "null" || t === null) {
             uniqueTypes.push(NULL);
           } else {
-            uniqueTypes.push(transformSchemaObject({ ...schemaObject, type: t } as SchemaObject, options));
+            // 'type' alone fully describes a primitive member, so re-running anyOf/allOf
+            // here only stacks the composition the caller already applies. object/array
+            // members keep it: there, composition is what carries the shape.
+            const stackable = t === "object" || t === "array";
+            uniqueTypes.push(
+              transformSchemaObject(
+                (stackable
+                  ? { ...schemaObject, type: t }
+                  : { ...schemaObject, type: t, anyOf: undefined, allOf: undefined }) as SchemaObject,
+                options,
+              ),
+            );
           }
         }
       }

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -54,6 +54,50 @@ describe("composition", () => {
       },
     ],
     [
+      "polymorphic > anyOf + nullable",
+      {
+        given: {
+          type: ["string", "null"],
+          anyOf: [{ type: "string", format: "ipv4" }, { type: "string", format: "ipv6" }, { type: "null" }],
+        },
+        want: "(string | null) | string | null",
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "polymorphic > allOf + nullable",
+      {
+        given: {
+          type: ["string", "null"],
+          allOf: [{ type: "string" }],
+        },
+        want: "(string | null) & string",
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "polymorphic > anyOf + nullable object",
+      {
+        given: {
+          type: ["null", "object"],
+          anyOf: [
+            { type: "object", properties: { a: { type: "string" } } },
+            { type: "object", properties: { b: { type: "string" } } },
+          ],
+        },
+        want: `(null | ({
+    a?: string;
+} | {
+    b?: string;
+})) | {
+    a?: string;
+} | {
+    b?: string;
+}`,
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
       "oneOf > primitives",
       {
         given: { oneOf: [{ type: "string" }, { type: "number" }] },

--- a/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
+++ b/packages/openapi-typescript/test/transform/schema-object/composition.test.ts
@@ -76,6 +76,40 @@ describe("composition", () => {
       },
     ],
     [
+      "polymorphic > allOf + nullable, multiple members",
+      {
+        given: {
+          type: ["string", "null"],
+          allOf: [{ type: "string" }, { type: "string", format: "uuid" }],
+        },
+        want: "(string | null) & (string)",
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "polymorphic > anyOf + nullable array",
+      {
+        given: {
+          type: ["array", "null"],
+          anyOf: [{ type: "array", items: { type: "string" } }],
+        },
+        want: "((unknown[] | string[]) | null) | string[]",
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
+      "polymorphic > oneOf + allOf + nullable",
+      {
+        given: {
+          type: ["string", "null"],
+          oneOf: [{ type: "number" }],
+          allOf: [{ type: "string" }],
+        },
+        want: "((string | null) & string) | number",
+        // options: DEFAULT_OPTIONS,
+      },
+    ],
+    [
       "polymorphic > anyOf + nullable object",
       {
         given: {


### PR DESCRIPTION
## Changes

Each member of a `type` array gets its own recursive `transformSchemaObject` call, spread
from the full schema object. A sibling `anyOf` comes along for the ride and gets
transformed inside every member, on top of the top-level pass:

```json
{ "type": ["string","null"], "anyOf": [{"type":"string","format":"ipv4"},{"type":"null"}] }
```

```ts
// before
clientIp?: ((string | null) | null) | string | null;
// after
clientIp?: (string | null) | string | null;
```

`allOf` has the same problem. `{"type":["string","null"],"allOf":[{"type":"string"}]}`
gave `((string) | null) & string`, now `(string | null) & string`.

There are two of these loops, one for schemas with a `oneOf` and one for everything else.
The `oneOf` loop already blanked `oneOf` before recursing but not `anyOf`/`allOf`, so
schemas carrying both were still broken. Both loops now call the same
`transformTypeMember` helper.

## How to Review

`anyOf`/`allOf` are stripped only for primitive members. Object and array members keep
them: there the composition carries the shape, and stripping leaves
`Record<string, never>` / `unknown[]`, which widens the union. Tests cover both.

One example line changes, narrower than before:

```ts
- [key: string]: (null | (string | number | boolean) | (number | string | boolean) | (boolean | string | number)) | string | number | boolean;
+ [key: string]: (null | string | number | boolean) | string | number | boolean;
```

The `oneOf` half changes no example output — no schema in `examples/` hits that
combination. Unit-tested only.

## Checklist

- [x] Unit tests updated
- [ ] `docs/` updated (if necessary)
- [x] `pnpm run update:examples` run (only applicable for openapi-typescript)