### PR TITLE
fix(openapi-react-query): reject query options as request init

### DIFF
--- a/.changeset/fix-query-options-init.md
+++ b/.changeset/fix-query-options-init.md
@@ -1,0 +1,5 @@
+---
+"openapi-react-query": patch
+---
+
+Reject React Query options passed as request init.

--- a/packages/openapi-react-query/src/index.ts
+++ b/packages/openapi-react-query/src/index.ts
@@ -30,6 +30,9 @@ import type { HttpMethod, MediaType, PathsWithMethod, RequiredKeysOf } from "ope
 type InferSelectReturnType<TData, TSelect> = TSelect extends (data: TData) => infer R ? R : TData;
 
 type InitWithUnknowns<Init> = Init & { [key: string]: unknown };
+// Keep arbitrary fetch init fields while reserving options for React Query itself.
+type QueryInit<Init> = InitWithUnknowns<Init> & { [Key in keyof UseQueryOptions]?: never };
+type InfiniteQueryInit<Init> = InitWithUnknowns<Init> & { [Key in keyof UseInfiniteQueryOptions]?: never };
 
 export type QueryKey<
   Paths extends Record<string, Record<HttpMethod, {}>>,
@@ -55,9 +58,7 @@ export type QueryOptionsFunction<Paths extends Record<string, Record<HttpMethod,
 >(
   method: Method,
   path: Path,
-  ...[init, options]: RequiredKeysOf<Init> extends never
-    ? [InitWithUnknowns<Init>?, Options?]
-    : [InitWithUnknowns<Init>, Options?]
+  ...[init, options]: RequiredKeysOf<Init> extends never ? [QueryInit<Init>?, Options?] : [QueryInit<Init>, Options?]
 ) => NoInfer<
   Omit<
     UseQueryOptions<
@@ -99,8 +100,8 @@ export type UseQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>,
   method: Method,
   url: Path,
   ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
-    ? [InitWithUnknowns<Init>?, Options?, QueryClient?]
-    : [InitWithUnknowns<Init>, Options?, QueryClient?]
+    ? [QueryInit<Init>?, Options?, QueryClient?]
+    : [QueryInit<Init>, Options?, QueryClient?]
 ) => UseQueryResult<InferSelectReturnType<Response["data"], Options["select"]>, Response["error"]>;
 
 export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <
@@ -123,7 +124,7 @@ export type UseInfiniteQueryMethod<Paths extends Record<string, Record<HttpMetho
 >(
   method: Method,
   url: Path,
-  init: InitWithUnknowns<Init>,
+  init: InfiniteQueryInit<Init>,
   options: Options,
   queryClient?: QueryClient,
 ) => UseInfiniteQueryResult<
@@ -149,8 +150,8 @@ export type UseSuspenseQueryMethod<Paths extends Record<string, Record<HttpMetho
   method: Method,
   url: Path,
   ...[init, options, queryClient]: RequiredKeysOf<Init> extends never
-    ? [InitWithUnknowns<Init>?, Options?, QueryClient?]
-    : [InitWithUnknowns<Init>, Options?, QueryClient?]
+    ? [QueryInit<Init>?, Options?, QueryClient?]
+    : [QueryInit<Init>, Options?, QueryClient?]
 ) => UseSuspenseQueryResult<InferSelectReturnType<Response["data"], Options["select"]>, Response["error"]>;
 
 export type UseMutationMethod<Paths extends Record<string, Record<HttpMethod, {}>>, Media extends MediaType> = <

--- a/packages/openapi-react-query/test/index.test.tsx
+++ b/packages/openapi-react-query/test/index.test.tsx
@@ -478,6 +478,18 @@ describe("client", () => {
       >();
     });
 
+    it("should reject query options passed as request init", () => {
+      const fetchClient = createFetchClient<minimalGetPaths>({ baseUrl });
+      const client = createClient(fetchClient);
+
+      // @ts-expect-error Query options belong in the fourth argument.
+      const invalidQuery = () => client.useQuery("get", "/foo", { retry: false });
+      const customInit = () => client.useQuery("get", "/foo", { customRequestOption: true });
+      expectTypeOf(customInit).toBeFunction();
+
+      expectTypeOf(invalidQuery).toBeFunction();
+    });
+
     it("passes abort signal to fetch", async () => {
       let signalPassedToFetch: AbortSignal | undefined;
 


### PR DESCRIPTION
## Changes

Fixes #2642.

The third useQuery argument is the fetch init object and the fourth argument is the React Query options object. Before this change, the fetch init type accepted React Query keys such as retry, so those options could be silently ignored at runtime. The public init types now reserve React Query option keys while retaining arbitrary request-init extensions.

## How to Review

Review QueryInit and InfiniteQueryInit in packages/openapi-react-query/src/index.ts. The regression test rejects retry in the third argument and keeps a custom request-init extension accepted. The Changeset declares a patch release for openapi-react-query.

## Validation

- pnpm run build - passed before the change
- pnpm --filter openapi-react-query test - passed before the change; 37 tests
- ../../node_modules/.bin/tsc --noEmit -p tsconfig.json - passed after the change
- ../../node_modules/.bin/biome check . --diagnostic-level=error - passed after the change
- ../../node_modules/.bin/vitest run test/index.test.tsx - passed after the change; 38 tests
- git diff HEAD^ HEAD --check - passed

The pnpm wrapper could not be rerun after the change because the environment filesystem was full (ENOSPC); the direct local TypeScript, Biome, and Vitest checks passed.

## Checklist

- [x] Unit tests updated
- [ ] docs/ updated (not necessary)
- [ ] pnpm run update:examples run (not applicable for openapi-react-query)
